### PR TITLE
LDAF-207 Set up Figma design file embeds within Storybook stories

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -5,6 +5,7 @@ const config: StorybookConfig = {
     "@storybook/addon-links",
     "@storybook/addon-essentials",
     "@storybook/addon-interactions",
+    "storybook-addon-designs", // Figma plugin
   ],
   framework: {
     name: "@storybook/sveltekit",

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "react-dom": "^18.2.0",
         "sass": "^1.53.0",
         "storybook": "^7.0.4",
+        "storybook-addon-designs": "^7.0.0-beta.2",
         "svelte": "^3.54.0",
         "svelte-check": "^3.0.1",
         "tslib": "^2.4.1",
@@ -2511,6 +2512,28 @@
       "integrity": "sha512-cEee/Z+I12mZcFJshKcCqC8tuX5hG3s+d+9nZ3LabqKF1vKdF41B92pJVCBggjAGORAeOzyyDDKrZwIkLffeOQ==",
       "dev": true
     },
+    "node_modules/@figspec/components": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@figspec/components/-/components-1.0.1.tgz",
+      "integrity": "sha512-UvnEamPEAMh9HExViqpobWmX25g1+soA9kcJu+It3VerMa7CeVyaIbQydNf1Gys5v/rxJVdTDRgQ7OXW2zAAig==",
+      "dev": true,
+      "dependencies": {
+        "lit": "^2.1.3"
+      }
+    },
+    "node_modules/@figspec/react": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@figspec/react/-/react-1.0.3.tgz",
+      "integrity": "sha512-r683qOko+5CbT48Ox280fMx2MNAtaFPgCNJvldOqN3YtmAzlcTT+YSxd3OahA+kjXGGrnzDbUgeTOX1cPLII+g==",
+      "dev": true,
+      "dependencies": {
+        "@figspec/components": "^1.0.1",
+        "@lit-labs/react": "^1.0.2"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.8",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
@@ -2777,6 +2800,27 @@
       "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.4.0.tgz",
       "integrity": "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==",
       "dev": true
+    },
+    "node_modules/@lit-labs/react": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/react/-/react-1.1.1.tgz",
+      "integrity": "sha512-9TC+/ZWb6BJlWCyUr14FKFlaGnyKpeEDorufXozQgke/VoVrslUQNaL7nBmrAWdNrmzx5jWgi8lFmWwrxMjnlA==",
+      "dev": true
+    },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.1.0.tgz",
+      "integrity": "sha512-92uQ5ARf7UXYrzaFcAX3T2rTvaS9Z1//ukV+DqjACM4c8s0ZBQd7ayJU5Dh2AFLD/Ayuyz4uMmxQec8q3U4Ong==",
+      "dev": true
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.1.tgz",
+      "integrity": "sha512-va15kYZr7KZNNPZdxONGQzpUr+4sxVu7V/VG7a8mRfPPXUyhEYj5RzXCQmGrlP3tAh0L3HHm5AjBMFYRqlM9SA==",
+      "dev": true,
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.0.0"
+      }
     },
     "node_modules/@mdx-js/react": {
       "version": "2.3.0",
@@ -3319,6 +3363,53 @@
         "@storybook/theming": "7.0.4",
         "memoizerific": "^1.11.3",
         "prop-types": "^15.7.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/addons": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-7.0.4.tgz",
+      "integrity": "sha512-dkpyKNwAY+Ev9ZbgiLB0ki7H6AbAMqYcBx1qYvyFR2hv3k1Ta2OQIMTkODWdkYsgffH00SSpgaBwb2lBUrMZkw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@storybook/manager-api": "7.0.4",
+        "@storybook/preview-api": "7.0.4",
+        "@storybook/types": "7.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@storybook/api": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/@storybook/api/-/api-7.0.4.tgz",
+      "integrity": "sha512-6Zd83ByPhEeDlNmtVOvlurw5AmjELjun4hUYdy6awy6WGgroAPGO1639LLZTToCa0YxIuf7ZAWa6p3dMZOluMA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@storybook/client-logger": "7.0.4",
+        "@storybook/manager-api": "7.0.4"
       },
       "funding": {
         "type": "opencollective",
@@ -5676,6 +5767,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/treeify/-/treeify-1.0.0.tgz",
       "integrity": "sha512-ONpcZAEYlbPx4EtJwfTyCDQJGUpKf4sEcuySdCVjK5Fj/3vHp5HII1fqa1/+qrsLnpYELCQTfVW/awsGJePoIg==",
+      "dev": true
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.3.tgz",
+      "integrity": "sha512-NfQ4gyz38SL8sDNrSixxU2Os1a5xcdFxipAFxYEuLUlvU2uDwS4NUpsImcf1//SlWItCVMMLiylsxbmNMToV/g==",
       "dev": true
     },
     "node_modules/@types/unist": {
@@ -11419,6 +11516,37 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
     },
+    "node_modules/lit": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.7.2.tgz",
+      "integrity": "sha512-9QnZmG5mIKPRja96cpndMclLSi0Qrz2BXD6EbqNqCKMMjOWVm/BwAeXufFk2jqFsNmY07HOzU8X+8aTSVt3yrA==",
+      "dev": true,
+      "dependencies": {
+        "@lit/reactive-element": "^1.6.0",
+        "lit-element": "^3.3.0",
+        "lit-html": "^2.7.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.1.tgz",
+      "integrity": "sha512-Gl+2409uXWbf7n6cCl7Kzasm7zjT9xmdwi2BhLNi70sRKAgRkqueDu5mSIH3hPYMM0/vqBCdPXod3NbGkRA2ww==",
+      "dev": true,
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.1.0",
+        "@lit/reactive-element": "^1.3.0",
+        "lit-html": "^2.7.0"
+      }
+    },
+    "node_modules/lit-html": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.7.2.tgz",
+      "integrity": "sha512-ZJCfKlA2XELu5tn7XuzOziGFGvf1SeQm+ngLWoJ8bXtSkRrrR3ms6SWy+gsdxeYwySLij5xAhdd2C3EX0ftxdQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
+    },
     "node_modules/local-pkg": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.4.3.tgz",
@@ -14259,6 +14387,32 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/storybook-addon-designs": {
+      "version": "7.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/storybook-addon-designs/-/storybook-addon-designs-7.0.0-beta.2.tgz",
+      "integrity": "sha512-ljBNmyCJdPTXhiBSfA1S+GBxtMooW2M7nxlt49OoCRH7jcxZOYQdiI8JYQiMF5Ur0MGakbSci0Xm+JzAvcm02g==",
+      "dev": true,
+      "dependencies": {
+        "@figspec/react": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@storybook/addon-docs": "^6.4.0 || ^7.0.0",
+        "@storybook/addons": "^6.4.0 || ^7.0.0",
+        "@storybook/api": "^6.4.0 || ^7.0.0",
+        "@storybook/components": "^6.4.0 || ^7.0.0",
+        "@storybook/theming": "^6.4.0 || ^7.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/stream-buffers": {
@@ -17796,6 +17950,25 @@
       "integrity": "sha512-cEee/Z+I12mZcFJshKcCqC8tuX5hG3s+d+9nZ3LabqKF1vKdF41B92pJVCBggjAGORAeOzyyDDKrZwIkLffeOQ==",
       "dev": true
     },
+    "@figspec/components": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@figspec/components/-/components-1.0.1.tgz",
+      "integrity": "sha512-UvnEamPEAMh9HExViqpobWmX25g1+soA9kcJu+It3VerMa7CeVyaIbQydNf1Gys5v/rxJVdTDRgQ7OXW2zAAig==",
+      "dev": true,
+      "requires": {
+        "lit": "^2.1.3"
+      }
+    },
+    "@figspec/react": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@figspec/react/-/react-1.0.3.tgz",
+      "integrity": "sha512-r683qOko+5CbT48Ox280fMx2MNAtaFPgCNJvldOqN3YtmAzlcTT+YSxd3OahA+kjXGGrnzDbUgeTOX1cPLII+g==",
+      "dev": true,
+      "requires": {
+        "@figspec/components": "^1.0.1",
+        "@lit-labs/react": "^1.0.2"
+      }
+    },
     "@humanwhocodes/config-array": {
       "version": "0.11.8",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
@@ -18008,6 +18181,27 @@
       "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.4.0.tgz",
       "integrity": "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==",
       "dev": true
+    },
+    "@lit-labs/react": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/react/-/react-1.1.1.tgz",
+      "integrity": "sha512-9TC+/ZWb6BJlWCyUr14FKFlaGnyKpeEDorufXozQgke/VoVrslUQNaL7nBmrAWdNrmzx5jWgi8lFmWwrxMjnlA==",
+      "dev": true
+    },
+    "@lit-labs/ssr-dom-shim": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.1.0.tgz",
+      "integrity": "sha512-92uQ5ARf7UXYrzaFcAX3T2rTvaS9Z1//ukV+DqjACM4c8s0ZBQd7ayJU5Dh2AFLD/Ayuyz4uMmxQec8q3U4Ong==",
+      "dev": true
+    },
+    "@lit/reactive-element": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.1.tgz",
+      "integrity": "sha512-va15kYZr7KZNNPZdxONGQzpUr+4sxVu7V/VG7a8mRfPPXUyhEYj5RzXCQmGrlP3tAh0L3HHm5AjBMFYRqlM9SA==",
+      "dev": true,
+      "requires": {
+        "@lit-labs/ssr-dom-shim": "^1.0.0"
+      }
     },
     "@mdx-js/react": {
       "version": "2.3.0",
@@ -18365,6 +18559,29 @@
         "@storybook/theming": "7.0.4",
         "memoizerific": "^1.11.3",
         "prop-types": "^15.7.2"
+      }
+    },
+    "@storybook/addons": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-7.0.4.tgz",
+      "integrity": "sha512-dkpyKNwAY+Ev9ZbgiLB0ki7H6AbAMqYcBx1qYvyFR2hv3k1Ta2OQIMTkODWdkYsgffH00SSpgaBwb2lBUrMZkw==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@storybook/manager-api": "7.0.4",
+        "@storybook/preview-api": "7.0.4",
+        "@storybook/types": "7.0.4"
+      }
+    },
+    "@storybook/api": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/@storybook/api/-/api-7.0.4.tgz",
+      "integrity": "sha512-6Zd83ByPhEeDlNmtVOvlurw5AmjELjun4hUYdy6awy6WGgroAPGO1639LLZTToCa0YxIuf7ZAWa6p3dMZOluMA==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@storybook/client-logger": "7.0.4",
+        "@storybook/manager-api": "7.0.4"
       }
     },
     "@storybook/blocks": {
@@ -19998,6 +20215,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/treeify/-/treeify-1.0.0.tgz",
       "integrity": "sha512-ONpcZAEYlbPx4EtJwfTyCDQJGUpKf4sEcuySdCVjK5Fj/3vHp5HII1fqa1/+qrsLnpYELCQTfVW/awsGJePoIg==",
+      "dev": true
+    },
+    "@types/trusted-types": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.3.tgz",
+      "integrity": "sha512-NfQ4gyz38SL8sDNrSixxU2Os1a5xcdFxipAFxYEuLUlvU2uDwS4NUpsImcf1//SlWItCVMMLiylsxbmNMToV/g==",
       "dev": true
     },
     "@types/unist": {
@@ -24366,6 +24589,37 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
     },
+    "lit": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.7.2.tgz",
+      "integrity": "sha512-9QnZmG5mIKPRja96cpndMclLSi0Qrz2BXD6EbqNqCKMMjOWVm/BwAeXufFk2jqFsNmY07HOzU8X+8aTSVt3yrA==",
+      "dev": true,
+      "requires": {
+        "@lit/reactive-element": "^1.6.0",
+        "lit-element": "^3.3.0",
+        "lit-html": "^2.7.0"
+      }
+    },
+    "lit-element": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.1.tgz",
+      "integrity": "sha512-Gl+2409uXWbf7n6cCl7Kzasm7zjT9xmdwi2BhLNi70sRKAgRkqueDu5mSIH3hPYMM0/vqBCdPXod3NbGkRA2ww==",
+      "dev": true,
+      "requires": {
+        "@lit-labs/ssr-dom-shim": "^1.1.0",
+        "@lit/reactive-element": "^1.3.0",
+        "lit-html": "^2.7.0"
+      }
+    },
+    "lit-html": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.7.2.tgz",
+      "integrity": "sha512-ZJCfKlA2XELu5tn7XuzOziGFGvf1SeQm+ngLWoJ8bXtSkRrrR3ms6SWy+gsdxeYwySLij5xAhdd2C3EX0ftxdQ==",
+      "dev": true,
+      "requires": {
+        "@types/trusted-types": "^2.0.2"
+      }
+    },
     "local-pkg": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.4.3.tgz",
@@ -26525,6 +26779,15 @@
       "dev": true,
       "requires": {
         "@storybook/cli": "7.0.4"
+      }
+    },
+    "storybook-addon-designs": {
+      "version": "7.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/storybook-addon-designs/-/storybook-addon-designs-7.0.0-beta.2.tgz",
+      "integrity": "sha512-ljBNmyCJdPTXhiBSfA1S+GBxtMooW2M7nxlt49OoCRH7jcxZOYQdiI8JYQiMF5Ur0MGakbSci0Xm+JzAvcm02g==",
+      "dev": true,
+      "requires": {
+        "@figspec/react": "^1.0.0"
       }
     },
     "stream-buffers": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "react-dom": "^18.2.0",
     "sass": "^1.53.0",
     "storybook": "^7.0.4",
+    "storybook-addon-designs": "^7.0.0-beta.2",
     "svelte": "^3.54.0",
     "svelte-check": "^3.0.1",
     "tslib": "^2.4.1",

--- a/src/stories/Icon.stories.ts
+++ b/src/stories/Icon.stories.ts
@@ -18,6 +18,12 @@ const meta = {
       options: [undefined, 3, 4, 5, 6, 7, 8, 9],
     },
   },
+  parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/file/oGKbyCnCRRdNzLYbiags93/LDAF-Component-Library-USWDS-3.0.2?node-id=2196-11369&t=w7ksKxV0kX4Da0k0-4",
+    },
+  },
 } satisfies Meta<Icon>;
 
 export default meta;


### PR DESCRIPTION
## Closes #5

Jira ticket: [LDAF-207](https://ldaf.atlassian.net/browse/LDAF-207)

Connecting our Storybook stories with Figma design files is a nice-to-have feature that could help to mitigate the two getting out of sync.

## Proposed changes

Following the latter half of [this Figma tutorial](https://help.figma.com/hc/en-us/articles/360045003494-Storybook-and-Figma#Embed_Figma_in_Storybook), I made the following changes:

- Installed the [storybook-addon-designs](https://github.com/storybookjs/addon-designs) plugin to add Figma support. We need to use the `beta` version since the plugin doesn't officially support Storybook 7 yet.
- "Configured" the plugin by adding it to the list of `addons` in `.storybook/main.ts`.
- Showed an example of how we can use this plugin by adding it to the `Icon` component stories. In Storybook this shows up under "Design" in the bottom / side panel. 
  - I wasn't able to get this working on the main `Docs` page for components; it seems like it will only work on individual stories.
  - Unfortunately we haven't finalized the `Icon` component in our mocks yet so it's currently linking to a blank page (but you can open up the link at the bottom to quickly zoom in on the relevant section in the Figma component library).

## Screenshots

I already deployed this to chromatic, so you can [see the addon in action here](https://641a2b7efd9419d13bbf8390-sgmdlizpsl.chromatic.com/?path=/story/example-icon--small). Just click "Design" in the bottom / side panel and you should see the embed, assuming you're logged into Ad Hoc's Figma account.

## Acceptance criteria validation

A/C in related ticket were not quite met due to limitations:
- There is no `Link` component in the Figma design library, so I opted to use `Icon` as our starting point instead.
- The connection between Figma and Storybook is not two-way; we can link Figma design files within Storybook stories, but someone with edit permissions in Ad Hoc's Figma account will need to make the corresponding link in Figma files to our Storybook hosted on chromatic (if they happen to find this useful, that is).


[LDAF-207]: https://ldaf.atlassian.net/browse/LDAF-207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ