### PR TITLE
Run prebuild before dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "prepare": "svelte-kit sync && npm run gen-operations",
+    "predev": "npm run prebuild",
     "dev": "concurrently --kill-others --names graphql,dev \"npm run gen-operations -- --watch\" \"vite dev\"",
     "prebuild": "node scripts/prebuild.js && npm run gen-operations",
     "build": "vite build",


### PR DESCRIPTION
## Proposed changes

Runs `npm run prebuild` before `npm run dev` starts. This prevents errors due to missing JSON "test" documents that we actually rely on in development when the Contentful connection isn't present.