### PR TITLE
ESLint linting for GraphQL queries

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -11,6 +11,8 @@ node_modules
 /e2e-tests/report
 /e2e-tests/results
 /bundle-visualizer
+src/lib/services/contentful/schema.ts
+src/lib/services/contentful/schema.graphql
 
 # Ignore files for PNPM, NPM and YARN
 pnpm-lock.yaml

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -16,6 +16,18 @@ module.exports = {
       files: ["*.svelte"],
       processor: "svelte3/svelte3",
     },
+    {
+      files: ["*.ts", "*.js"],
+      processor: "@graphql-eslint/graphql",
+    },
+    {
+      files: ["*.graphql"],
+      extends: "plugin:@graphql-eslint/operations-recommended",
+      parserOptions: {
+        schema: "./src/lib/services/contentful/schema.graphql",
+        operations: "./src/**/*.{ts,svelte,gql,graphql}",
+      },
+    },
   ],
   settings: {
     "svelte3/typescript": () => require("typescript"),

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,8 @@
         "@contentful/rich-text-types": "^16.0.3",
         "@uswds/uswds": "^3.4.1",
         "fast-blurhash": "^1.1.2",
+        "graphql": "^16.6.0",
+        "graphql-tag": "^2.12.6",
         "lodash": "^4.17.21"
       },
       "devDependencies": {
@@ -19,6 +21,7 @@
         "@graphql-codegen/cli": "^3.3.1",
         "@graphql-codegen/schema-ast": "^3.0.1",
         "@graphql-codegen/typescript": "^3.0.4",
+        "@graphql-eslint/eslint-plugin": "^3.18.0",
         "@playwright/test": "^1.34.3",
         "@poppanator/sveltekit-svg": "^3.0.1",
         "@rollup/plugin-node-resolve": "^15.1.0",
@@ -3006,6 +3009,28 @@
         "graphql-tag": "^2.11.0",
         "parse-filepath": "^1.0.2",
         "tslib": "~2.5.0"
+      },
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-eslint/eslint-plugin": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@graphql-eslint/eslint-plugin/-/eslint-plugin-3.18.0.tgz",
+      "integrity": "sha512-riEEfRycc0+pWxcEWqHi8woRxzg1xZqAfh9DRACJUR7bTN8dmc1N04i7+pvW4sevClUFYC2wuL1Vtr+DwzXLUg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.18.6",
+        "@graphql-tools/code-file-loader": "^7.3.6",
+        "@graphql-tools/graphql-tag-pluck": "^7.3.6",
+        "@graphql-tools/utils": "^9.0.0",
+        "chalk": "^4.1.2",
+        "debug": "^4.3.4",
+        "fast-glob": "^3.2.12",
+        "graphql-config": "^4.4.0",
+        "graphql-depth-limit": "^1.1.0",
+        "lodash.lowercase": "^4.3.0",
+        "tslib": "^2.4.1"
       },
       "peerDependencies": {
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
@@ -10660,6 +10685,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
@@ -14698,7 +14732,6 @@
       "version": "16.6.0",
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.6.0.tgz",
       "integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==",
-      "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -14770,6 +14803,21 @@
         "node": ">=10"
       }
     },
+    "node_modules/graphql-depth-limit": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/graphql-depth-limit/-/graphql-depth-limit-1.1.0.tgz",
+      "integrity": "sha512-+3B2BaG8qQ8E18kzk9yiSdAa75i/hnnOwgSeAxVJctGQPvmeiLtqKOYF6HETCyRjiF7Xfsyal0HbLlxCQkgkrw==",
+      "dev": true,
+      "dependencies": {
+        "arrify": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "*"
+      }
+    },
     "node_modules/graphql-request": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-6.0.0.tgz",
@@ -14787,7 +14835,6 @@
       "version": "2.12.6",
       "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz",
       "integrity": "sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -16921,6 +16968,12 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-4.2.0.tgz",
       "integrity": "sha512-J79MkJcp7Df5mizHiVNpjoHXLi4HLjh9VLS/M7lQSGoQ+0oQ+lWEigREkqKyizPB1IawvQLLKY8mzEcm1tkyxQ==",
+      "dev": true
+    },
+    "node_modules/lodash.lowercase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.lowercase/-/lodash.lowercase-4.3.0.tgz",
+      "integrity": "sha512-UcvP1IZYyDKyEL64mmrwoA1AbFu5ahojhTtkOUr1K9dbuxzS9ev8i4TxMMGCqRC9TE8uDaSoufNAXxRPNTseVA==",
       "dev": true
     },
     "node_modules/lodash.map": {
@@ -21763,8 +21816,7 @@
     "node_modules/tslib": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
-      "integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA==",
-      "dev": true
+      "integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -25008,6 +25060,25 @@
         "graphql-tag": "^2.11.0",
         "parse-filepath": "^1.0.2",
         "tslib": "~2.5.0"
+      }
+    },
+    "@graphql-eslint/eslint-plugin": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@graphql-eslint/eslint-plugin/-/eslint-plugin-3.18.0.tgz",
+      "integrity": "sha512-riEEfRycc0+pWxcEWqHi8woRxzg1xZqAfh9DRACJUR7bTN8dmc1N04i7+pvW4sevClUFYC2wuL1Vtr+DwzXLUg==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.18.6",
+        "@graphql-tools/code-file-loader": "^7.3.6",
+        "@graphql-tools/graphql-tag-pluck": "^7.3.6",
+        "@graphql-tools/utils": "^9.0.0",
+        "chalk": "^4.1.2",
+        "debug": "^4.3.4",
+        "fast-glob": "^3.2.12",
+        "graphql-config": "^4.4.0",
+        "graphql-depth-limit": "^1.1.0",
+        "lodash.lowercase": "^4.3.0",
+        "tslib": "^2.4.1"
       }
     },
     "@graphql-tools/apollo-engine-loader": {
@@ -30760,6 +30831,12 @@
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
       "dev": true
     },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
+      "dev": true
+    },
     "asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
@@ -33873,8 +33950,7 @@
     "graphql": {
       "version": "16.6.0",
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.6.0.tgz",
-      "integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==",
-      "dev": true
+      "integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw=="
     },
     "graphql-config": {
       "version": "4.5.0",
@@ -33924,6 +34000,15 @@
         }
       }
     },
+    "graphql-depth-limit": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/graphql-depth-limit/-/graphql-depth-limit-1.1.0.tgz",
+      "integrity": "sha512-+3B2BaG8qQ8E18kzk9yiSdAa75i/hnnOwgSeAxVJctGQPvmeiLtqKOYF6HETCyRjiF7Xfsyal0HbLlxCQkgkrw==",
+      "dev": true,
+      "requires": {
+        "arrify": "^1.0.1"
+      }
+    },
     "graphql-request": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-6.0.0.tgz",
@@ -33938,7 +34023,6 @@
       "version": "2.12.6",
       "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz",
       "integrity": "sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==",
-      "dev": true,
       "requires": {
         "tslib": "^2.1.0"
       }
@@ -35531,6 +35615,12 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-4.2.0.tgz",
       "integrity": "sha512-J79MkJcp7Df5mizHiVNpjoHXLi4HLjh9VLS/M7lQSGoQ+0oQ+lWEigREkqKyizPB1IawvQLLKY8mzEcm1tkyxQ==",
+      "dev": true
+    },
+    "lodash.lowercase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.lowercase/-/lodash.lowercase-4.3.0.tgz",
+      "integrity": "sha512-UcvP1IZYyDKyEL64mmrwoA1AbFu5ahojhTtkOUr1K9dbuxzS9ev8i4TxMMGCqRC9TE8uDaSoufNAXxRPNTseVA==",
       "dev": true
     },
     "lodash.map": {
@@ -39189,8 +39279,7 @@
     "tslib": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
-      "integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA==",
-      "dev": true
+      "integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
     },
     "tsutils": {
       "version": "3.21.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@graphql-codegen/cli": "^3.3.1",
     "@graphql-codegen/schema-ast": "^3.0.1",
     "@graphql-codegen/typescript": "^3.0.4",
+    "@graphql-eslint/eslint-plugin": "^3.18.0",
     "@playwright/test": "^1.34.3",
     "@poppanator/sveltekit-svg": "^3.0.1",
     "@rollup/plugin-node-resolve": "^15.1.0",
@@ -91,6 +92,8 @@
     "@contentful/rich-text-types": "^16.0.3",
     "@uswds/uswds": "^3.4.1",
     "fast-blurhash": "^1.1.2",
+    "graphql": "^16.6.0",
+    "graphql-tag": "^2.12.6",
     "lodash": "^4.17.21"
   }
 }

--- a/src/lib/components/Header/Nav/Nav.server.ts
+++ b/src/lib/components/Header/Nav/Nav.server.ts
@@ -1,3 +1,5 @@
+import gql from "graphql-tag";
+import { print as printQuery } from "graphql";
 import contentfulFetch from "$lib/services/contentful";
 import mainNavTestContent from "./__tests__/MainNavTestContent";
 import secondaryNavTestContent from "./__tests__/SecondaryNavTestContent";
@@ -9,26 +11,27 @@ import type {
 import type { NavLinkType, NavMenuType } from "./types";
 
 export const loadMainNav = async () => {
-  const query = `
-  {
-    draftNavigationMenuCollection(where: { type: "Main Menu" }, limit: 1) {
-      items {
-        text
-        childrenCollection {
-          items {
-            ... on DraftNavigationMenu {
-              sys {
-                id
-              }
-              text
-              childrenCollection {
-                items {
-                  ... on DraftNavigationLink {
-                    sys {
-                      id
+  const query = gql`
+    query Nav {
+      draftNavigationMenuCollection(where: { type: "Main Menu" }, limit: 1) {
+        items {
+          text
+          childrenCollection {
+            items {
+              ... on DraftNavigationMenu {
+                sys {
+                  id
+                }
+                text
+                childrenCollection {
+                  items {
+                    ... on DraftNavigationLink {
+                      sys {
+                        id
+                      }
+                      text
+                      link
                     }
-                    text
-                    link
                   }
                 }
               }
@@ -37,9 +40,8 @@ export const loadMainNav = async () => {
         }
       }
     }
-  }
   `;
-  const data = await contentfulFetch(query);
+  const data = await contentfulFetch(printQuery(query));
   if (data) {
     const mainMenu = data?.draftNavigationMenuCollection?.items[0] as DraftNavigationMenu;
     const mainMenuChildren = mainMenu?.childrenCollection

--- a/src/routes/[...dynamicRoute]/+page.server.ts
+++ b/src/routes/[...dynamicRoute]/+page.server.ts
@@ -1,23 +1,29 @@
-import { error } from "@sveltejs/kit";
-import contentfulFetch from "$lib/services/contentful";
+import type { PageServerLoad } from "./$types";
 import type { DraftNavigationLink } from "$lib/services/contentful/schema";
 
+import gql from "graphql-tag";
+import { print as printQuery } from "graphql";
+import { error } from "@sveltejs/kit";
+import contentfulFetch from "$lib/services/contentful";
+
 // TODO: Raise limit filter as needed. Default is 100; might need to paginate above that.
-const query = `
-{
-  draftNavigationLinkCollection(limit: 100) {
-    items {
-      sys { id }
-      text
-      link
+const query = gql`
+  query Stub {
+    draftNavigationLinkCollection(limit: 100) {
+      items {
+        sys {
+          id
+        }
+        text
+        link
+      }
     }
   }
-}
 `;
 
-export async function load({ params }): Promise<DraftNavigationLink> {
+export const load = (async ({ params }): Promise<DraftNavigationLink> => {
   const dynamicRoute = `/${params.dynamicRoute}`;
-  const data = await contentfulFetch(query);
+  const data = await contentfulFetch(printQuery(query));
   if (data) {
     const navLinks = data?.draftNavigationLinkCollection?.items as DraftNavigationLink[];
     const matchedNavLink = navLinks.find((navLink) => navLink.link === dynamicRoute);
@@ -26,4 +32,4 @@ export async function load({ params }): Promise<DraftNavigationLink> {
     }
   }
   throw error(404);
-}
+}) satisfies PageServerLoad;

--- a/src/routes/[...dynamicRoute]/+page.svelte
+++ b/src/routes/[...dynamicRoute]/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  export let data;
+  import type { PageData } from "./$types";
+  export let data: PageData;
   $: ({ text } = data);
 </script>
 

--- a/src/routes/test-contentful-content/+page.server.ts
+++ b/src/routes/test-contentful-content/+page.server.ts
@@ -1,20 +1,22 @@
+import gql from "graphql-tag";
+import { print as printQuery } from "graphql";
 import contentfulFetch from "$lib/services/contentful";
 import { markdownDocument } from "$lib/components/ContentfulRichText/__tests__/documents";
 import type { Document } from "@contentful/rich-text-types";
 
-const query = `
-{
-  testRichText(id: "V7ibT9I8Vg99iKsDgLhsK") {
-    title
-    body {
-      json
+const query = gql`
+  query Entry {
+    testRichText(id: "V7ibT9I8Vg99iKsDgLhsK") {
+      title
+      body {
+        json
+      }
     }
   }
-}
 `;
 
 export async function load(): Promise<Document> {
-  const data = await contentfulFetch(query);
+  const data = await contentfulFetch(printQuery(query));
   if (data) {
     return data?.testRichText?.body?.json;
   } else {


### PR DESCRIPTION
Depends on #150.

## Proposed changes

- Adds and configures `@graphql-eslint/eslint-plugin` to lint GraphQL queries declared with the `gql` tag or in `.graphql` or `.gql` files using the checked-in Contentful schema.
- Adds `graphql` and `graphql-tag`; uses `gql` on the server side to generate GraphQL queries that are linted by the ESLint plugin and then uses `graphql`'s `print` function to turn them back into strings (we'll do more interesting things with the parsed queries in the future).
- Names the GraphQL queries to get rid of a lint warning.