### PR TITLE
Spin up separate Vercel app for Storybook

### DIFF
--- a/.github/workflows/tests_and_reports.yml
+++ b/.github/workflows/tests_and_reports.yml
@@ -15,11 +15,13 @@ permissions:
   pull-requests: write
 
 env:
+  # Preview URLs
+  VERCEL_META_PREVIEW_URL: meta-site-${{ github.event.number }}-ldaf.vercel.app
+  VERCEL_STORYBOOK_PREVIEW_URL: storybook-${{ github.event.number }}-ldaf.vercel.app
   # Names for report paths on Vercel Meta-Site
   UNIT_PATH: unit-test-coverage
   E2E_PATH: e2e-test-report
   BUNDLE_VISUALIZER_PATH: bundle-visualizer
-  STORYBOOK_PATH: storybook
   # Just run this check once; used to determine whether to post PR comments, deploy to Vercel production, etc.
   IS_MAIN: ${{ github.ref == 'refs/heads/main' }}
 
@@ -124,38 +126,11 @@ jobs:
           path: bundle-visualizer
           retention-days: 1
 
-  storybook:
-    name: "Build Storybook"
-    runs-on: "ubuntu-latest"
-    timeout-minutes: 60
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Setup node
-        uses: actions/setup-node@v3
-        with:
-          node-version-file: ".nvmrc"
-          cache: npm
-
-      - name: Install
-        run: npm ci
-
-      - name: Build Storybook
-        run: npm run build-storybook
-
-      - name: Create artifact with built Storybook
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ github.event.after }}-${{ env.STORYBOOK_PATH }}
-          path: storybook-static
-          retention-days: 1
-
   deploy-reports-to-vercel-meta-site:
     # Guide: https://vercel.com/guides/how-can-i-use-github-actions-with-vercel
     name: "Deploy Reports to Vercel Meta-Site"
     # Wait for tests to complete before deploying.
-    needs: [lint-and-unit-tests, end-to-end-tests, bundle-visualizer, storybook]
+    needs: [lint-and-unit-tests, end-to-end-tests, bundle-visualizer]
     # We still want to upload reports regardless of whether tests failed.
     if: ${{ always() }}
     runs-on: ubuntu-latest
@@ -163,7 +138,6 @@ jobs:
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_META_SITE_PROJECT_ID }}
       VERCEL_TOKEN: ${{secrets.VERCEL_META_SITE_DEPLOY_TOKEN }}
-      VERCEL_PREVIEW_URL: meta-site-${{ github.event.number }}-ldaf.vercel.app
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -198,12 +172,6 @@ jobs:
           name: ${{ github.event.after }}-${{ env.BUNDLE_VISUALIZER_PATH }}
           path: .meta/${{ env.BUNDLE_VISUALIZER_PATH }}
 
-      - name: Download Storybook build artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: ${{ github.event.after }}-${{ env.STORYBOOK_PATH }}
-          path: .meta/${{ env.STORYBOOK_PATH }}
-
       - name: Build for Vercel
         run: vercel build --cwd .meta --token=${{env.VERCEL_TOKEN}} ${{ fromJSON(env.IS_MAIN) && '--prod'}}
 
@@ -212,7 +180,7 @@ jobs:
         # Guide: https://vercel.com/guides/how-to-alias-a-preview-deployment-using-the-cli
         run: |
           url="$(vercel deploy --cwd .meta --prebuilt --token=${{env.VERCEL_TOKEN}})"
-          vercel alias --cwd .meta --scope ldaf --token=${{env.VERCEL_TOKEN}} set "$url" ${{env.VERCEL_PREVIEW_URL}}
+          vercel alias --cwd .meta --scope ldaf --token=${{env.VERCEL_TOKEN}} set "$url" ${{env.VERCEL_META_PREVIEW_URL}}
 
       - name: Deploy to Vercel production
         if: ${{ fromJSON(env.IS_MAIN) }}
@@ -228,4 +196,48 @@ jobs:
           number: ${{ github.event.number }}
           id: vercel-deploy
           recreate: true
-          message: "Reports for ${{ github.event.after }} have been [deployed to Vercel](https://${{env.VERCEL_PREVIEW_URL}}):\n\n* [Unit Test Coverage Report](https://${{ env.VERCEL_PREVIEW_URL }}/${{ env.UNIT_PATH }})\n* [End-to-End Test Report](https://${{ env.VERCEL_PREVIEW_URL }}/${{ env.E2E_PATH }})\n* [Bundle Visualizer](https://${{ env.VERCEL_PREVIEW_URL }}/${{ env.BUNDLE_VISUALIZER_PATH }})\n* [Storybook](https://${{ env.VERCEL_PREVIEW_URL }}/${{ env.STORYBOOK_PATH }})"
+          message: "Reports for ${{ github.event.after }} have been [deployed to Vercel](https://${{env.VERCEL_META_PREVIEW_URL}}):\n\n* [Unit Test Coverage Report](https://${{ env.VERCEL_META_PREVIEW_URL }}/${{ env.UNIT_PATH }})\n* [End-to-End Test Report](https://${{ env.VERCEL_META_PREVIEW_URL }}/${{ env.E2E_PATH }})\n* [Bundle Visualizer](https://${{ env.VERCEL_META_PREVIEW_URL }}/${{ env.BUNDLE_VISUALIZER_PATH }})\n* [Storybook](https://${{ env.VERCEL_STORYBOOK_PREVIEW_URL }})"
+
+  # Handle Storybook separately since it takes much longer to build and deploy.
+  storybook:
+    name: "Build and deploy Storybook"
+    runs-on: "ubuntu-latest"
+    timeout-minutes: 60
+    env:
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_STORYBOOK_PROJECT_ID }}
+      VERCEL_TOKEN: ${{secrets.VERCEL_STORYBOOK_DEPLOY_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: ".nvmrc"
+          cache: npm
+
+      - name: Install
+        run: npm ci
+
+      - name: Build Storybook
+        run: npm run build-storybook
+
+      - name: Install Vercel CLI
+        run: npm i -g vercel@latest
+
+      - name: Setup Vercel to build and deploy
+        run: vercel pull --yes --cwd storybook-static --environment=${{ fromJSON(env.IS_MAIN) && 'production' || 'preview' }} --token=${{env.VERCEL_TOKEN}}
+
+      - name: Build for Vercel
+        run: vercel build --cwd storybook-static --token=${{env.VERCEL_TOKEN}} ${{ fromJSON(env.IS_MAIN) && '--prod'}}
+
+      - name: Deploy to Vercel preview
+        if: ${{ !fromJSON(env.IS_MAIN) }}
+        run: |
+          url="$(vercel deploy --cwd storybook-static --prebuilt --token=${{env.VERCEL_TOKEN}})"
+          vercel alias --cwd storybook-static --scope ldaf --token=${{env.VERCEL_TOKEN}} set "$url" ${{env.VERCEL_STORYBOOK_PREVIEW_URL}}
+
+      - name: Deploy to Vercel production
+        if: ${{ fromJSON(env.IS_MAIN) }}
+        run: vercel deploy --cwd storybook-static --prebuilt --prod --token=${{env.VERCEL_TOKEN}}

--- a/.github/workflows/tests_and_reports.yml
+++ b/.github/workflows/tests_and_reports.yml
@@ -200,7 +200,7 @@ jobs:
 
   # Handle Storybook separately since it takes much longer to build and deploy.
   storybook:
-    name: "Build and deploy Storybook"
+    name: "Build and Deploy Storybook"
     runs-on: "ubuntu-latest"
     timeout-minutes: 60
     env:

--- a/.meta/index.html
+++ b/.meta/index.html
@@ -19,11 +19,10 @@
     <h2 id="current-title">Reports for this Branch or Pull Request</h2>
     <div id="current-pull-info"></div>
     <p>The following are all the generated reports:</p>
-    <ul>
+    <ul id="current-reports-list">
       <li>📊 <a href="/unit-test-coverage">Unit Test Coverage Report</a></li>
       <li>🖥️ <a href="/e2e-test-report">End-to-End Test Report</a></li>
       <li>🧮 <a href="/bundle-visualizer">Bundle Visualizer</a></li>
-      <li>📖 <a href="/storybook">Storybook</a></li>
     </ul>
     <div id="main">
       <h2>Main Branch</h2>
@@ -39,7 +38,8 @@
     (async () => {
       const siteTitleElement = document.getElementById("site-title");
       const currentTitleElement = document.getElementById("current-title");
-      const currentPullInfo = document.getElementById("current-pull-info");
+      const currentPullInfoElement = document.getElementById("current-pull-info");
+      const currentReportsListElement = document.getElementById("current-reports-list");
       const mainContainer = document.getElementById("main");
       const pullsContainer = document.getElementById("pulls");
 
@@ -59,14 +59,20 @@
       }
 
       if (current) {
+        const storybookListItem = document.createElement("li");
         if (current === "main") {
           siteTitleElement.innerHTML = "LDAF Meta-Site 🏗️ <code>[Production]</code>";
           currentTitleElement.innerHTML = "Reports for the Main Branch";
+          storybookListItem.innerHTML =
+            '📖 <a href="https://ldaf-storybook.vercel.app/">Storybook</a>';
+          currentReportsListElement.appendChild(storybookListItem);
           // Don't link to prod if we're on prod
           mainContainer.remove();
         } else {
           siteTitleElement.innerHTML = "LDAF Meta-Site 🏗️ <code>[PR Preview]</code>";
           currentTitleElement.innerHTML = `Reports for PR #${current}`;
+          storybookListItem.innerHTML = `📖 <a href="https://storybook-${current}-ldaf.vercel.app">Storybook</a>`;
+          currentReportsListElement.appendChild(storybookListItem);
         }
       }
 
@@ -81,7 +87,7 @@
           if (current == number) {
             // Give some more info on the current PR, at the top.
             currentTitleElement.innerHTML = `<a href="${html_url}">PR #${number} - ${title}</a>`;
-            currentPullInfo.innerHTML = `
+            currentPullInfoElement.innerHTML = `
               <span>✒️ by <a href="${user.html_url}">${user.login}</a></span>
               <br/>
               <span>${(draft && "📝 In Draft") || "👀 Ready for Review!"}</span>

--- a/src/routes/.build-info/+page.svelte
+++ b/src/routes/.build-info/+page.svelte
@@ -17,7 +17,7 @@
   const unitCoverageUrl = `${metaSiteUrl}/unit-test-coverage`;
   const e2eReportUrl = `${metaSiteUrl}/e2e-test-report`;
   const bundleVisualizerUrl = `${metaSiteUrl}/bundle-visualizer`;
-  const storybookUrl = `${metaSiteUrl}/storybook`;
+  const storybookUrl = `https://storybook-${VERCEL_GIT_PULL_REQUEST_ID}-ldaf.vercel.app`;
 </script>
 
 <section class="usa-section">


### PR DESCRIPTION
Jira ticket: LDAF-250

This is a follow-up to #168. Storybook currently takes a considerable amount of time to build and deploy, and since we're including it in the meta-site it's holding up the deploys of more immediately important reports. Moving it into its own Vercel app steamlines this; the meta-site can deploy much more quickly and since we're building and deploying Storybook all in the same step, we don't need to worry about creating an artifact (bypassing a lengthy upload / download process).

## Proposed changes

- Create a new Vercel app for Storybook: 
  - App in Vercel: https://vercel.com/ldaf/storybook
  - Production URL (showing Jekyll until we merge this): https://ldaf-storybook.vercel.app/
  - Preview URL (where 188 is the PR number): https://storybook-188-ldaf.vercel.app/
- Create a new step in our current GitHub Actions workflow for building and deploying Storybook.
- Update [the meta-site landing page](https://meta-site-188-ldaf.vercel.app/) and [the main site `/.build-info` route](https://ldaf-git-louis-vercel-storybook-ldaf.vercel.app/.build-info) with the new Storybook URL.
