### PR TITLE
Review suggestions for #2

### DIFF
--- a/src/lib/components/Header/Header.svelte
+++ b/src/lib/components/Header/Header.svelte
@@ -3,7 +3,7 @@
   import iconBgSearchWhite from "@uswds/uswds/img/usa-icons-bg/search--white.svg";
   import "./Header.scss";
 
-  import type NavItemType from "./Nav/NavItemType";
+  import type { NavItemType } from "./Nav";
 
   import classNames from "$lib/util/classNames";
   import Nav from "./Nav";

--- a/src/lib/components/Header/Nav/Nav.svelte
+++ b/src/lib/components/Header/Nav/Nav.svelte
@@ -4,13 +4,20 @@
   import NavItem from "./NavItem.svelte";
 
   export let items: NavItemType[] = [];
+
+  let expandedI: number | undefined = undefined;
 </script>
 
 <ul class="usa-nav__primary usa-accordion">
-  {#each items as item (item.id)}
+  {#each items as item, i (item.id)}
     {@const { name, ...restProps } = item}
     <li class="usa-nav__primary-item">
-      <NavItem {...restProps}>{name}</NavItem>
+      <NavItem
+        expanded={i === expandedI}
+        on:toggle={() => (expandedI = expandedI === i ? undefined : i)}
+        on:close={() => expandedI === i && (expandedI = undefined)}
+        {...restProps}>{name}</NavItem
+      >
     </li>
   {/each}
 </ul>

--- a/src/lib/components/Header/Nav/Nav.svelte
+++ b/src/lib/components/Header/Nav/Nav.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type NavItemType from "./NavItemType";
+  import type { NavItemType } from "./types";
 
   import NavItem from "./NavItem.svelte";
 

--- a/src/lib/components/Header/Nav/NavItem.svelte
+++ b/src/lib/components/Header/Nav/NavItem.svelte
@@ -1,108 +1,21 @@
 <script lang="ts">
   import type { NavItemProps, NavLinkType } from "./types";
 
-  import classNames from "$lib/util/classNames";
-  import chunk from "$lib/util/chunk";
-  import Link from "$lib/components/Link";
   import NavLink from "./NavLink.svelte";
+  import NavMenu from "./NavMenu.svelte";
 
   type $$Props = NavItemProps;
 
   export let id = "";
-  export let link = "";
-  export let isCurrent = false;
-  export let megaMenuColumns = 0;
+  export let link: string | undefined = undefined;
+  export let current = false;
+  export let columns = 0;
   export let children: NavLinkType[] = [];
-
-  let isParent = children.length > 0;
-  let isExpanded = false;
-
-  $: buttonClassNames = classNames(
-    "usa-accordion__button usa-nav__link",
-    isCurrent && "usa-current"
-  );
-
-  // Divide nav items into columns.
-  // TODO: We may want to let the CMS determine the position of each item in the future.
-  let megaMenu: NavLinkType[][] = [];
-  if (megaMenuColumns > 0) {
-    const columnLength = Math.ceil(children.length / megaMenuColumns);
-    megaMenu = chunk(children, columnLength);
-  }
-
-  const toggleSubMenu = (show?: boolean) => {
-    if (typeof show !== "undefined") isExpanded = show;
-    else isExpanded = !isExpanded;
-  };
-
-  // By default focusout on the container will trigger for all its children, but using 'self'
-  //   doesn't resolve the issue since the container element isn't the one with the focus.
-  // This workaround will ignore the event if the new focused element is a child of the container.
-  // Based on this REPL: https://svelte.dev/repl/4c5dfd34cc634774bd242725f0fc2dab?version=3.46.4
-  const handleDropdownFocusLoss = ({
-    relatedTarget,
-    currentTarget,
-  }: FocusEvent & { currentTarget: EventTarget & HTMLDivElement }) => {
-    if (relatedTarget instanceof HTMLElement && currentTarget?.contains(relatedTarget)) return;
-    toggleSubMenu(false);
-  };
-
-  // We can't use on:click since it only triggers if the mousedown and mouseup events occur on the
-  //   same target, and on mobile the collapse of an accordion when it loses focus happens on
-  //   mousedown, sometimes shifting the elements so that mouseup misses the target.
-  // Instead, we'll use both mousedown and keydown to ensure everything functions accessibly on
-  //   both desktop and mobile screen sizes.
-  const handleDropdownKeyDown = (event: KeyboardEvent) => {
-    if (event.key === "Enter" || event.key === " ") toggleSubMenu();
-  };
+  export let expanded = false;
 </script>
 
-{#if isParent}
-  <div on:focusout={handleDropdownFocusLoss}>
-    <button
-      type="button"
-      class={buttonClassNames}
-      aria-expanded={isExpanded}
-      aria-controls="extended-mega-nav-section-{id}"
-      on:keydown={handleDropdownKeyDown}
-      on:mousedown={() => toggleSubMenu()}
-    >
-      <!-- Extra <span/> elements in the this template are necessary for expand icons to load. -->
-      <span><slot /></span>
-    </button>
-    {#if megaMenu.length > 0}
-      <!-- Mega Menu Layout-->
-      <div
-        id="extended-mega-nav-section-{id}"
-        class="usa-nav__submenu usa-megamenu"
-        hidden={!isExpanded}
-      >
-        <div class="grid-row grid-gap-4">
-          {#each megaMenu as column, i (i)}
-            <div class="usa-col">
-              <ul class="usa-nav__submenu-list">
-                {#each column as { id, link, name } (id)}
-                  <li class="usa-nav__submenu-item">
-                    <Link href={link}>{name}</Link>
-                  </li>
-                {/each}
-              </ul>
-            </div>
-          {/each}
-        </div>
-      </div>
-    {:else}
-      <!-- Basic Menu Layout -->
-      <ul id="extended-mega-nav-section-{id}" class="usa-nav__submenu" hidden={!isExpanded}>
-        {#each children as { id, link, name } (id)}
-          <li class="usa-nav__submenu-item">
-            <Link href={link}>{name}</Link>
-          </li>
-        {/each}
-      </ul>
-    {/if}
-  </div>
+{#if children.length > 0}
+  <NavMenu {id} {current} {children} {columns} {expanded} on:toggle on:close><slot /></NavMenu>
 {:else}
-  <!-- Basic Nav Link -->
-  <NavLink href={link} current={isCurrent} />
+  <NavLink href={link} {current}><slot /></NavLink>
 {/if}

--- a/src/lib/components/Header/Nav/NavItem.svelte
+++ b/src/lib/components/Header/Nav/NavItem.svelte
@@ -4,6 +4,7 @@
   import classNames from "$lib/util/classNames";
   import chunk from "$lib/util/chunk";
   import Link from "$lib/components/Link";
+  import NavLink from "./NavLink.svelte";
 
   type $$Props = NavItemProps;
 
@@ -20,7 +21,6 @@
     "usa-accordion__button usa-nav__link",
     isCurrent && "usa-current"
   );
-  $: navLinkClassNames = classNames("usa-nav-link", isCurrent && "usa-current");
 
   // Divide nav items into columns.
   // TODO: We may want to let the CMS determine the position of each item in the future.
@@ -104,5 +104,5 @@
   </div>
 {:else}
   <!-- Basic Nav Link -->
-  <Link href={link} class={navLinkClassNames}><span><slot /></span></Link>
+  <NavLink href={link} current={isCurrent} />
 {/if}

--- a/src/lib/components/Header/Nav/NavItem.svelte
+++ b/src/lib/components/Header/Nav/NavItem.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { NavItemProps, NavItemType } from "./NavItemType";
+  import type { NavItemProps, NavLinkType } from "./types";
 
   import classNames from "$lib/util/classNames";
   import chunk from "$lib/util/chunk";
@@ -11,7 +11,7 @@
   export let link = "";
   export let isCurrent = false;
   export let megaMenuColumns = 0;
-  export let children: NavItemType[] = [];
+  export let children: NavLinkType[] = [];
 
   let isParent = children.length > 0;
   let isExpanded = false;
@@ -24,7 +24,7 @@
 
   // Divide nav items into columns.
   // TODO: We may want to let the CMS determine the position of each item in the future.
-  let megaMenu: NavItemType[][] = [];
+  let megaMenu: NavLinkType[][] = [];
   if (megaMenuColumns > 0) {
     const columnLength = Math.ceil(children.length / megaMenuColumns);
     megaMenu = chunk(children, columnLength);

--- a/src/lib/components/Header/Nav/NavItem.test.ts
+++ b/src/lib/components/Header/Nav/NavItem.test.ts
@@ -43,7 +43,7 @@ describe("Header.NavItem", () => {
         Component: NavItem,
         slotContent: "mega menu",
         id: "0",
-        megaMenuColumns: 3,
+        columns: 3,
         children: generateMenuItems(3),
       },
     });
@@ -60,7 +60,7 @@ describe("Header.NavItem", () => {
         Component: NavItem,
         slotContent: "mega menu",
         id: "0",
-        megaMenuColumns: 5,
+        columns: 5,
         children: generateMenuItems(9),
       },
     });

--- a/src/lib/components/Header/Nav/NavLink.svelte
+++ b/src/lib/components/Header/Nav/NavLink.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+  import Link from "$lib/components/Link";
+  import classNames from "$lib/util/classNames";
+  export let href: string | undefined = undefined;
+  export let current = false;
+  $: classes = classNames("usa-nav-link", current && "usa-current");
+</script>
+
+<Link {href} class={classes}><span><slot /></span></Link>

--- a/src/lib/components/Header/Nav/NavMenu.svelte
+++ b/src/lib/components/Header/Nav/NavMenu.svelte
@@ -1,0 +1,86 @@
+<script lang="ts">
+  import Link from "$lib/components/Link/Link.svelte";
+  import chunk from "$lib/util/chunk";
+  import classNames from "$lib/util/classNames";
+  import { createEventDispatcher } from "svelte";
+  import type { NavMenuProps, NavLinkType } from "./types";
+  type $$Props = NavMenuProps;
+
+  const dispatch = createEventDispatcher();
+
+  export let id = "";
+  export let current = false;
+  export let columns = 1;
+  export let children: NavLinkType[] = [];
+  export let expanded = false;
+
+  $: buttonClassNames = classNames("usa-accordion__button usa-nav__link", current && "usa-current");
+
+  // Divide nav items into columns.
+  // TODO: We may want to let the CMS determine the position of each item in the future.
+  // let childColumns: NavLinkType[][];
+  $: childColumns = chunk(children, Math.ceil(children.length / columns));
+
+  // We can't use on:click since it only triggers if the mousedown and mouseup events occur on the
+  //   same target, and on mobile the collapse of an accordion when it loses focus happens on
+  //   mousedown, sometimes shifting the elements so that mouseup misses the target.
+  // Instead, we'll use both mousedown and keydown to ensure everything functions accessibly on
+  //   both desktop and mobile screen sizes.
+  const handleKeyDown = (event: KeyboardEvent) =>
+    (event.key === "Enter" || event.key === " ") && dispatch("toggle");
+  const handleMouseDown = () => dispatch("toggle");
+
+  // By default focusout on the container will trigger for all its children, but using 'self'
+  //   doesn't resolve the issue since the container element isn't the one with the focus.
+  // This workaround will ignore the event if the new focused element is a child of the container.
+  // Based on this REPL: https://svelte.dev/repl/4c5dfd34cc634774bd242725f0fc2dab?version=3.46.4
+  const handleDropdownFocusLoss = ({
+    relatedTarget,
+    currentTarget,
+  }: FocusEvent & { currentTarget: EventTarget & HTMLDivElement }) => {
+    if (relatedTarget instanceof HTMLElement && currentTarget?.contains(relatedTarget)) return;
+    dispatch("close");
+  };
+</script>
+
+<div on:focusout={handleDropdownFocusLoss}>
+  <button
+    type="button"
+    class={buttonClassNames}
+    aria-expanded={expanded}
+    aria-controls="extended-mega-nav-section-{id}"
+    on:keydown={handleKeyDown}
+    on:mousedown={handleMouseDown}
+  >
+    <span><slot /></span>
+  </button>
+  {#if columns <= 1}
+    <ul id="extended-mega-nav-section-{id}" class="usa-nav__submenu" hidden={!expanded}>
+      {#each children as { id, link, name } (id)}
+        <li class="usa-nav__submenu-item">
+          <Link href={link}>{name}</Link>
+        </li>
+      {/each}
+    </ul>
+  {:else}
+    <div
+      id="extended-mega-nav-section-{id}"
+      class="usa-nav__submenu usa-megamenu"
+      hidden={!expanded}
+    >
+      <div class="grid-row grid-gap-4">
+        {#each childColumns as column, i (i)}
+          <div class="usa-col">
+            <ul class="usa-nav__submenu-list">
+              {#each column as { id, link, name } (id)}
+                <li class="usa-nav__submenu-item">
+                  <Link href={link}>{name}</Link>
+                </li>
+              {/each}
+            </ul>
+          </div>
+        {/each}
+      </div>
+    </div>
+  {/if}
+</div>

--- a/src/lib/components/Header/Nav/index.ts
+++ b/src/lib/components/Header/Nav/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./Nav.svelte";
+export type { NavItemType, NavLinkType, NavMenuType } from "./types";

--- a/src/lib/components/Header/Nav/types.ts
+++ b/src/lib/components/Header/Nav/types.ts
@@ -11,8 +11,9 @@ export type NavLinkProps = CommonNavItemProps & {
 };
 
 export type NavMenuProps = CommonNavItemProps & {
-  megaMenuColumns?: number;
+  columns?: number;
   children?: NavLinkType[];
+  expanded?: boolean;
 };
 
 export type NavItemProps = NavLinkProps | NavMenuProps;

--- a/src/lib/components/Header/Nav/types.ts
+++ b/src/lib/components/Header/Nav/types.ts
@@ -1,16 +1,26 @@
 // Ideally this would sit within NavItem.svelte, but the way that exporting types works in Svelte
 //   clashes with that approach.
-export type NavItemProps = {
+
+type CommonNavItemProps = {
   id: string;
-  link?: string;
-  isCurrent?: boolean;
-  megaMenuColumns?: number;
-  children?: NavItemType[];
+  current?: boolean;
 };
+
+export type NavLinkProps = CommonNavItemProps & {
+  link?: string;
+};
+
+export type NavMenuProps = CommonNavItemProps & {
+  megaMenuColumns?: number;
+  children?: NavLinkType[];
+};
+
+export type NavItemProps = NavLinkProps | NavMenuProps;
 
 // Whole reason for this hullabaloo is that we want a type for the component props as well as a
 //   type for the data structure for a list of nav items. The data structure houses what will
 //   become <slot/> content as `name`, but that field shouldn't be included in the component props.
-export type NavItemType = NavItemProps & { name?: string };
+export type NavLinkType = NavLinkProps & { name?: string };
+export type NavMenuType = NavMenuProps & { name?: string };
 
-export default NavItemType;
+export type NavItemType = NavMenuType | NavLinkType;

--- a/src/lib/util/chunk.ts
+++ b/src/lib/util/chunk.ts
@@ -1,9 +1,10 @@
 // https://github.com/you-dont-need/You-Dont-Need-Lodash-Underscore#_chunk
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const chunk = (input: any[], size: number) => {
-  return input.reduce((arr, item, idx) => {
-    return idx % size === 0 ? [...arr, [item]] : [...arr.slice(0, -1), [...arr.slice(-1)[0], item]];
-  }, []);
-};
+const chunk = (input: any[], size: number) =>
+  input.reduce(
+    (arr, item, idx) =>
+      idx % size === 0 ? [...arr, [item]] : [...arr.slice(0, -1), [...arr.slice(-1)[0], item]],
+    []
+  );
 
 export default chunk;

--- a/src/lib/util/chunk.ts
+++ b/src/lib/util/chunk.ts
@@ -1,10 +1,13 @@
 // https://github.com/you-dont-need/You-Dont-Need-Lodash-Underscore#_chunk
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const chunk = (input: any[], size: number) =>
-  input.reduce(
-    (arr, item, idx) =>
-      idx % size === 0 ? [...arr, [item]] : [...arr.slice(0, -1), [...arr.slice(-1)[0], item]],
+const chunk = <T>(input: T[], size: number): T[][] => {
+  if (size === 0) return [];
+  if (size === 1) return [input];
+  return input.reduce<T[][]>(
+    (arr, item, i) =>
+      i % size === 0 ? [...arr, [item]] : [...arr.slice(0, -1), [...arr.slice(-1)[0], item]],
     []
   );
+};
 
 export default chunk;

--- a/src/stories/Header.stories.ts
+++ b/src/stories/Header.stories.ts
@@ -43,19 +43,19 @@ export const Default: Story = {
       {
         id: genId(),
         name: "MegaMenu 1",
-        megaMenuColumns: 2,
+        columns: 2,
         children: generateMenuItems(4, "MegaMenu 1"),
       },
       {
         id: genId(),
         name: "MegaMenu 2",
-        megaMenuColumns: 3,
+        columns: 3,
         children: generateMenuItems(7, "MegaMenu 2"),
       },
       {
         id: genId(),
         name: "MegaMenu 3",
-        megaMenuColumns: 5,
+        columns: 5,
         children: generateMenuItems(22, "MegaMenu 3"),
       },
     ],


### PR DESCRIPTION
- Makes `chunk` generic so that it doesn't infect variables with `any` types.
- Splits up `NavItemType` into `NavLinkType` and `NavMenuType`
- Splits up `NavItem` into `NavLink` and `NavMenu`
- Keeps "which, if any, menu is expanded" state in `Nav` component
- Uses events to signal expanding and closing the menu so that state can be kept in `Nav`