### PR TITLE
Stop robots from crawling the site until we're ready to launch

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
Very quick PR that adds a `/robots.txt` that disallows all bots on all routes.

Created a Jira ticket to remind us to update this before launch: [LDAF-265](https://ldaf.atlassian.net/browse/LDAF-265)

[LDAF-265]: https://ldaf.atlassian.net/browse/LDAF-265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ