### PR TITLE
Set a reasonable time for dependabot to run.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+      time: "09:00"
+      timezone: "America/Chicago"
     open-pull-requests-limit: 10
     reviewers:
       - "la-ldaf/ad-hoc-engineers"


### PR DESCRIPTION
Not sure how I missed this in #41 but with the current config dependabot is running in the middle of the night, so I figured it would make more sense to use [`time`](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#scheduletime) and [`timezone`](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#scheduletimezone) to have it run in the morning, Central time. 

@Benaiah @hinzed1127 if you'd prefer, I could switch it to like 11am CT (9am PT) so that it's running during our core operating hours.