### PR TITLE
Button: fix unstyled button :hover and :active styles

### DIFF
--- a/src/lib/components/Button/Button.scss
+++ b/src/lib/components/Button/Button.scss
@@ -79,46 +79,28 @@ $colors: (
     background: none;
     color: map.get($colors, "disabled");
   }
-}
-
-.usa-button.usa-button--outline {
-  background: none;
-  color: map.get($colors, "primary");
-  border: 2px solid map.get($colors, "primary");
-  box-shadow: none;
-  &:hover {
+  &:disabled:hover,
+  &:disabled:active {
     background: none;
-    color: map.get($colors, "primary-dark");
-    border: 2px solid map.get($colors, "primary-dark");
-    box-shadow: none;
-  }
-  &:active {
-    background: none;
-    color: map.get($colors, "base-darker");
-    border: 2px solid map.get($colors, "base-darker");
-    box-shadow: none;
-  }
-  &:disabled {
-    background: none;
-    color: map.get($colors, "disabled");
-    border: 2px solid map.get($colors, "disabled");
   }
 }
 
 .usa-button.usa-button--outline-inverse {
   color: map.get($colors, "outline-inverse");
-  border-color: map.get($colors, "base-light");
+  box-shadow: inset 0 0 0 2px map.get($colors, "base-light");
   &:hover {
     color: map.get($colors, "base-lightest");
-    border-color: map.get($colors, "base-lightest");
+    box-shadow: inset 0 0 0 2px map.get($colors, "base-lightest");
   }
   &:active {
     color: #fff;
-    border-color: #fff;
+    box-shadow: inset 0 0 0 2px #fff;
   }
-  &:disabled {
+  &:disabled,
+  &:disabled:hover,
+  &:disabled:active {
     color: map.get($colors, "disabled-dark");
-    border-color: map.get($colors, "disabled-dark");
+    box-shadow: inset 0 0 0 2px map.get($colors, "disabled-dark");
   }
 }
 
@@ -147,7 +129,9 @@ $colors: (
     background: map.get($colors, "primary-lightest");
     color: map.get($colors, "primary");
   }
-  &:disabled {
+  &:disabled,
+  &:disabled:hover,
+  &:disabled:active {
     background: map.get($colors, "disabled-dark");
     color: #fff;
   }
@@ -156,24 +140,42 @@ $colors: (
 .usa-button.usa-button--unstyled {
   background: none;
   color: map.get($colors, "unstyled-fg");
-  border: none;
+  box-shadow: none;
   &:hover {
     background: none;
     color: map.get($colors, "unstyled-fg-hover");
-    border: none;
+    box-shadow: none;
   }
   &:active {
     background: none;
     color: map.get($colors, "unstyled-fg-active");
-    border: none;
+    box-shadow: none;
   }
-}
 
-.usa-button.usa-button--unstyled.usa-button--inverse,
-.usa-button.usa-button--unstyled.usa-button--outline-inverse,
-.usa-button.usa-button--unstyled.usa-button--big-inverse {
-  color: map.get($colors, "unstyled-inverse");
-  &:active {
-    color: map.get($colors, "unstyled-inverse-active");
+  &:disabled,
+  &:disabled:hover,
+  &:disabled:active {
+    color: map.get($colors, "disabled");
+  }
+
+  &.usa-button--inverse,
+  &.usa-button--outline-inverse,
+  &.usa-button--big-inverse {
+    background: none;
+    color: map.get($colors, "unstyled-inverse");
+    &:hover {
+      background: none;
+      color: map.get($colors, "unstyled-inverse");
+    }
+    &:active {
+      background: none;
+      color: map.get($colors, "unstyled-inverse-active");
+    }
+    &:disabled,
+    &:disabled:hover,
+    &:disabled:active {
+      background: none;
+      color: map.get($colors, "disabled-dark");
+    }
   }
 }

--- a/src/lib/components/Button/Button.scss
+++ b/src/lib/components/Button/Button.scss
@@ -33,7 +33,9 @@ $colors: (
   &:active {
     background: map.get($colors, "primary-darker");
   }
-  &:disabled {
+  &:disabled,
+  &:disabled:hover,
+  &:disabled:active {
     background: map.get($colors, "disabled-dark");
   }
 }
@@ -45,6 +47,11 @@ $colors: (
   }
   &:active {
     background: map.get($colors, "base-darker");
+  }
+  &:disabled,
+  &:disabled:hover,
+  &:disabled:active {
+    background: map.get($colors, "disabled-dark");
   }
 }
 
@@ -59,8 +66,11 @@ $colors: (
     color: map.get($colors, "primary");
     background: map.get($colors, "primary-lightest");
   }
-  &:disabled {
+  &:disabled,
+  &:disabled:hover,
+  &:disabled:active {
     color: #fff;
+    background: map.get($colors, "disabled-dark");
   }
 }
 
@@ -75,12 +85,39 @@ $colors: (
     color: map.get($colors, "primary");
     background: map.get($colors, "text-only-active");
   }
-  &:disabled {
+  &:disabled,
+  &:disabled:hover,
+  &:disabled:active {
     background: none;
     color: map.get($colors, "disabled");
   }
+}
+
+.usa-button.usa-button--outline {
+  background: none;
+  color: map.get($colors, "outline");
+  &:disabled,
   &:disabled:hover,
   &:disabled:active {
+    background: none;
+  }
+}
+
+.usa-button.usa-button--outline {
+  background: none;
+  color: map.get($colors, "primary");
+  &:hover {
+    background: none;
+    color: map.get($colors, "primary-dark");
+  }
+  &:active {
+    background: none;
+    color: map.get($colors, "base-darker");
+  }
+  &:disabled,
+  &:disabled:hover,
+  &:disabled:active {
+    color: map.get($colors, "disabled");
     background: none;
   }
 }
@@ -99,6 +136,7 @@ $colors: (
   &:disabled,
   &:disabled:hover,
   &:disabled:active {
+    background: none;
     color: map.get($colors, "disabled-dark");
     box-shadow: inset 0 0 0 2px map.get($colors, "disabled-dark");
   }

--- a/src/lib/components/Button/Button.scss
+++ b/src/lib/components/Button/Button.scss
@@ -154,12 +154,15 @@ $colors: (
 .usa-button.usa-button--unstyled {
   background: none;
   color: map.get($colors, "unstyled-fg");
+  border: none;
   &:hover {
     background: none;
     color: map.get($colors, "unstyled-fg-hover");
+    border: none;
   }
   &:active {
     background: none;
     color: map.get($colors, "unstyled-fg-active");
+    border: none;
   }
 }

--- a/src/lib/components/Button/Button.scss
+++ b/src/lib/components/Button/Button.scss
@@ -19,6 +19,8 @@ $colors: (
   "unstyled-fg": #005ea2,
   "unstyled-fg-hover": #1a4480,
   "unstyled-fg-active": #162e51,
+  "unstyled-inverse": #e6e6e6,
+  "unstyled-inverse-active": #fff,
 );
 
 .usa-button {
@@ -164,5 +166,14 @@ $colors: (
     background: none;
     color: map.get($colors, "unstyled-fg-active");
     border: none;
+  }
+}
+
+.usa-button.usa-button--unstyled.usa-button--inverse,
+.usa-button.usa-button--unstyled.usa-button--outline-inverse,
+.usa-button.usa-button--unstyled.usa-button--big-inverse {
+  color: map.get($colors, "unstyled-inverse");
+  &:active {
+    color: map.get($colors, "unstyled-inverse-active");
   }
 }

--- a/src/lib/components/Button/Button.scss
+++ b/src/lib/components/Button/Button.scss
@@ -155,6 +155,7 @@ $colors: (
   &:disabled,
   &:disabled:hover,
   &:disabled:active {
+    background: none;
     color: map.get($colors, "disabled");
   }
 

--- a/src/lib/components/Button/Button.scss
+++ b/src/lib/components/Button/Button.scss
@@ -193,6 +193,7 @@ $colors: (
   &:disabled,
   &:disabled:hover,
   &:disabled:active {
+    box-shadow: none;
     background: none;
     color: map.get($colors, "disabled");
   }

--- a/src/lib/components/Button/Button.scss
+++ b/src/lib/components/Button/Button.scss
@@ -16,6 +16,9 @@ $colors: (
   "text-only-hover": rgba(6, 60, 122, 16%),
   "text-only-active": rgba(6, 60, 122, 30%),
   "outline-inverse": #dcdee0,
+  "unstyled-fg": #005ea2,
+  "unstyled-fg-hover": #1a4480,
+  "unstyled-fg-active": #162e51,
 );
 
 .usa-button {
@@ -150,5 +153,13 @@ $colors: (
 
 .usa-button.usa-button--unstyled {
   background: none;
-  color: #005ea2;
+  color: map.get($colors, "unstyled-fg");
+  &:hover {
+    background: none;
+    color: map.get($colors, "unstyled-fg-hover");
+  }
+  &:active {
+    background: none;
+    color: map.get($colors, "unstyled-fg-active");
+  }
 }

--- a/src/stories/Button.stories.ts
+++ b/src/stories/Button.stories.ts
@@ -36,6 +36,10 @@ export const Primary: Story = {
   args: {},
 };
 
+export const Disabled: Story = {
+  args: { disabled: true },
+};
+
 export const Base: Story = {
   args: {
     variant: "base",

--- a/src/stories/Button.stories.ts
+++ b/src/stories/Button.stories.ts
@@ -93,6 +93,16 @@ export const Unstyled: Story = {
   },
 };
 
+export const UnstyledInverse: Story = {
+  parameters: {
+    backgrounds: { default: "dark" },
+  },
+  args: {
+    variant: "inverse",
+    unstyled: true,
+  },
+};
+
 export const BigUnstyled: Story = {
   args: {
     variant: "big",


### PR DESCRIPTION
Followup to #63.

## Proposed changes

- Adds explicit background and foreground color settings to `.usa-button.usa-button--unstyled`.