### PR TITLE
Add lazy image loading Storybook example

### DIFF
--- a/src/lib/components/Image/Image.svelte
+++ b/src/lib/components/Image/Image.svelte
@@ -19,6 +19,9 @@
   let className: string | undefined = undefined;
   export { className as class };
   export let imageClass: string | undefined = undefined;
+  export let nativeLazyLoading = loading === "lazy" && lazyImageLoadingSupport;
+  export let intersectionObserverLazyLoading =
+    loading === "lazy" && !nativeLazyLoading && intersectionObserverSupport;
 
   if (!width || !height) warn("image width or height was missing!");
 
@@ -43,7 +46,7 @@
     srcProps = withSrcProp;
   } else if (!browser) {
     srcProps = withNoSrcProp;
-  } else if (lazyImageLoadingSupport || !intersectionObserverSupport || intersecting) {
+  } else if (nativeLazyLoading || !intersectionObserverLazyLoading || intersecting) {
     srcProps = withSrcProp;
   } else {
     srcProps = withNoSrcProp;
@@ -73,7 +76,7 @@
   target={thisContainer}
   once={true}
   on:intersect={() => (intersecting = true)}
-  enabled={loading === "lazy" && intersectionObserverSupport && !lazyImageLoadingSupport}
+  enabled={intersectionObserverLazyLoading}
 >
   <div
     role="img"

--- a/src/lib/components/Image/types.ts
+++ b/src/lib/components/Image/types.ts
@@ -1,1 +1,3 @@
 export type Color = { r: number; g: number; b: number };
+export type Loading = "eager" | "lazy";
+export type LazyLoading = "none" | "native" | "intersectionObserver";

--- a/src/stories/Examples/LazyImageLoading/LazyImageLoading.mdx
+++ b/src/stories/Examples/LazyImageLoading/LazyImageLoading.mdx
@@ -19,4 +19,4 @@ We could also use a scroll handler as a step in between `IntersectionObserver` a
 
 To use the example, open it, then choose a lazy loading strategy, then refresh the preview and scroll down and new elements will be added as long as you keep scrolling. This is only really useful with the `IntersectionObserver` strategy, since it has a `rootMargin` of `75%` that makes images only load once they've reached the top quarter of the viewport. Native lazy loading will load the images at some point before they reach the viewport, so images will mostly appear to load instantly.
 
-Note that the green line indicating where the edge of the `IntersectionObserver` is is inaccurate unless you open the preview in a new tab. This is because of how the `IntersectionObserver` interacts with Storybook and does not represent how it works on the real site.
+Note that the green line indicating where the edge of the `IntersectionObserver` is is inaccurate unless you open the preview in a new tab (using the "open canvas in new tab" button in the top right). This is because of how the `IntersectionObserver` interacts with Storybook and does not represent how it works on the real site.

--- a/src/stories/Examples/LazyImageLoading/LazyImageLoading.mdx
+++ b/src/stories/Examples/LazyImageLoading/LazyImageLoading.mdx
@@ -1,0 +1,22 @@
+import { Canvas, Meta, Story } from "@storybook/blocks";
+import * as Stories from "./LazyImageLoading.stories";
+
+# Lazy Image Loading
+
+<Meta of={Stories} />
+
+Lazy image loading uses the following techniques, from most preferred to least:
+
+- `loading="lazy"` - this is always set on the `img` element, and if `"loading" in HTMLImageElement.prototype` evaluates to `true` then the `src` attribute is added immediately to the image and nothing else is done.
+
+- `IntersectionObserver` - if lazy loading is not natively supported, but `IntersectionObserver` is supported, then it is used to add the `src` to the image only when the image reaches the viewport.
+
+- No lazy image loading - if neither of the above techniques are available, the `src` element is immediately added to the image and the browser uses its default behavior. `loading="lazy"` is still added to the `img` element in case feature detection was mistaken.
+
+We could also use a scroll handler as a step in between `IntersectionObserver` and no lazy image loading, but this is unlikely to be helpful to many users.
+
+## Using the example
+
+To use the example, open it, then choose a lazy loading strategy, then refresh the preview and scroll down and new elements will be added as long as you keep scrolling. This is only really useful with the `IntersectionObserver` strategy, since it has a `rootMargin` of `75%` that makes images only load once they've reached the top quarter of the viewport. Native lazy loading will load the images at some point before they reach the viewport, so images will mostly appear to load instantly.
+
+Note that the green line indicating where the edge of the `IntersectionObserver` is is inaccurate unless you open the preview in a new tab. This is because of how the `IntersectionObserver` interacts with Storybook and does not represent how it works on the real site.

--- a/src/stories/Examples/LazyImageLoading/LazyImageLoading.stories.ts
+++ b/src/stories/Examples/LazyImageLoading/LazyImageLoading.stories.ts
@@ -1,0 +1,15 @@
+import LazyImageLoading from "./LazyImageLoading.svelte";
+import BlurhashRendererDecorator from "../../decorators/BlurhashRendererDecorator.svelte";
+import type { Meta, StoryObj } from "@storybook/svelte";
+
+const meta = {
+  title: "Examples/Lazy Image Loading",
+  component: LazyImageLoading,
+  // @ts-expect-error Unclear how to resolve SvelteComponent <=> SvelteStoryResult type mismatch.
+  decorators: [() => BlurhashRendererDecorator],
+} satisfies Meta<LazyImageLoading>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Example: Story = {};

--- a/src/stories/Examples/LazyImageLoading/LazyImageLoading.stories.ts
+++ b/src/stories/Examples/LazyImageLoading/LazyImageLoading.stories.ts
@@ -7,6 +7,12 @@ const meta = {
   component: LazyImageLoading,
   // @ts-expect-error Unclear how to resolve SvelteComponent <=> SvelteStoryResult type mismatch.
   decorators: [() => BlurhashRendererDecorator],
+  argTypes: {
+    lazyLoadingType: {
+      control: { type: "radio" },
+      options: ["none", "native", "intersectionObserver"],
+    },
+  },
 } satisfies Meta<LazyImageLoading>;
 
 export default meta;

--- a/src/stories/Examples/LazyImageLoading/LazyImageLoading.svelte
+++ b/src/stories/Examples/LazyImageLoading/LazyImageLoading.svelte
@@ -19,6 +19,7 @@
     width: number;
     height: number;
   }[] = [];
+
   let thisContainer: HTMLDivElement;
   let thisEndOfList: HTMLDivElement;
 

--- a/src/stories/Examples/LazyImageLoading/LazyImageLoading.svelte
+++ b/src/stories/Examples/LazyImageLoading/LazyImageLoading.svelte
@@ -1,0 +1,93 @@
+<script lang="ts">
+  import Image from "$lib/components/Image";
+  import { RootIntersectionObserver } from "$lib/components/IntersectionObserver";
+
+  import sampleImage from "../../../sample.jpg";
+  import sampleImageBlurhash, {
+    width as sampleImageWidth,
+    height as sampleImageHeight,
+    mean as sampleImageMean,
+  } from "../../../sample.jpg?blurhash";
+
+  export let nativeLazyLoading = false;
+  export let intersectionObserverLazyLoading = true;
+
+  let images: {
+    src: string;
+    blurhash: string;
+    mean: { r: number; g: number; b: number };
+    width: number;
+    height: number;
+  }[] = [];
+  let thisContainer: HTMLDivElement;
+  let thisEndOfList: HTMLDivElement;
+
+  let observer: IntersectionObserver;
+
+  $: if (thisContainer && thisEndOfList && !observer) {
+    observer = new IntersectionObserver(([{ isIntersecting }]) => {
+      if (isIntersecting) {
+        images.push({
+          src: sampleImage,
+          blurhash: sampleImageBlurhash,
+          mean: sampleImageMean,
+          width: sampleImageWidth,
+          height: sampleImageHeight,
+        });
+        images = images;
+      }
+    });
+    observer.observe(thisEndOfList);
+  }
+
+  $: if (observer && images) {
+    // re-observe each time images changes
+    observer.unobserve(thisEndOfList);
+    observer.observe(thisEndOfList);
+  }
+</script>
+
+<RootIntersectionObserver rootMargin="0px 0px -75% 0px">
+  <div class="container" bind:this={thisContainer}>
+    <div class="highlight-border" />
+    {#each images as { src, blurhash, mean, width, height }}
+      <Image
+        alt=""
+        {nativeLazyLoading}
+        {intersectionObserverLazyLoading}
+        {src}
+        {blurhash}
+        {mean}
+        {width}
+        {height}
+      />
+    {/each}
+    <div class="end" bind:this={thisEndOfList} />
+  </div>
+</RootIntersectionObserver>
+
+<style lang="scss">
+  .container {
+    width: 50%;
+    margin-left: auto;
+    margin-right: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 50px;
+    overflow-y: scroll;
+  }
+  .end {
+    width: 100%;
+    height: 50px;
+  }
+  .highlight-border {
+    position: fixed;
+    left: 0;
+    top: 0;
+    right: 0;
+    bottom: 75%;
+    border-bottom: 1px solid green;
+    z-index: 1;
+    pointer-events: none;
+  }
+</style>

--- a/src/stories/Examples/LazyImageLoading/LazyImageLoading.svelte
+++ b/src/stories/Examples/LazyImageLoading/LazyImageLoading.svelte
@@ -66,7 +66,6 @@
     display: flex;
     flex-direction: column;
     gap: 50px;
-    overflow-y: scroll;
   }
   .end {
     width: 100%;

--- a/src/stories/Examples/LazyImageLoading/LazyImageLoading.svelte
+++ b/src/stories/Examples/LazyImageLoading/LazyImageLoading.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import Image from "$lib/components/Image";
+  import type { LazyLoading } from "$lib/components/Image/types";
   import { RootIntersectionObserver } from "$lib/components/IntersectionObserver";
 
   import sampleImage from "../../../sample.jpg";
@@ -9,8 +10,7 @@
     mean as sampleImageMean,
   } from "../../../sample.jpg?blurhash";
 
-  export let nativeLazyLoading = false;
-  export let intersectionObserverLazyLoading = true;
+  export let lazyLoadingType: LazyLoading = "intersectionObserver";
 
   let images: {
     src: string;
@@ -24,16 +24,17 @@
 
   let observer: IntersectionObserver;
 
+  const image = {
+    src: sampleImage,
+    blurhash: sampleImageBlurhash,
+    mean: sampleImageMean,
+    width: sampleImageWidth,
+    height: sampleImageHeight,
+  };
   $: if (thisContainer && thisEndOfList && !observer) {
     observer = new IntersectionObserver(([{ isIntersecting }]) => {
       if (isIntersecting) {
-        images.push({
-          src: sampleImage,
-          blurhash: sampleImageBlurhash,
-          mean: sampleImageMean,
-          width: sampleImageWidth,
-          height: sampleImageHeight,
-        });
+        images.push(image, image, image, image, image);
         images = images;
       }
     });
@@ -51,16 +52,7 @@
   <div class="container" bind:this={thisContainer}>
     <div class="highlight-border" />
     {#each images as { src, blurhash, mean, width, height }}
-      <Image
-        alt=""
-        {nativeLazyLoading}
-        {intersectionObserverLazyLoading}
-        {src}
-        {blurhash}
-        {mean}
-        {width}
-        {height}
-      />
+      <Image alt="" {lazyLoadingType} {src} {blurhash} {mean} {width} {height} />
     {/each}
     <div class="end" bind:this={thisEndOfList} />
   </div>
@@ -85,7 +77,7 @@
     left: 0;
     top: 0;
     right: 0;
-    bottom: 75%;
+    bottom: 75vh;
     border-bottom: 1px solid green;
     z-index: 1;
     pointer-events: none;


### PR DESCRIPTION
## Proposed changes

- Organizes Storybook stories into folders
- Adds a demo of `IntersectionObserver` based lazy image loading to Storybook

## Screenshots

![image](https://user-images.githubusercontent.com/1425133/234441544-15fbb546-c661-4c05-b60b-c431010111b2.png)