### PR TITLE
Attempt to upload artifacts even if the artifact creation step exited with an error

### DIFF
--- a/.github/workflows/tests_and_reports.yml
+++ b/.github/workflows/tests_and_reports.yml
@@ -63,6 +63,7 @@ jobs:
           delete-old-comments: true
 
       - name: Create artifact with report
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v3
         with:
           name: ${{ github.event.after }}-${{ env.UNIT_PATH }}
@@ -94,6 +95,7 @@ jobs:
         run: npm run test:e2e
 
       - name: Create artifact with report
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v3
         with:
           name: ${{ github.event.after }}-${{ env.E2E_PATH }}
@@ -121,6 +123,7 @@ jobs:
         run: npm run bundle-visualizer
 
       - name: Create artifact with bundle visualizer
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v3
         with:
           name: ${{ github.event.after }}-${{ env.BUNDLE_VISUALIZER_PATH }}
@@ -161,6 +164,7 @@ jobs:
         run: cp .lighthouse/index.html lighthouse-reports/index.html
 
       - name: Create artifact with Lighthouse reports
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v3
         with:
           name: ${{ github.event.after }}-${{ env.LIGHTHOUSE_PATH }}

--- a/e2e-tests/homepage.spec.ts
+++ b/e2e-tests/homepage.spec.ts
@@ -1,7 +1,6 @@
 import { expect, test } from "@playwright/test";
 
 test("index page has expected h1", async ({ page }) => {
-  throw new Error("fail");
   await page.goto("/");
   await expect(page.getByRole("heading", { name: "Hello There." })).toBeVisible();
 });

--- a/e2e-tests/homepage.spec.ts
+++ b/e2e-tests/homepage.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@playwright/test";
 
 test("index page has expected h1", async ({ page }) => {
+  throw new Error("fail");
   await page.goto("/");
   await expect(page.getByRole("heading", { name: "Hello There." })).toBeVisible();
 });


### PR DESCRIPTION
## Proposed changes

Always attempts to upload the artifact, even if the steps to create that artifact exited with an error. This fixes the issue where e2e test reports are not uploaded if any of the tests fail.

## Acceptance criteria validation

- [x] Manually tested CI