### PR TITLE
Refactor IntersectionObserver and add Storybook story

### DIFF
--- a/src/lib/components/Image/Image.test.ts
+++ b/src/lib/components/Image/Image.test.ts
@@ -93,6 +93,7 @@ describe("Image", () => {
       });
       it("renders without src", () => expect(getImage()).not.toHaveAttribute("src"));
       it("adds src on intersect", async () => {
+        await waitFor(() => expect(intersectionObserverMock.observe).toHaveBeenCalledOnce());
         intersectionObserverMock.intersect();
         await waitFor(() => expect(getImage()).toHaveAttribute("src", sampleImage));
       });

--- a/src/lib/components/IntersectionObserver/IntersectionObserver.svelte
+++ b/src/lib/components/IntersectionObserver/IntersectionObserver.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { createEventDispatcher, getContext, hasContext, onMount } from "svelte";
+  import { createEventDispatcher, getContext, hasContext } from "svelte";
   import { browser } from "$app/environment";
   import warn from "$lib/util/warn";
   import { getRootObserver, type RootObserver } from "./observe";
@@ -33,12 +33,11 @@
   observerPromise.then((resolved) => (observer = resolved));
 
   $: if (enabled && observer) {
-    // If the target has been changed, unobserve the previous target
-    if (lastTarget && target !== lastTarget) observer.unobserve(lastTarget);
-    if (!target) break $;
     if (target === lastTarget) break $;
-    observer.observe(target, ({ isIntersecting }) => (intersecting = isIntersecting), { once });
+    if (lastTarget) observer.unobserve(lastTarget);
     lastTarget = target;
+    if (!target) break $;
+    observer.observe(target, ({ isIntersecting }) => (intersecting = isIntersecting), { once });
   }
 </script>
 

--- a/src/lib/components/IntersectionObserver/IntersectionObserver.svelte
+++ b/src/lib/components/IntersectionObserver/IntersectionObserver.svelte
@@ -25,7 +25,7 @@
     warn(
       "<IntersectionObserver> was not wrapped in a <RootIntersectionObserver>. It will continue to work, but it is more efficient to wrap the page in a single <RootIntersectionObserver> that can be used by all <IntersectionObserver> components. A <RootIntersectionObserver> also allows you to pass options to the IntersectionObserver used behind the scenes."
     );
-    observerPromise = new Promise((resolve) => onMount(() => resolve(getRootObserver())));
+    observerPromise = Promise.resolve(getRootObserver());
   } else {
     observerPromise = Promise.resolve(undefined);
   }
@@ -36,6 +36,7 @@
     // If the target has been changed, unobserve the previous target
     if (lastTarget && target !== lastTarget) observer.unobserve(lastTarget);
     if (!target) break $;
+    if (target === lastTarget) break $;
     observer.observe(target, ({ isIntersecting }) => (intersecting = isIntersecting), { once });
     lastTarget = target;
   }

--- a/src/lib/components/IntersectionObserver/IntersectionObserver.test.ts
+++ b/src/lib/components/IntersectionObserver/IntersectionObserver.test.ts
@@ -46,11 +46,16 @@ describe("IntersectionObserver", () => {
     }));
   };
 
+  const waitForInitialization = async () =>
+    waitFor(() => expect(IntersectionObserverMock).toHaveBeenCalledOnce());
+
   describe("with default props", () => {
-    beforeEach(() => renderWithProps());
+    beforeEach(async () => {
+      renderWithProps();
+      await waitForInitialization();
+    });
 
     it("sets up an IntersectionObserver", async () => {
-      expect(IntersectionObserverMock).toHaveBeenCalledOnce();
       expect(IntersectionObserverMock).toHaveBeenCalledWith(intersectionObserverMock.callback, {});
       expect(intersectionObserverMock.observe).toHaveBeenCalledOnce();
     });
@@ -67,7 +72,10 @@ describe("IntersectionObserver", () => {
   });
 
   describe('with "once" set', () => {
-    beforeEach(() => renderWithProps({ props: { once: true } }));
+    beforeEach(async () => {
+      renderWithProps({ props: { once: true } });
+      await waitForInitialization();
+    });
     it("emits an event on the first intersection", async () => {
       const onIntersect = vi.fn();
       component.$on("intersect", onIntersect);

--- a/src/lib/components/IntersectionObserver/RootIntersectionObserver.svelte
+++ b/src/lib/components/IntersectionObserver/RootIntersectionObserver.svelte
@@ -1,23 +1,24 @@
 <script lang="ts">
   import { getRootObserver, type RootObserver } from "./observe";
-  import { onMount, setContext } from "svelte";
+  import { setContext } from "svelte";
   import key from "./key";
   import { browser } from "$app/environment";
 
-  type Root = Element | undefined;
+  type RootOption = Element | undefined;
 
-  export let root: Root | Promise<Root> = undefined;
+  export let root: RootOption | Promise<RootOption> = undefined;
   export let rootMargin: string | undefined = undefined;
   export let enabled = true;
 
-  const rootObserverPromise = new Promise<RootObserver | undefined>((resolve) =>
-    browser
-      ? onMount(async () => resolve(getRootObserver({ root: await root, rootMargin })))
-      : resolve(undefined)
-  );
+  const getRootObserverPromise = async (): Promise<RootObserver | undefined> => {
+    if (!browser) return undefined;
+    if (!root) return getRootObserver({ rootMargin });
+    if (root instanceof Element) return getRootObserver({ root, rootMargin });
+    if (root instanceof Promise) return getRootObserver({ root: await root, rootMargin });
+  };
 
   if (enabled && browser) {
-    setContext<Promise<RootObserver | undefined>>(key, rootObserverPromise);
+    setContext<Promise<RootObserver | undefined>>(key, getRootObserverPromise());
   }
 </script>
 

--- a/src/lib/components/IntersectionObserver/RootIntersectionObserver.svelte
+++ b/src/lib/components/IntersectionObserver/RootIntersectionObserver.svelte
@@ -1,17 +1,23 @@
 <script lang="ts">
   import { getRootObserver, type RootObserver } from "./observe";
-  import { setContext } from "svelte";
+  import { onMount, setContext } from "svelte";
   import key from "./key";
   import { browser } from "$app/environment";
 
+  type Root = Element | undefined;
+
+  export let root: Root | Promise<Root> = undefined;
   export let rootMargin: string | undefined = undefined;
   export let enabled = true;
 
+  const rootObserverPromise = new Promise<RootObserver | undefined>((resolve) =>
+    browser
+      ? onMount(async () => resolve(getRootObserver({ root: await root, rootMargin })))
+      : resolve(undefined)
+  );
+
   if (enabled && browser) {
-    const observer: RootObserver | undefined = getRootObserver({ rootMargin });
-    if (observer) {
-      setContext<RootObserver>(key, observer);
-    }
+    setContext<Promise<RootObserver | undefined>>(key, rootObserverPromise);
   }
 </script>
 

--- a/src/stories/IntersectionObserver.stories.ts
+++ b/src/stories/IntersectionObserver.stories.ts
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from "@storybook/svelte";
+
+import type IntersectionObserver from "$lib/components/IntersectionObserver";
+import IntersectionObserverStory from "./IntersectionObserverStory.svelte";
+
+const meta = {
+  title: "IntersectionObserver",
+  component: IntersectionObserverStory,
+  tags: [],
+} satisfies Meta<IntersectionObserver>;
+
+type Story = StoryObj<typeof meta>;
+
+export const Example: Story = {};
+
+export default meta;

--- a/src/stories/IntersectionObserverStory.svelte
+++ b/src/stories/IntersectionObserverStory.svelte
@@ -18,11 +18,7 @@
   <div class="view" bind:this={viewElement}>
     <div class="viewBorder" />
     {#each { length: numberOfChildren } as _, i}
-      <IntersectionObserver
-        let:intersecting
-        on:intersect={() => console.log(childElements[i])}
-        target={childElements[i]}
-      >
+      <IntersectionObserver let:intersecting target={childElements[i]}>
         <div
           class={classNames("child", intersecting && "intersecting")}
           bind:this={childElements[i]}

--- a/src/stories/IntersectionObserverStory.svelte
+++ b/src/stories/IntersectionObserverStory.svelte
@@ -6,11 +6,11 @@
   let numberOfChildren = 25;
 
   let viewElement: HTMLDivElement;
-  let resolveViewElementPromise: (viewElement: Element) => void;
+  let resolveViewElement: (viewElement: Element) => void;
   const viewElementPromise = new Promise<Element | undefined>(
-    (resolve) => (resolveViewElementPromise = resolve)
+    (resolve) => (resolveViewElement = resolve)
   );
-  $: if (resolveViewElementPromise && viewElement) resolveViewElementPromise(viewElement);
+  $: if (resolveViewElement && viewElement) resolveViewElement(viewElement);
   let childElements: HTMLDivElement[] = [];
 </script>
 

--- a/src/stories/IntersectionObserverStory.svelte
+++ b/src/stories/IntersectionObserverStory.svelte
@@ -1,0 +1,71 @@
+<script lang="ts">
+  import IntersectionObserver, {
+    RootIntersectionObserver,
+  } from "$lib/components/IntersectionObserver";
+  import classNames from "$lib/util/classNames";
+  let numberOfChildren = 25;
+
+  let viewElement: HTMLDivElement;
+  let resolveViewElementPromise: (viewElement: Element) => void;
+  const viewElementPromise = new Promise<Element | undefined>(
+    (resolve) => (resolveViewElementPromise = resolve)
+  );
+  $: if (resolveViewElementPromise && viewElement) resolveViewElementPromise(viewElement);
+  let childElements: HTMLDivElement[] = [];
+</script>
+
+<RootIntersectionObserver rootMargin="-25% 0px -25% 0px" root={viewElementPromise}>
+  <div class="view" bind:this={viewElement}>
+    <div class="viewBorder" />
+    {#each { length: numberOfChildren } as _, i}
+      <IntersectionObserver
+        let:intersecting
+        on:intersect={() => console.log(childElements[i])}
+        target={childElements[i]}
+      >
+        <div
+          class={classNames("child", intersecting && "intersecting")}
+          bind:this={childElements[i]}
+        >
+          Intersecting: {intersecting}
+        </div>
+      </IntersectionObserver>
+    {/each}
+  </div>
+</RootIntersectionObserver>
+
+<style>
+  .view {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    overflow-x: hidden;
+    overflow-y: scroll;
+  }
+
+  .viewBorder {
+    position: fixed;
+    top: 25%;
+    left: 0;
+    right: 0;
+    bottom: 25%;
+    border: 1px solid green;
+    pointer-events: none;
+  }
+
+  .child {
+    width: 100%;
+    height: 50px;
+    background: #eee;
+    margin-bottom: 1rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .child.intersecting {
+    background: #cec;
+  }
+</style>


### PR DESCRIPTION
## Proposed changes

- Adds support in `IntersectionObserver` and `RootIntersectionObserver` to wait for a promise resolving to a root element before initializing the observer, since `onMount` in child components runs before the DOM bindings in the parent component have initialized. This lets you do the following:

  ```svelte
  <script lang="ts">
    import { RootIntersectionObserver } from "$lib/components/IntersectionObserver";
    let viewElement: HTMLDivElement;
    let resolveViewElement: (viewElement: HTMLDivElement) => void;
    const viewElementPromise = new Promise(
      (resolve) => (resolveViewElement = resolve)
    );
    $: if (resolveViewElement && viewElement) resolveViewElement(viewElement);
  </script>

  <RootIntersectionObserver root={viewElementPromise}>
    <div bind:this={viewElement}>
      <slot />
    </div>
  </RootIntersectionObserver>
  ```

- Adds a Storybook story demonstrating `IntersectionObserver`.

## Screenshots

![image](https://user-images.githubusercontent.com/1425133/233744443-4023e9e6-93a3-4e98-b363-71964407af18.png)

## Acceptance criteria validation

- [x] Tests updated and passing
- [x] `IntersectionObserver` continues to work properly
