### PR TITLE
Remove Chromatic in favor of publishing Storybook to Vercel.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,6 @@ To run Storybook locally:
 npm run storybook
 ```
 
-To deploy Storybook to chromatic (requires `CHROMATIC_PROJECT_TOKEN` be set in `.env`):
-
-```
-npm run chromatic
-```
-
 ## Vercel
 
 If you are a member of the LDAF team on Vercel, first set up the Vercel CLI:

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,6 @@
         "@vitest/coverage-c8": "^0.32.0",
         "autoprefixer": "^10.4.7",
         "blurhash": "^2.0.5",
-        "chromatic": "^6.19.4",
         "concurrently": "^8.2.0",
         "contentful": "^10.2.3",
         "dotenv": "^16.1.4",
@@ -12424,17 +12423,6 @@
       "dev": true,
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/chromatic": {
-      "version": "6.19.4",
-      "resolved": "https://registry.npmjs.org/chromatic/-/chromatic-6.19.4.tgz",
-      "integrity": "sha512-K4EZ0OqTOYDEvAg5J6BeRtQe4WeB8q2cTNLA1R3z6Lz6vIlcj7tCUoQ//IuzJLrvWGEWKlsQr/YTwAId1o/P9w==",
-      "dev": true,
-      "bin": {
-        "chroma": "dist/bin.js",
-        "chromatic": "dist/bin.js",
-        "chromatic-cli": "dist/bin.js"
       }
     },
     "node_modules/ci-info": {
@@ -32319,12 +32307,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
       "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-      "dev": true
-    },
-    "chromatic": {
-      "version": "6.19.4",
-      "resolved": "https://registry.npmjs.org/chromatic/-/chromatic-6.19.4.tgz",
-      "integrity": "sha512-K4EZ0OqTOYDEvAg5J6BeRtQe4WeB8q2cTNLA1R3z6Lz6vIlcj7tCUoQ//IuzJLrvWGEWKlsQr/YTwAId1o/P9w==",
       "dev": true
     },
     "ci-info": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "format": "prettier --plugin-search-dir . --write .",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "chromatic": "chromatic --zip",
     "bundle-visualizer": "npm run prebuild && mkdir -p ./bundle-visualizer && vite-bundle-visualizer --open=false -o bundle-visualizer/index.html",
     "gen-schema": "graphql-codegen --config codegen-schema.yml --require dotenv/config",
     "gen-operations": "graphql-codegen --config codegen-operations.yml"
@@ -60,7 +59,6 @@
     "@vitest/coverage-c8": "^0.32.0",
     "autoprefixer": "^10.4.7",
     "blurhash": "^2.0.5",
-    "chromatic": "^6.19.4",
     "concurrently": "^8.2.0",
     "contentful": "^10.2.3",
     "dotenv": "^16.1.4",


### PR DESCRIPTION
Pretty straightforward; we're no longer using Chromatic due to rate limits, so we might as well remove the CLI (and stop getting dependabot updates for it). Afterwards I'll remove the API token from our secrets storage.