### PR TITLE
Set up automatic Dependabot version updates.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,8 +17,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-      reviewers:
-        - "la-ldaf/ad-hoc-engineers"
+    reviewers:
+      - "la-ldaf/ad-hoc-engineers"
     commit-message:
       prefix: "github-actions"
     labels:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,17 @@ updates:
       - "la-ldaf/ad-hoc-engineers"
     commit-message:
       prefix: "npm"
-    labels: 
-      - 'dependencies'
-      - 'dependabot'
+    labels:
+      - "dependencies"
+      - "dependabot"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      reviewers:
+        - "la-ldaf/ad-hoc-engineers"
+    commit-message:
+      prefix: "github-actions"
+    labels:
+      - "dependencies"
+      - "dependabot"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# See the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "la-ldaf/ad-hoc-engineers"
+    commit-message:
+      prefix: "npm"
+    labels: 
+      - 'dependencies'
+      - 'dependabot'


### PR DESCRIPTION
This adds a config file that will have Dependabot run on our `npm` packages weekly, and will open PRs that are automatically assigned to our engineering team. I set the commit prefix to `npm: ...` and it should automatically apply the `dependabot` and `dependencies` labels.