### PR TITLE
LDAF-216: Refactor USWDS dependency to single global import

### DIFF
--- a/src/app.scss
+++ b/src/app.scss
@@ -1,5 +1,6 @@
 /* Write your global styles here, in SCSS syntax. Variables and mixins from the src/variables.scss file are available here without importing */
-@use "uswds-fonts";
-@use "uswds-global";
-@use "uswds-typography";
-@use "uswds-utilities";
+@use "uswds" with (
+  $theme-font-path: $theme-font-path,
+  $theme-image-path: $theme-image-path,
+  $theme-show-notifications: false
+);

--- a/src/lib/components/Header/Header.scss
+++ b/src/lib/components/Header/Header.scss
@@ -1,5 +1,0 @@
-@use "usa-layout-grid";
-@use "usa-header";
-@use "usa-search";
-@use "usa-accordion";
-@use "usa-nav";

--- a/src/lib/components/Header/Header.svelte
+++ b/src/lib/components/Header/Header.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import iconBgSearchWhite from "@uswds/uswds/img/usa-icons-bg/search--white.svg?url";
-  import "./Header.scss";
 
   import type { NavItemType } from "./Nav";
 
@@ -48,7 +47,7 @@
             <a href="/news">Grants and funding</a>
           </li>
           <li class="usa-nav__secondary-item">
-            <a href="/news" class="usa-current">Licensing and permits</a>
+            <a href="/documentation" class="usa-current">Licensing and permits</a>
           </li>
         </ul>
 

--- a/src/lib/components/Link/Link.scss
+++ b/src/lib/components/Link/Link.scss
@@ -3,7 +3,6 @@
   $theme-image-path: $theme-image-path,
   $theme-show-notifications: false
 );
-@use "usa-link";
 // For some reason the USWDS rules for alternate color links depends on the link being a child of an element with the 'usa-dark-background' class.
 // This seems overly restrictive, so we'll set up the alternate style to be independent of its parent element.
 // Following styles were taken from: https://github.com/uswds/uswds/blob/30c61f34288bc706961b12b536fdc57537026385/packages/usa-dark-background/src/styles/_usa-dark-background.scss

--- a/src/lib/components/Link/Link.scss
+++ b/src/lib/components/Link/Link.scss
@@ -1,3 +1,8 @@
+@use "uswds" with (
+  $theme-font-path: $theme-font-path,
+  $theme-image-path: $theme-image-path,
+  $theme-show-notifications: false
+);
 @use "usa-link";
 // For some reason the USWDS rules for alternate color links depends on the link being a child of an element with the 'usa-dark-background' class.
 // This seems overly restrictive, so we'll set up the alternate style to be independent of its parent element.

--- a/src/lib/components/landingPage/Banner.scss
+++ b/src/lib/components/landingPage/Banner.scss
@@ -1,8 +1,3 @@
-@use "usa-accordion";
-@use "usa-banner";
-@use "usa-icon";
-@use "usa-media-block";
-
 // See https://github.com/uswds/uswds/issues/5194
 .usa-accordion__button.usa-banner__button {
   @extend .usa-banner__button;

--- a/src/lib/components/landingPage/Footer.svelte
+++ b/src/lib/components/landingPage/Footer.svelte
@@ -1,5 +1,4 @@
 <script>
-  import "@uswds/uswds/scss/usa-footer";
   import logoImg from "@uswds/uswds/img/logo-img.png";
   import iconFacebook from "@uswds/uswds/img/usa-icons/facebook.svg?url";
   import iconTwitter from "@uswds/uswds/img/usa-icons/twitter.svg?url";

--- a/src/lib/components/landingPage/GraphicList.scss
+++ b/src/lib/components/landingPage/GraphicList.scss
@@ -1,4 +1,0 @@
-@use "usa-graphic-list";
-@use "usa-layout-grid";
-@use "usa-media-block";
-@use "usa-section";

--- a/src/lib/components/landingPage/GraphicList.svelte
+++ b/src/lib/components/landingPage/GraphicList.svelte
@@ -1,5 +1,4 @@
 <script>
-  import "./GraphicList.scss";
   import circle124 from "@uswds/uswds/img/circle-124.png";
 </script>
 

--- a/src/lib/components/landingPage/Hero.scss
+++ b/src/lib/components/landingPage/Hero.scss
@@ -1,2 +1,0 @@
-@use "usa-hero";
-@use "usa-button";

--- a/src/lib/components/landingPage/Hero.svelte
+++ b/src/lib/components/landingPage/Hero.svelte
@@ -1,7 +1,3 @@
-<script lang="ts">
-  import "./Hero.scss";
-</script>
-
 <section class="usa-hero" aria-label="Introduction">
   <div class="grid-container">
     <div class="usa-hero__callout">

--- a/src/lib/components/landingPage/Identifier.svelte
+++ b/src/lib/components/landingPage/Identifier.svelte
@@ -1,5 +1,4 @@
 <script>
-  import "@uswds/uswds/scss/usa-identifier";
   import circleGray20 from "@uswds/uswds/img/circle-gray-20.svg?url";
 </script>
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,5 +1,4 @@
 <script>
-  import "./page.scss";
   import GraphicList from "$lib/components/landingPage/GraphicList.svelte";
   import Hero from "$lib/components/landingPage/Hero.svelte";
 </script>

--- a/src/routes/documentation/+page.svelte
+++ b/src/routes/documentation/+page.svelte
@@ -1,0 +1,80 @@
+<a class="usa-skipnav" href="#main-content">Skip to main content</a>
+
+<div class="usa-section">
+  <div class="grid-container">
+    <div class="grid-row grid-gap">
+      <div class="usa-layout-docs__sidenav desktop:grid-col-3">
+        <nav aria-label="Secondary navigation">
+          <ul class="usa-sidenav">
+            <li class="usa-sidenav__item"><a href="/">Parent link</a></li>
+            <li class="usa-sidenav__item">
+              <a href="/" class="usa-current">Current page</a>
+              <ul class="usa-sidenav__sublist">
+                <li class="usa-sidenav__item"><a href="/">Child link</a></li>
+                <li class="usa-sidenav__item">
+                  <a href="/" class="usa-current">Child link</a>
+                  <ul class="usa-sidenav__sublist">
+                    <li class="usa-sidenav__item">
+                      <a href="/">Grandchild link</a>
+                    </li>
+                    <li class="usa-sidenav__item">
+                      <a href="/">Grandchild link</a>
+                    </li>
+                    <li class="usa-sidenav__item">
+                      <a href="/" class="usa-current">Grandchild link</a>
+                    </li>
+                    <li class="usa-sidenav__item">
+                      <a href="/">Grandchild link</a>
+                    </li>
+                  </ul>
+                </li>
+                <li class="usa-sidenav__item"><a href="/">Child link</a></li>
+                <li class="usa-sidenav__item"><a href="/">Child link</a></li>
+                <li class="usa-sidenav__item"><a href="/">Child link</a></li>
+              </ul>
+            </li>
+            <li class="usa-sidenav__item"><a href="/">Parent link</a></li>
+          </ul>
+        </nav>
+      </div>
+      <main
+        class="
+            usa-layout-docs__main
+            desktop:grid-col-9
+            usa-prose usa-layout-docs
+          "
+        id="main-content"
+      >
+        <h1>Page heading (h1)</h1>
+        <p class="usa-intro">
+          The page heading communicates the main focus of the page. Make your page heading
+          descriptive and keep it succinct.
+        </p>
+        <h2 id="section-heading-h2">Section heading (h2)</h2>
+        <p>
+          These headings introduce, respectively, sections and subsections within your body copy. As
+          you create these headings, follow the same guidelines that you use when writing section
+          headings: Be succinct, descriptive, and precise.
+        </p>
+        <h3 id="section-heading-h3">Subsection heading (h3)</h3>
+        <p>
+          The particulars of your body copy will be determined by the topic of your page. Regardless
+          of topic, it’s a good practice to follow the inverted pyramid structure when writing copy:
+          Begin with the information that’s most important to your users and then present
+          information of less importance.
+        </p>
+        <p>
+          Keep each section and subsection focused — a good approach is to include one theme (topic)
+          per section.
+        </p>
+        <h4 id="section-heading-h4">Subsection heading (h4)</h4>
+        <p>
+          Use the side navigation menu to help your users quickly skip to different sections of your
+          page. The menu is best suited to displaying a hierarchy with one to three levels and, as
+          we mentioned, to display the sub-navigation of a given page.
+        </p>
+        <p>Read the full documentation on our side navigation on the component page.</p>
+      </main>
+    </div>
+  </div>
+</div>

--- a/src/routes/documentation/+page.svelte
+++ b/src/routes/documentation/+page.svelte
@@ -1,5 +1,3 @@
-<a class="usa-skipnav" href="#main-content">Skip to main content</a>
-
 <div class="usa-section">
   <div class="grid-container">
     <div class="grid-row grid-gap">

--- a/src/routes/news/+page.svelte
+++ b/src/routes/news/+page.svelte
@@ -1,7 +1,3 @@
-<script lang="ts">
-  import "@uswds/uswds/scss/usa-alert";
-</script>
-
 <section class="usa-section">
   <div class="grid-container">
     <h1>News</h1>

--- a/src/routes/page.scss
+++ b/src/routes/page.scss
@@ -1,4 +1,0 @@
-@use "usa-button";
-@use "usa-layout-grid";
-@use "usa-section";
-@use "usa-skipnav";

--- a/src/stories/decorators/Prose.svelte
+++ b/src/stories/decorators/Prose.svelte
@@ -1,7 +1,3 @@
-<script lang="ts">
-  import "@uswds/uswds/scss/usa-prose";
-</script>
-
 <div class="usa-prose">
   <slot />
 </div>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,16 +19,7 @@ export default defineConfig({
   css: {
     preprocessorOptions: {
       scss: {
-        additionalData: (content: string) =>
-          `
-            @use "src/variables.scss" as *;
-            @use "uswds-core" as uswds with (
-              $theme-font-path: $theme-font-path,
-              $theme-image-path: $theme-image-path,
-              $theme-show-notifications: false,
-            );
-            ${content}
-        `,
+        additionalData: '@use "src/variables.scss" as *;',
         includePaths: ["./node_modules/@uswds/uswds/packages"],
       },
     },


### PR DESCRIPTION
<!-- If fixing a bug, add `?template=bug.md` to the end of the URL to use that template instead. -->
<!-- If changing only documentation, add `?template=documentation.md` to the end of the URL to use that template instead. -->

<!-- PR title should start with Jira ticket number if applicable, e.g. `LDAF-12345 Add a new feature that does a cool thing` -->

Jira ticket: [LDAF-216](https://ldaf.atlassian.net/browse/LDAF-216)

<!-- Summarize the feature described in the related issue. -->

## Proposed changes

- Add sub-route that copies the [USWDS Documentation page template](https://designsystem.digital.gov/templates/documentation-page/#component-code)
- Use a single global import of USWDS
- Move shared components into top-level `+layout.svelte`

<!-- If the changes affect the design, insert screenshots here and assign a UX Designer as a reviewer. -->

## Acceptance criteria validation

<!-- Were you able to fully test the acceptance criteria on the related ticket? -->

- [x] Fulfilled exit criteria 
- Refactoring of styles, tests not needed yet for this change
<!-- If not, why not? -->

## Other details

[Gist summary of the different stylesheet sizes depending on import strategy   ](https://gist.github.com/hinzed1127/7baf4149a1a1e18d92e9b75fc3e9a907)

### Alternate solutions

<!-- Explain what other alternatives were considered and why the proposed version was selected. -->
- This _is_ the alternate solution. See full list of considered options in the [original approach taken](https://github.com/adhocteam/ldaf/pull/64).

### Possible drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? Are there any security concerns? -->
- Individual page sizes might be marginally larger, since a single top-level global import of USWDS will cause PurgeCSS to remove all USWDS styles not used _overall_, not per individual page. This is likely a negligible different in the context of full bundle size, but we can revisit if page sizes go up disproportionately.


[LDAF-216]: https://ldaf.atlassian.net/browse/LDAF-216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ