### PR TITLE
Quick fix to reflect change to Office Page model in Contentful.

### DIFF
--- a/src/lib/services/contentful/schema.graphql
+++ b/src/lib/services/contentful/schema.graphql
@@ -189,7 +189,7 @@ type BoardsAndCommissions implements Entry {
   meetings(locale: String): BoardsAndCommissionsMeetings
   membership(locale: String): BoardsAndCommissionsMembership
   overview(locale: String): BoardsAndCommissionsOverview
-  pageMetadata(locale: String, preview: Boolean): PageMetadata
+  pageMetadata(locale: String, preview: Boolean, where: PageMetadataFilter): PageMetadata
   subheading(locale: String): String
   sys: Sys!
   title(locale: String): String
@@ -214,6 +214,11 @@ type BoardsAndCommissionsAdditionalInformationEntries {
 type BoardsAndCommissionsAdditionalInformationLinks {
   assets: BoardsAndCommissionsAdditionalInformationAssets!
   entries: BoardsAndCommissionsAdditionalInformationEntries!
+  resources: BoardsAndCommissionsAdditionalInformationResources!
+}
+
+type BoardsAndCommissionsAdditionalInformationResources {
+  block: [ResourceLink!]!
 }
 
 type BoardsAndCommissionsCollection {
@@ -309,6 +314,11 @@ type BoardsAndCommissionsMeetingsEntries {
 type BoardsAndCommissionsMeetingsLinks {
   assets: BoardsAndCommissionsMeetingsAssets!
   entries: BoardsAndCommissionsMeetingsEntries!
+  resources: BoardsAndCommissionsMeetingsResources!
+}
+
+type BoardsAndCommissionsMeetingsResources {
+  block: [ResourceLink!]!
 }
 
 type BoardsAndCommissionsMembership {
@@ -330,6 +340,11 @@ type BoardsAndCommissionsMembershipEntries {
 type BoardsAndCommissionsMembershipLinks {
   assets: BoardsAndCommissionsMembershipAssets!
   entries: BoardsAndCommissionsMembershipEntries!
+  resources: BoardsAndCommissionsMembershipResources!
+}
+
+type BoardsAndCommissionsMembershipResources {
+  block: [ResourceLink!]!
 }
 
 enum BoardsAndCommissionsOrder {
@@ -366,24 +381,48 @@ type BoardsAndCommissionsOverviewEntries {
 type BoardsAndCommissionsOverviewLinks {
   assets: BoardsAndCommissionsOverviewAssets!
   entries: BoardsAndCommissionsOverviewEntries!
+  resources: BoardsAndCommissionsOverviewResources!
+}
+
+type BoardsAndCommissionsOverviewResources {
+  block: [ResourceLink!]!
 }
 
 """
 Button or link to landing page with URL and description [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/callToAction)
 """
 type CallToAction implements Entry {
-  callToActionMessage(locale: String): String
+  callToActionDestination(locale: String): CallToActionCallToActionDestination
   contentfulMetadata: ContentfulMetadata!
   ctaInternalName(locale: String): String
-  ctaLink(locale: String): String
-  ctaName(locale: String): String
-  ctaType(locale: String): Boolean
-  internalContentLink(locale: String, preview: Boolean): PageMetadata
-  internalOrExternal(locale: String): Boolean
-  linkText(locale: String): String
   linkedFrom(allowedLocales: [String]): CallToActionLinkingCollections
-  phoneNumberCta(locale: String): String
   sys: Sys!
+}
+
+type CallToActionCallToActionDestination {
+  json: JSON!
+  links: CallToActionCallToActionDestinationLinks!
+}
+
+type CallToActionCallToActionDestinationAssets {
+  block: [Asset]!
+  hyperlink: [Asset]!
+}
+
+type CallToActionCallToActionDestinationEntries {
+  block: [Entry]!
+  hyperlink: [Entry]!
+  inline: [Entry]!
+}
+
+type CallToActionCallToActionDestinationLinks {
+  assets: CallToActionCallToActionDestinationAssets!
+  entries: CallToActionCallToActionDestinationEntries!
+  resources: CallToActionCallToActionDestinationResources!
+}
+
+type CallToActionCallToActionDestinationResources {
+  block: [ResourceLink!]!
 }
 
 type CallToActionCollection {
@@ -396,13 +435,9 @@ type CallToActionCollection {
 input CallToActionFilter {
   AND: [CallToActionFilter]
   OR: [CallToActionFilter]
-  callToActionMessage: String
-  callToActionMessage_contains: String
-  callToActionMessage_exists: Boolean
-  callToActionMessage_in: [String]
-  callToActionMessage_not: String
-  callToActionMessage_not_contains: String
-  callToActionMessage_not_in: [String]
+  callToActionDestination_contains: String
+  callToActionDestination_exists: Boolean
+  callToActionDestination_not_contains: String
   contentfulMetadata: ContentfulMetadataFilter
   ctaInternalName: String
   ctaInternalName_contains: String
@@ -411,42 +446,6 @@ input CallToActionFilter {
   ctaInternalName_not: String
   ctaInternalName_not_contains: String
   ctaInternalName_not_in: [String]
-  ctaLink: String
-  ctaLink_contains: String
-  ctaLink_exists: Boolean
-  ctaLink_in: [String]
-  ctaLink_not: String
-  ctaLink_not_contains: String
-  ctaLink_not_in: [String]
-  ctaName: String
-  ctaName_contains: String
-  ctaName_exists: Boolean
-  ctaName_in: [String]
-  ctaName_not: String
-  ctaName_not_contains: String
-  ctaName_not_in: [String]
-  ctaType: Boolean
-  ctaType_exists: Boolean
-  ctaType_not: Boolean
-  internalContentLink: cfPageMetadataNestedFilter
-  internalContentLink_exists: Boolean
-  internalOrExternal: Boolean
-  internalOrExternal_exists: Boolean
-  internalOrExternal_not: Boolean
-  linkText: String
-  linkText_contains: String
-  linkText_exists: Boolean
-  linkText_in: [String]
-  linkText_not: String
-  linkText_not_contains: String
-  linkText_not_in: [String]
-  phoneNumberCta: String
-  phoneNumberCta_contains: String
-  phoneNumberCta_exists: Boolean
-  phoneNumberCta_in: [String]
-  phoneNumberCta_not: String
-  phoneNumberCta_not_contains: String
-  phoneNumberCta_not_in: [String]
   sys: SysFilter
 }
 
@@ -485,20 +484,8 @@ enum CallToActionLinkingCollectionsServiceEntryCollectionOrder {
 }
 
 enum CallToActionOrder {
-  callToActionMessage_ASC
-  callToActionMessage_DESC
   ctaInternalName_ASC
   ctaInternalName_DESC
-  ctaName_ASC
-  ctaName_DESC
-  ctaType_ASC
-  ctaType_DESC
-  internalOrExternal_ASC
-  internalOrExternal_DESC
-  linkText_ASC
-  linkText_DESC
-  phoneNumberCta_ASC
-  phoneNumberCta_DESC
   sys_firstPublishedAt_ASC
   sys_firstPublishedAt_DESC
   sys_id_ASC
@@ -585,8 +572,6 @@ type CategoryLinkingCollections {
   eventEntryCollection(limit: Int = 100, locale: String, order: [CategoryLinkingCollectionsEventEntryCollectionOrder], preview: Boolean, skip: Int = 0): EventEntryCollection
   imageWrapperCollection(limit: Int = 100, locale: String, order: [CategoryLinkingCollectionsImageWrapperCollectionOrder], preview: Boolean, skip: Int = 0): ImageWrapperCollection
   promoBannerWithCtaCollection(limit: Int = 100, locale: String, order: [CategoryLinkingCollectionsPromoBannerWithCtaCollectionOrder], preview: Boolean, skip: Int = 0): PromoBannerWithCtaCollection
-  serviceEntryCollection(limit: Int = 100, locale: String, order: [CategoryLinkingCollectionsServiceEntryCollectionOrder], preview: Boolean, skip: Int = 0): ServiceEntryCollection
-  serviceGroupCollection(limit: Int = 100, locale: String, order: [CategoryLinkingCollectionsServiceGroupCollectionOrder], preview: Boolean, skip: Int = 0): ServiceGroupCollection
   videoWrapperCollection(limit: Int = 100, locale: String, order: [CategoryLinkingCollectionsVideoWrapperCollectionOrder], preview: Boolean, skip: Int = 0): VideoWrapperCollection
 }
 
@@ -667,38 +652,6 @@ enum CategoryLinkingCollectionsPromoBannerWithCtaCollectionOrder {
   sys_publishedVersion_DESC
 }
 
-enum CategoryLinkingCollectionsServiceEntryCollectionOrder {
-  entryTitle_ASC
-  entryTitle_DESC
-  subheading_ASC
-  subheading_DESC
-  sys_firstPublishedAt_ASC
-  sys_firstPublishedAt_DESC
-  sys_id_ASC
-  sys_id_DESC
-  sys_publishedAt_ASC
-  sys_publishedAt_DESC
-  sys_publishedVersion_ASC
-  sys_publishedVersion_DESC
-}
-
-enum CategoryLinkingCollectionsServiceGroupCollectionOrder {
-  serviceListName_ASC
-  serviceListName_DESC
-  subheading_ASC
-  subheading_DESC
-  sys_firstPublishedAt_ASC
-  sys_firstPublishedAt_DESC
-  sys_id_ASC
-  sys_id_DESC
-  sys_publishedAt_ASC
-  sys_publishedAt_DESC
-  sys_publishedVersion_ASC
-  sys_publishedVersion_DESC
-  title_ASC
-  title_DESC
-}
-
 enum CategoryLinkingCollectionsVideoWrapperCollectionOrder {
   internalTitle_ASC
   internalTitle_DESC
@@ -736,7 +689,7 @@ enum CategoryOrder {
 }
 
 """
-The name, phone number and email of any person, office or program at LDAF. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/contact)
+The name, phone number, and/or email of any person, office, or program at LDAF. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/contact)
 """
 type Contact implements Entry {
   contentfulMetadata: ContentfulMetadata!
@@ -794,6 +747,7 @@ type ContactLinkingCollections {
   boardsAndCommissionsCollection(limit: Int = 100, locale: String, order: [ContactLinkingCollectionsBoardsAndCommissionsCollectionOrder], preview: Boolean, skip: Int = 0): BoardsAndCommissionsCollection
   entryCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): EntryCollection
   officePageCollection(limit: Int = 100, locale: String, order: [ContactLinkingCollectionsOfficePageCollectionOrder], preview: Boolean, skip: Int = 0): OfficePageCollection
+  serviceEntryCollection(limit: Int = 100, locale: String, order: [ContactLinkingCollectionsServiceEntryCollectionOrder], preview: Boolean, skip: Int = 0): ServiceEntryCollection
   serviceGroupCollection(limit: Int = 100, locale: String, order: [ContactLinkingCollectionsServiceGroupCollectionOrder], preview: Boolean, skip: Int = 0): ServiceGroupCollection
 }
 
@@ -815,6 +769,21 @@ enum ContactLinkingCollectionsBoardsAndCommissionsCollectionOrder {
 enum ContactLinkingCollectionsOfficePageCollectionOrder {
   pageTitle_ASC
   pageTitle_DESC
+  subheading_ASC
+  subheading_DESC
+  sys_firstPublishedAt_ASC
+  sys_firstPublishedAt_DESC
+  sys_id_ASC
+  sys_id_DESC
+  sys_publishedAt_ASC
+  sys_publishedAt_DESC
+  sys_publishedVersion_ASC
+  sys_publishedVersion_DESC
+}
+
+enum ContactLinkingCollectionsServiceEntryCollectionOrder {
+  entryTitle_ASC
+  entryTitle_DESC
   subheading_ASC
   subheading_DESC
   sys_firstPublishedAt_ASC
@@ -853,54 +822,6 @@ enum ContactOrder {
   phoneExt_DESC
   phone_ASC
   phone_DESC
-  sys_firstPublishedAt_ASC
-  sys_firstPublishedAt_DESC
-  sys_id_ASC
-  sys_id_DESC
-  sys_publishedAt_ASC
-  sys_publishedAt_DESC
-  sys_publishedVersion_ASC
-  sys_publishedVersion_DESC
-}
-
-"""
-Headline for block-level content, such as paragraphs, tables or cards within the body of the page [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/contentBlockHeader)
-"""
-type ContentBlockHeader implements Entry {
-  contentfulMetadata: ContentfulMetadata!
-  headlineText(locale: String): String
-  linkedFrom(allowedLocales: [String]): ContentBlockHeaderLinkingCollections
-  sys: Sys!
-}
-
-type ContentBlockHeaderCollection {
-  items: [ContentBlockHeader]!
-  limit: Int!
-  skip: Int!
-  total: Int!
-}
-
-input ContentBlockHeaderFilter {
-  AND: [ContentBlockHeaderFilter]
-  OR: [ContentBlockHeaderFilter]
-  contentfulMetadata: ContentfulMetadataFilter
-  headlineText: String
-  headlineText_contains: String
-  headlineText_exists: Boolean
-  headlineText_in: [String]
-  headlineText_not: String
-  headlineText_not_contains: String
-  headlineText_not_in: [String]
-  sys: SysFilter
-}
-
-type ContentBlockHeaderLinkingCollections {
-  entryCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): EntryCollection
-}
-
-enum ContentBlockHeaderOrder {
-  headlineText_ASC
-  headlineText_DESC
   sys_firstPublishedAt_ASC
   sys_firstPublishedAt_DESC
   sys_id_ASC
@@ -1242,6 +1163,41 @@ enum DraftNavigationLinkLinkingCollectionsDraftNavigationMenuCollectionOrder {
   type_DESC
 }
 
+"""
+[See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/draftNavigationLinkOrDraftNavigationMenu)
+"""
+type DraftNavigationLinkOrDraftNavigationMenu implements Entry {
+  contentfulMetadata: ContentfulMetadata!
+  linkedFrom(allowedLocales: [String]): DraftNavigationLinkOrDraftNavigationMenuLinkingCollections
+  sys: Sys!
+  text(locale: String): String
+}
+
+type DraftNavigationLinkOrDraftNavigationMenuCollection {
+  items: [DraftNavigationLinkOrDraftNavigationMenu]!
+  limit: Int!
+  skip: Int!
+  total: Int!
+}
+
+input DraftNavigationLinkOrDraftNavigationMenuFilter {
+  AND: [DraftNavigationLinkOrDraftNavigationMenuFilter]
+  OR: [DraftNavigationLinkOrDraftNavigationMenuFilter]
+  contentfulMetadata: ContentfulMetadataFilter
+  sys: SysFilter
+  text: String
+  text_contains: String
+  text_exists: Boolean
+  text_in: [String]
+  text_not: String
+  text_not_contains: String
+  text_not_in: [String]
+}
+
+type DraftNavigationLinkOrDraftNavigationMenuLinkingCollections {
+  entryCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): EntryCollection
+}
+
 enum DraftNavigationLinkOrder {
   link_ASC
   link_DESC
@@ -1261,7 +1217,7 @@ enum DraftNavigationLinkOrder {
 A draft of how we will structure navigation menus that can appear either as the main menu in the header, a submenu under the main menu in the header, or a section sidebar. Should accept a list of references to either navigation links or child navigation menus. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/draftNavigationMenu)
 """
 type DraftNavigationMenu implements Entry {
-  childrenCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): DraftNavigationMenuChildrenCollection
+  childrenCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0, where: DraftNavigationLinkOrDraftNavigationMenuFilter): DraftNavigationMenuChildrenCollection
   contentfulMetadata: ContentfulMetadata!
   linkedFrom(allowedLocales: [String]): DraftNavigationMenuLinkingCollections
   sys: Sys!
@@ -1288,6 +1244,7 @@ type DraftNavigationMenuCollection {
 input DraftNavigationMenuFilter {
   AND: [DraftNavigationMenuFilter]
   OR: [DraftNavigationMenuFilter]
+  children: cfDraftNavigationLinkOrDraftNavigationMenuNestedFilter
   childrenCollection_exists: Boolean
   contentfulMetadata: ContentfulMetadataFilter
   sys: SysFilter
@@ -1373,7 +1330,7 @@ enum EntryOrder {
 }
 
 """
-Consistent format for adding events to the system [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/eventEntry)
+LDAF events such as board meetings, saddle microchipping events, etc. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/eventEntry)
 """
 type EventEntry implements Entry {
   contentfulMetadata: ContentfulMetadata!
@@ -1511,7 +1468,7 @@ enum EventEntryOrder {
 }
 
 """
-Big wide image on top of page [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/heroImage)
+Big wide image intended for the top of a page. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/heroImage)
 """
 type HeroImage implements Entry {
   altField(locale: String): String
@@ -1561,6 +1518,40 @@ input HeroImageFilter {
 
 type HeroImageLinkingCollections {
   entryCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): EntryCollection
+  serviceGroupCollection(limit: Int = 100, locale: String, order: [HeroImageLinkingCollectionsServiceGroupCollectionOrder], preview: Boolean, skip: Int = 0): ServiceGroupCollection
+  topTierCollection(limit: Int = 100, locale: String, order: [HeroImageLinkingCollectionsTopTierCollectionOrder], preview: Boolean, skip: Int = 0): TopTierCollection
+}
+
+enum HeroImageLinkingCollectionsServiceGroupCollectionOrder {
+  serviceListName_ASC
+  serviceListName_DESC
+  subheading_ASC
+  subheading_DESC
+  sys_firstPublishedAt_ASC
+  sys_firstPublishedAt_DESC
+  sys_id_ASC
+  sys_id_DESC
+  sys_publishedAt_ASC
+  sys_publishedAt_DESC
+  sys_publishedVersion_ASC
+  sys_publishedVersion_DESC
+  title_ASC
+  title_DESC
+}
+
+enum HeroImageLinkingCollectionsTopTierCollectionOrder {
+  subheading_ASC
+  subheading_DESC
+  sys_firstPublishedAt_ASC
+  sys_firstPublishedAt_DESC
+  sys_id_ASC
+  sys_id_DESC
+  sys_publishedAt_ASC
+  sys_publishedAt_DESC
+  sys_publishedVersion_ASC
+  sys_publishedVersion_DESC
+  title_ASC
+  title_DESC
 }
 
 enum HeroImageOrder {
@@ -1582,6 +1573,147 @@ enum HeroImageOrder {
 
 """The 'HexColor' type represents color in `rgb:ffffff` string format."""
 scalar HexColor
+
+"""
+The home page for the ldaf.la.gov website [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/home)
+"""
+type Home implements Entry {
+  alertMessage(locale: String): HomeAlertMessage
+  alertTitle(locale: String): String
+  contentfulMetadata: ContentfulMetadata!
+  featuredServiceCardsCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0, where: ServiceEntryOrServiceGroupFilter): HomeFeaturedServiceCardsCollection
+  heroVideo(locale: String, preview: Boolean, where: VideoWrapperFilter): VideoWrapper
+  internalTitle(locale: String): String
+  linkedFrom(allowedLocales: [String]): HomeLinkingCollections
+  metadata(locale: String, preview: Boolean, where: PageMetadataFilter): PageMetadata
+  popularResourcesListCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0, where: ServiceEntryOrServiceGroupFilter): HomePopularResourcesListCollection
+  promotionalCardsCollection(limit: Int = 100, locale: String, order: [HomePromotionalCardsCollectionOrder], preview: Boolean, skip: Int = 0, where: PromoBannerWithCtaFilter): HomePromotionalCardsCollection
+  sys: Sys!
+}
+
+type HomeAlertMessage {
+  json: JSON!
+  links: HomeAlertMessageLinks!
+}
+
+type HomeAlertMessageAssets {
+  block: [Asset]!
+  hyperlink: [Asset]!
+}
+
+type HomeAlertMessageEntries {
+  block: [Entry]!
+  hyperlink: [Entry]!
+  inline: [Entry]!
+}
+
+type HomeAlertMessageLinks {
+  assets: HomeAlertMessageAssets!
+  entries: HomeAlertMessageEntries!
+  resources: HomeAlertMessageResources!
+}
+
+type HomeAlertMessageResources {
+  block: [ResourceLink!]!
+}
+
+type HomeCollection {
+  items: [Home]!
+  limit: Int!
+  skip: Int!
+  total: Int!
+}
+
+type HomeFeaturedServiceCardsCollection {
+  items: [HomeFeaturedServiceCardsItem]!
+  limit: Int!
+  skip: Int!
+  total: Int!
+}
+
+union HomeFeaturedServiceCardsItem = ServiceEntry | ServiceGroup
+
+input HomeFilter {
+  AND: [HomeFilter]
+  OR: [HomeFilter]
+  alertMessage_contains: String
+  alertMessage_exists: Boolean
+  alertMessage_not_contains: String
+  alertTitle: String
+  alertTitle_contains: String
+  alertTitle_exists: Boolean
+  alertTitle_in: [String]
+  alertTitle_not: String
+  alertTitle_not_contains: String
+  alertTitle_not_in: [String]
+  contentfulMetadata: ContentfulMetadataFilter
+  featuredServiceCards: cfServiceEntryOrServiceGroupNestedFilter
+  featuredServiceCardsCollection_exists: Boolean
+  heroVideo: cfVideoWrapperNestedFilter
+  heroVideo_exists: Boolean
+  internalTitle: String
+  internalTitle_contains: String
+  internalTitle_exists: Boolean
+  internalTitle_in: [String]
+  internalTitle_not: String
+  internalTitle_not_contains: String
+  internalTitle_not_in: [String]
+  metadata: cfPageMetadataNestedFilter
+  metadata_exists: Boolean
+  popularResourcesList: cfServiceEntryOrServiceGroupNestedFilter
+  popularResourcesListCollection_exists: Boolean
+  promotionalCards: cfPromoBannerWithCtaNestedFilter
+  promotionalCardsCollection_exists: Boolean
+  sys: SysFilter
+}
+
+type HomeLinkingCollections {
+  entryCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): EntryCollection
+}
+
+enum HomeOrder {
+  alertTitle_ASC
+  alertTitle_DESC
+  internalTitle_ASC
+  internalTitle_DESC
+  sys_firstPublishedAt_ASC
+  sys_firstPublishedAt_DESC
+  sys_id_ASC
+  sys_id_DESC
+  sys_publishedAt_ASC
+  sys_publishedAt_DESC
+  sys_publishedVersion_ASC
+  sys_publishedVersion_DESC
+}
+
+type HomePopularResourcesListCollection {
+  items: [HomePopularResourcesListItem]!
+  limit: Int!
+  skip: Int!
+  total: Int!
+}
+
+union HomePopularResourcesListItem = ServiceEntry | ServiceGroup
+
+type HomePromotionalCardsCollection {
+  items: [PromoBannerWithCta]!
+  limit: Int!
+  skip: Int!
+  total: Int!
+}
+
+enum HomePromotionalCardsCollectionOrder {
+  promoInternalName_ASC
+  promoInternalName_DESC
+  sys_firstPublishedAt_ASC
+  sys_firstPublishedAt_DESC
+  sys_id_ASC
+  sys_id_DESC
+  sys_publishedAt_ASC
+  sys_publishedAt_DESC
+  sys_publishedVersion_ASC
+  sys_publishedVersion_DESC
+}
 
 enum ImageFormat {
   AVIF
@@ -1717,7 +1849,7 @@ input ImageTransformOptions {
 type ImageWrapper implements Entry {
   altText(locale: String): String
   contentfulMetadata: ContentfulMetadata!
-  imageCategory(locale: String, preview: Boolean): Category
+  imageCategory(locale: String, preview: Boolean, where: CategoryFilter): Category
   internalTitle(locale: String): String
   linkedFrom(allowedLocales: [String]): ImageWrapperLinkingCollections
   linkedImage(locale: String, preview: Boolean): Asset
@@ -1846,22 +1978,6 @@ input ListWithTitleFilter {
 
 type ListWithTitleLinkingCollections {
   entryCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): EntryCollection
-  serviceEntryCollection(limit: Int = 100, locale: String, order: [ListWithTitleLinkingCollectionsServiceEntryCollectionOrder], preview: Boolean, skip: Int = 0): ServiceEntryCollection
-}
-
-enum ListWithTitleLinkingCollectionsServiceEntryCollectionOrder {
-  entryTitle_ASC
-  entryTitle_DESC
-  subheading_ASC
-  subheading_DESC
-  sys_firstPublishedAt_ASC
-  sys_firstPublishedAt_DESC
-  sys_id_ASC
-  sys_id_DESC
-  sys_publishedAt_ASC
-  sys_publishedAt_DESC
-  sys_publishedVersion_ASC
-  sys_publishedVersion_DESC
 }
 
 enum ListWithTitleOrder {
@@ -1900,6 +2016,209 @@ type ListWithTitleParagraphOrListEntries {
 type ListWithTitleParagraphOrListLinks {
   assets: ListWithTitleParagraphOrListAssets!
   entries: ListWithTitleParagraphOrListEntries!
+  resources: ListWithTitleParagraphOrListResources!
+}
+
+type ListWithTitleParagraphOrListResources {
+  block: [ResourceLink!]!
+}
+
+"""
+Used to provide some structure to menus in the header and footer. The items in the menus in the header will be auto-generated (so this will only allow you to order the top menus, e.g. Animals, then Plants and crops, etc.), while the items in menus in the footer should be written out as Menu Item entries. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/menu)
+"""
+type Menu implements Entry {
+  childrenCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0, where: MenuOrMenuItemOrTopTierFilter): MenuChildrenCollection
+  contentfulMetadata: ContentfulMetadata!
+  linkedFrom(allowedLocales: [String]): MenuLinkingCollections
+  menuType(locale: String): String
+  sys: Sys!
+  title(locale: String): String
+}
+
+type MenuChildrenCollection {
+  items: [MenuChildrenItem]!
+  limit: Int!
+  skip: Int!
+  total: Int!
+}
+
+union MenuChildrenItem = Menu | MenuItem | TopTier
+
+type MenuCollection {
+  items: [Menu]!
+  limit: Int!
+  skip: Int!
+  total: Int!
+}
+
+input MenuFilter {
+  AND: [MenuFilter]
+  OR: [MenuFilter]
+  children: cfMenuOrMenuItemOrTopTierNestedFilter
+  childrenCollection_exists: Boolean
+  contentfulMetadata: ContentfulMetadataFilter
+  menuType: String
+  menuType_contains: String
+  menuType_exists: Boolean
+  menuType_in: [String]
+  menuType_not: String
+  menuType_not_contains: String
+  menuType_not_in: [String]
+  sys: SysFilter
+  title: String
+  title_contains: String
+  title_exists: Boolean
+  title_in: [String]
+  title_not: String
+  title_not_contains: String
+  title_not_in: [String]
+}
+
+"""
+A single internal or external link to be included in a Menu. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/menuItem)
+"""
+type MenuItem implements Entry {
+  contentfulMetadata: ContentfulMetadata!
+  externalLink(locale: String): String
+  internalLink(locale: String, preview: Boolean, where: PageMetadataFilter): PageMetadata
+  linkedFrom(allowedLocales: [String]): MenuItemLinkingCollections
+  sys: Sys!
+  title(locale: String): String
+}
+
+type MenuItemCollection {
+  items: [MenuItem]!
+  limit: Int!
+  skip: Int!
+  total: Int!
+}
+
+input MenuItemFilter {
+  AND: [MenuItemFilter]
+  OR: [MenuItemFilter]
+  contentfulMetadata: ContentfulMetadataFilter
+  externalLink: String
+  externalLink_contains: String
+  externalLink_exists: Boolean
+  externalLink_in: [String]
+  externalLink_not: String
+  externalLink_not_contains: String
+  externalLink_not_in: [String]
+  internalLink: cfPageMetadataNestedFilter
+  internalLink_exists: Boolean
+  sys: SysFilter
+  title: String
+  title_contains: String
+  title_exists: Boolean
+  title_in: [String]
+  title_not: String
+  title_not_contains: String
+  title_not_in: [String]
+}
+
+type MenuItemLinkingCollections {
+  entryCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): EntryCollection
+  menuCollection(limit: Int = 100, locale: String, order: [MenuItemLinkingCollectionsMenuCollectionOrder], preview: Boolean, skip: Int = 0): MenuCollection
+}
+
+enum MenuItemLinkingCollectionsMenuCollectionOrder {
+  menuType_ASC
+  menuType_DESC
+  sys_firstPublishedAt_ASC
+  sys_firstPublishedAt_DESC
+  sys_id_ASC
+  sys_id_DESC
+  sys_publishedAt_ASC
+  sys_publishedAt_DESC
+  sys_publishedVersion_ASC
+  sys_publishedVersion_DESC
+  title_ASC
+  title_DESC
+}
+
+enum MenuItemOrder {
+  externalLink_ASC
+  externalLink_DESC
+  sys_firstPublishedAt_ASC
+  sys_firstPublishedAt_DESC
+  sys_id_ASC
+  sys_id_DESC
+  sys_publishedAt_ASC
+  sys_publishedAt_DESC
+  sys_publishedVersion_ASC
+  sys_publishedVersion_DESC
+  title_ASC
+  title_DESC
+}
+
+type MenuLinkingCollections {
+  entryCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): EntryCollection
+  menuCollection(limit: Int = 100, locale: String, order: [MenuLinkingCollectionsMenuCollectionOrder], preview: Boolean, skip: Int = 0): MenuCollection
+}
+
+enum MenuLinkingCollectionsMenuCollectionOrder {
+  menuType_ASC
+  menuType_DESC
+  sys_firstPublishedAt_ASC
+  sys_firstPublishedAt_DESC
+  sys_id_ASC
+  sys_id_DESC
+  sys_publishedAt_ASC
+  sys_publishedAt_DESC
+  sys_publishedVersion_ASC
+  sys_publishedVersion_DESC
+  title_ASC
+  title_DESC
+}
+
+"""
+[See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/menuOrMenuItemOrTopTier)
+"""
+type MenuOrMenuItemOrTopTier implements Entry {
+  contentfulMetadata: ContentfulMetadata!
+  linkedFrom(allowedLocales: [String]): MenuOrMenuItemOrTopTierLinkingCollections
+  sys: Sys!
+  title(locale: String): String
+}
+
+type MenuOrMenuItemOrTopTierCollection {
+  items: [MenuOrMenuItemOrTopTier]!
+  limit: Int!
+  skip: Int!
+  total: Int!
+}
+
+input MenuOrMenuItemOrTopTierFilter {
+  AND: [MenuOrMenuItemOrTopTierFilter]
+  OR: [MenuOrMenuItemOrTopTierFilter]
+  contentfulMetadata: ContentfulMetadataFilter
+  sys: SysFilter
+  title: String
+  title_contains: String
+  title_exists: Boolean
+  title_in: [String]
+  title_not: String
+  title_not_contains: String
+  title_not_in: [String]
+}
+
+type MenuOrMenuItemOrTopTierLinkingCollections {
+  entryCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): EntryCollection
+}
+
+enum MenuOrder {
+  menuType_ASC
+  menuType_DESC
+  sys_firstPublishedAt_ASC
+  sys_firstPublishedAt_DESC
+  sys_id_ASC
+  sys_id_DESC
+  sys_publishedAt_ASC
+  sys_publishedAt_DESC
+  sys_publishedVersion_ASC
+  sys_publishedVersion_DESC
+  title_ASC
+  title_DESC
 }
 
 """
@@ -1910,8 +2229,8 @@ type OfficePage implements Entry {
   contentfulMetadata: ContentfulMetadata!
   description(locale: String): OfficePageDescription
   linkedFrom(allowedLocales: [String]): OfficePageLinkingCollections
-  mailingAddress(locale: String, preview: Boolean): ContentTypeLocation
-  metadata(locale: String, preview: Boolean): PageMetadata
+  mailingAddress(locale: String, preview: Boolean, where: ContentTypeLocationFilter): ContentTypeLocation
+  pageMetadata(locale: String, preview: Boolean, where: PageMetadataFilter): PageMetadata
   pageTitle(locale: String): String
   servicesAndPrograms(locale: String): OfficePageServicesAndPrograms
   subheading(locale: String): String
@@ -1970,6 +2289,11 @@ type OfficePageDescriptionEntries {
 type OfficePageDescriptionLinks {
   assets: OfficePageDescriptionAssets!
   entries: OfficePageDescriptionEntries!
+  resources: OfficePageDescriptionResources!
+}
+
+type OfficePageDescriptionResources {
+  block: [ResourceLink!]!
 }
 
 input OfficePageFilter {
@@ -1983,8 +2307,8 @@ input OfficePageFilter {
   description_not_contains: String
   mailingAddress: cfContentTypeLocationNestedFilter
   mailingAddress_exists: Boolean
-  metadata: cfPageMetadataNestedFilter
-  metadata_exists: Boolean
+  pageMetadata: cfPageMetadataNestedFilter
+  pageMetadata_exists: Boolean
   pageTitle: String
   pageTitle_contains: String
   pageTitle_exists: Boolean
@@ -2043,19 +2367,28 @@ type OfficePageServicesAndProgramsEntries {
 type OfficePageServicesAndProgramsLinks {
   assets: OfficePageServicesAndProgramsAssets!
   entries: OfficePageServicesAndProgramsEntries!
+  resources: OfficePageServicesAndProgramsResources!
+}
+
+type OfficePageServicesAndProgramsResources {
+  block: [ResourceLink!]!
 }
 
 """
-Metadata about a page for setting the URL and for helping with SEO (search engine optimization). [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/pageMetadata)
+Metadata about a page for setting its URL, for linking to it from menus and other pages, and for setting up a redirect. Also contains additional fields for improving SEO (search engine optimization). A page will not appear on the site unless it has a corresponding Page metadata entry. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/pageMetadata)
 """
 type PageMetadata implements Entry {
   contentfulMetadata: ContentfulMetadata!
-  internalTitle(locale: String): String
+  externalRedirect(locale: String): String
+  internalRedirect(locale: String, preview: Boolean, where: PageMetadataFilter): PageMetadata
+  isRoot(locale: String): Boolean
   linkedFrom(allowedLocales: [String]): PageMetadataLinkingCollections
   metaDescription(locale: String): String
   metaTitle(locale: String): String
+  parent(locale: String, preview: Boolean, where: PageMetadataFilter): PageMetadata
   slug(locale: String): String
   sys: Sys!
+  title(locale: String): String
 }
 
 type PageMetadataCollection {
@@ -2069,13 +2402,18 @@ input PageMetadataFilter {
   AND: [PageMetadataFilter]
   OR: [PageMetadataFilter]
   contentfulMetadata: ContentfulMetadataFilter
-  internalTitle: String
-  internalTitle_contains: String
-  internalTitle_exists: Boolean
-  internalTitle_in: [String]
-  internalTitle_not: String
-  internalTitle_not_contains: String
-  internalTitle_not_in: [String]
+  externalRedirect: String
+  externalRedirect_contains: String
+  externalRedirect_exists: Boolean
+  externalRedirect_in: [String]
+  externalRedirect_not: String
+  externalRedirect_not_contains: String
+  externalRedirect_not_in: [String]
+  internalRedirect: cfPageMetadataNestedFilter
+  internalRedirect_exists: Boolean
+  isRoot: Boolean
+  isRoot_exists: Boolean
+  isRoot_not: Boolean
   metaDescription: String
   metaDescription_contains: String
   metaDescription_exists: Boolean
@@ -2090,6 +2428,8 @@ input PageMetadataFilter {
   metaTitle_not: String
   metaTitle_not_contains: String
   metaTitle_not_in: [String]
+  parent: cfPageMetadataNestedFilter
+  parent_exists: Boolean
   slug: String
   slug_contains: String
   slug_exists: Boolean
@@ -2098,13 +2438,23 @@ input PageMetadataFilter {
   slug_not_contains: String
   slug_not_in: [String]
   sys: SysFilter
+  title: String
+  title_contains: String
+  title_exists: Boolean
+  title_in: [String]
+  title_not: String
+  title_not_contains: String
+  title_not_in: [String]
 }
 
 type PageMetadataLinkingCollections {
   boardsAndCommissionsCollection(limit: Int = 100, locale: String, order: [PageMetadataLinkingCollectionsBoardsAndCommissionsCollectionOrder], preview: Boolean, skip: Int = 0): BoardsAndCommissionsCollection
-  callToActionCollection(limit: Int = 100, locale: String, order: [PageMetadataLinkingCollectionsCallToActionCollectionOrder], preview: Boolean, skip: Int = 0): CallToActionCollection
   entryCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): EntryCollection
+  homeCollection(limit: Int = 100, locale: String, order: [PageMetadataLinkingCollectionsHomeCollectionOrder], preview: Boolean, skip: Int = 0): HomeCollection
+  menuItemCollection(limit: Int = 100, locale: String, order: [PageMetadataLinkingCollectionsMenuItemCollectionOrder], preview: Boolean, skip: Int = 0): MenuItemCollection
   officePageCollection(limit: Int = 100, locale: String, order: [PageMetadataLinkingCollectionsOfficePageCollectionOrder], preview: Boolean, skip: Int = 0): OfficePageCollection
+  pageMetadataCollection(limit: Int = 100, locale: String, order: [PageMetadataLinkingCollectionsPageMetadataCollectionOrder], preview: Boolean, skip: Int = 0): PageMetadataCollection
+  serviceGroupCollection(limit: Int = 100, locale: String, order: [PageMetadataLinkingCollectionsServiceGroupCollectionOrder], preview: Boolean, skip: Int = 0): ServiceGroupCollection
   topTierCollection(limit: Int = 100, locale: String, order: [PageMetadataLinkingCollectionsTopTierCollectionOrder], preview: Boolean, skip: Int = 0): TopTierCollection
 }
 
@@ -2123,21 +2473,11 @@ enum PageMetadataLinkingCollectionsBoardsAndCommissionsCollectionOrder {
   title_DESC
 }
 
-enum PageMetadataLinkingCollectionsCallToActionCollectionOrder {
-  callToActionMessage_ASC
-  callToActionMessage_DESC
-  ctaInternalName_ASC
-  ctaInternalName_DESC
-  ctaName_ASC
-  ctaName_DESC
-  ctaType_ASC
-  ctaType_DESC
-  internalOrExternal_ASC
-  internalOrExternal_DESC
-  linkText_ASC
-  linkText_DESC
-  phoneNumberCta_ASC
-  phoneNumberCta_DESC
+enum PageMetadataLinkingCollectionsHomeCollectionOrder {
+  alertTitle_ASC
+  alertTitle_DESC
+  internalTitle_ASC
+  internalTitle_DESC
   sys_firstPublishedAt_ASC
   sys_firstPublishedAt_DESC
   sys_id_ASC
@@ -2146,6 +2486,21 @@ enum PageMetadataLinkingCollectionsCallToActionCollectionOrder {
   sys_publishedAt_DESC
   sys_publishedVersion_ASC
   sys_publishedVersion_DESC
+}
+
+enum PageMetadataLinkingCollectionsMenuItemCollectionOrder {
+  externalLink_ASC
+  externalLink_DESC
+  sys_firstPublishedAt_ASC
+  sys_firstPublishedAt_DESC
+  sys_id_ASC
+  sys_id_DESC
+  sys_publishedAt_ASC
+  sys_publishedAt_DESC
+  sys_publishedVersion_ASC
+  sys_publishedVersion_DESC
+  title_ASC
+  title_DESC
 }
 
 enum PageMetadataLinkingCollectionsOfficePageCollectionOrder {
@@ -2161,6 +2516,44 @@ enum PageMetadataLinkingCollectionsOfficePageCollectionOrder {
   sys_publishedAt_DESC
   sys_publishedVersion_ASC
   sys_publishedVersion_DESC
+}
+
+enum PageMetadataLinkingCollectionsPageMetadataCollectionOrder {
+  externalRedirect_ASC
+  externalRedirect_DESC
+  isRoot_ASC
+  isRoot_DESC
+  metaTitle_ASC
+  metaTitle_DESC
+  slug_ASC
+  slug_DESC
+  sys_firstPublishedAt_ASC
+  sys_firstPublishedAt_DESC
+  sys_id_ASC
+  sys_id_DESC
+  sys_publishedAt_ASC
+  sys_publishedAt_DESC
+  sys_publishedVersion_ASC
+  sys_publishedVersion_DESC
+  title_ASC
+  title_DESC
+}
+
+enum PageMetadataLinkingCollectionsServiceGroupCollectionOrder {
+  serviceListName_ASC
+  serviceListName_DESC
+  subheading_ASC
+  subheading_DESC
+  sys_firstPublishedAt_ASC
+  sys_firstPublishedAt_DESC
+  sys_id_ASC
+  sys_id_DESC
+  sys_publishedAt_ASC
+  sys_publishedAt_DESC
+  sys_publishedVersion_ASC
+  sys_publishedVersion_DESC
+  title_ASC
+  title_DESC
 }
 
 enum PageMetadataLinkingCollectionsTopTierCollectionOrder {
@@ -2179,8 +2572,10 @@ enum PageMetadataLinkingCollectionsTopTierCollectionOrder {
 }
 
 enum PageMetadataOrder {
-  internalTitle_ASC
-  internalTitle_DESC
+  externalRedirect_ASC
+  externalRedirect_DESC
+  isRoot_ASC
+  isRoot_DESC
   metaTitle_ASC
   metaTitle_DESC
   slug_ASC
@@ -2193,6 +2588,8 @@ enum PageMetadataOrder {
   sys_publishedAt_DESC
   sys_publishedVersion_ASC
   sys_publishedVersion_DESC
+  title_ASC
+  title_DESC
 }
 
 """
@@ -2202,8 +2599,8 @@ type PromoBannerWithCta implements Entry {
   contentfulMetadata: ContentfulMetadata!
   linkedFrom(allowedLocales: [String]): PromoBannerWithCtaLinkingCollections
   promoCategoryCollection(limit: Int = 100, locale: String, order: [PromoBannerWithCtaPromoCategoryCollectionOrder], preview: Boolean, skip: Int = 0, where: CategoryFilter): PromoBannerWithCtaPromoCategoryCollection
-  promoCta(locale: String, preview: Boolean): CallToAction
-  promoHeroImage(locale: String, preview: Boolean): ImageWrapper
+  promoCta(locale: String, preview: Boolean, where: CallToActionFilter): CallToAction
+  promoHeroImage(locale: String, preview: Boolean, where: ImageWrapperFilter): ImageWrapper
   promoInternalName(locale: String): String
   sys: Sys!
 }
@@ -2237,6 +2634,22 @@ input PromoBannerWithCtaFilter {
 
 type PromoBannerWithCtaLinkingCollections {
   entryCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): EntryCollection
+  homeCollection(limit: Int = 100, locale: String, order: [PromoBannerWithCtaLinkingCollectionsHomeCollectionOrder], preview: Boolean, skip: Int = 0): HomeCollection
+}
+
+enum PromoBannerWithCtaLinkingCollectionsHomeCollectionOrder {
+  alertTitle_ASC
+  alertTitle_DESC
+  internalTitle_ASC
+  internalTitle_DESC
+  sys_firstPublishedAt_ASC
+  sys_firstPublishedAt_DESC
+  sys_id_ASC
+  sys_id_DESC
+  sys_publishedAt_ASC
+  sys_publishedAt_DESC
+  sys_publishedVersion_ASC
+  sys_publishedVersion_DESC
 }
 
 enum PromoBannerWithCtaOrder {
@@ -2290,14 +2703,14 @@ type Query {
   categoryCollection(limit: Int = 100, locale: String, order: [CategoryOrder], preview: Boolean, skip: Int = 0, where: CategoryFilter): CategoryCollection
   contact(id: String!, locale: String, preview: Boolean): Contact
   contactCollection(limit: Int = 100, locale: String, order: [ContactOrder], preview: Boolean, skip: Int = 0, where: ContactFilter): ContactCollection
-  contentBlockHeader(id: String!, locale: String, preview: Boolean): ContentBlockHeader
-  contentBlockHeaderCollection(limit: Int = 100, locale: String, order: [ContentBlockHeaderOrder], preview: Boolean, skip: Int = 0, where: ContentBlockHeaderFilter): ContentBlockHeaderCollection
   contentTypeLocation(id: String!, locale: String, preview: Boolean): ContentTypeLocation
   contentTypeLocationCollection(limit: Int = 100, locale: String, order: [ContentTypeLocationOrder], preview: Boolean, skip: Int = 0, where: ContentTypeLocationFilter): ContentTypeLocationCollection
   documentWrapper(id: String!, locale: String, preview: Boolean): DocumentWrapper
   documentWrapperCollection(limit: Int = 100, locale: String, order: [DocumentWrapperOrder], preview: Boolean, skip: Int = 0, where: DocumentWrapperFilter): DocumentWrapperCollection
   draftNavigationLink(id: String!, locale: String, preview: Boolean): DraftNavigationLink
   draftNavigationLinkCollection(limit: Int = 100, locale: String, order: [DraftNavigationLinkOrder], preview: Boolean, skip: Int = 0, where: DraftNavigationLinkFilter): DraftNavigationLinkCollection
+  draftNavigationLinkOrDraftNavigationMenu(id: String!, locale: String, preview: Boolean): DraftNavigationLinkOrDraftNavigationMenu
+  draftNavigationLinkOrDraftNavigationMenuCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0, where: DraftNavigationLinkOrDraftNavigationMenuFilter): DraftNavigationLinkOrDraftNavigationMenuCollection
   draftNavigationMenu(id: String!, locale: String, preview: Boolean): DraftNavigationMenu
   draftNavigationMenuCollection(limit: Int = 100, locale: String, order: [DraftNavigationMenuOrder], preview: Boolean, skip: Int = 0, where: DraftNavigationMenuFilter): DraftNavigationMenuCollection
   entryCollection(limit: Int = 100, locale: String, order: [EntryOrder], preview: Boolean, skip: Int = 0, where: EntryFilter): EntryCollection
@@ -2305,10 +2718,18 @@ type Query {
   eventEntryCollection(limit: Int = 100, locale: String, order: [EventEntryOrder], preview: Boolean, skip: Int = 0, where: EventEntryFilter): EventEntryCollection
   heroImage(id: String!, locale: String, preview: Boolean): HeroImage
   heroImageCollection(limit: Int = 100, locale: String, order: [HeroImageOrder], preview: Boolean, skip: Int = 0, where: HeroImageFilter): HeroImageCollection
+  home(id: String!, locale: String, preview: Boolean): Home
+  homeCollection(limit: Int = 100, locale: String, order: [HomeOrder], preview: Boolean, skip: Int = 0, where: HomeFilter): HomeCollection
   imageWrapper(id: String!, locale: String, preview: Boolean): ImageWrapper
   imageWrapperCollection(limit: Int = 100, locale: String, order: [ImageWrapperOrder], preview: Boolean, skip: Int = 0, where: ImageWrapperFilter): ImageWrapperCollection
   listWithTitle(id: String!, locale: String, preview: Boolean): ListWithTitle
   listWithTitleCollection(limit: Int = 100, locale: String, order: [ListWithTitleOrder], preview: Boolean, skip: Int = 0, where: ListWithTitleFilter): ListWithTitleCollection
+  menu(id: String!, locale: String, preview: Boolean): Menu
+  menuCollection(limit: Int = 100, locale: String, order: [MenuOrder], preview: Boolean, skip: Int = 0, where: MenuFilter): MenuCollection
+  menuItem(id: String!, locale: String, preview: Boolean): MenuItem
+  menuItemCollection(limit: Int = 100, locale: String, order: [MenuItemOrder], preview: Boolean, skip: Int = 0, where: MenuItemFilter): MenuItemCollection
+  menuOrMenuItemOrTopTier(id: String!, locale: String, preview: Boolean): MenuOrMenuItemOrTopTier
+  menuOrMenuItemOrTopTierCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0, where: MenuOrMenuItemOrTopTierFilter): MenuOrMenuItemOrTopTierCollection
   officePage(id: String!, locale: String, preview: Boolean): OfficePage
   officePageCollection(limit: Int = 100, locale: String, order: [OfficePageOrder], preview: Boolean, skip: Int = 0, where: OfficePageFilter): OfficePageCollection
   pageMetadata(id: String!, locale: String, preview: Boolean): PageMetadata
@@ -2317,6 +2738,8 @@ type Query {
   promoBannerWithCtaCollection(limit: Int = 100, locale: String, order: [PromoBannerWithCtaOrder], preview: Boolean, skip: Int = 0, where: PromoBannerWithCtaFilter): PromoBannerWithCtaCollection
   serviceEntry(id: String!, locale: String, preview: Boolean): ServiceEntry
   serviceEntryCollection(limit: Int = 100, locale: String, order: [ServiceEntryOrder], preview: Boolean, skip: Int = 0, where: ServiceEntryFilter): ServiceEntryCollection
+  serviceEntryOrServiceGroup(id: String!, locale: String, preview: Boolean): ServiceEntryOrServiceGroup
+  serviceEntryOrServiceGroupCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0, where: ServiceEntryOrServiceGroupFilter): ServiceEntryOrServiceGroupCollection
   serviceGroup(id: String!, locale: String, preview: Boolean): ServiceGroup
   serviceGroupCollection(limit: Int = 100, locale: String, order: [ServiceGroupOrder], preview: Boolean, skip: Int = 0, where: ServiceGroupFilter): ServiceGroupCollection
   testRichText(id: String!, locale: String, preview: Boolean): TestRichText
@@ -2327,19 +2750,27 @@ type Query {
   videoWrapperCollection(limit: Int = 100, locale: String, order: [VideoWrapperOrder], preview: Boolean, skip: Int = 0, where: VideoWrapperFilter): VideoWrapperCollection
 }
 
+type ResourceLink {
+  sys: ResourceSys!
+}
+
+type ResourceSys {
+  linkType: String!
+  type: String!
+  urn: String!
+}
+
 """
-Description of a program's task-related service [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/serviceEntry)
+Service content that will show up as an accordion on a service group page. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/serviceEntry)
 """
 type ServiceEntry implements Entry {
-  contactInformationCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): ServiceEntryContactInformationCollection
+  contactInformationCollection(limit: Int = 100, locale: String, order: [ServiceEntryContactInformationCollectionOrder], preview: Boolean, skip: Int = 0, where: ContactFilter): ServiceEntryContactInformationCollection
   contentfulMetadata: ContentfulMetadata!
   description(locale: String): ServiceEntryDescription
   entryTitle(locale: String): String
   linkedDocumentCollection(limit: Int = 100, locale: String, order: [ServiceEntryLinkedDocumentCollectionOrder], preview: Boolean, skip: Int = 0, where: DocumentWrapperFilter): ServiceEntryLinkedDocumentCollection
   linkedFrom(allowedLocales: [String]): ServiceEntryLinkingCollections
-  serviceCategoryCollection(limit: Int = 100, locale: String, order: [ServiceEntryServiceCategoryCollectionOrder], preview: Boolean, skip: Int = 0, where: CategoryFilter): ServiceEntryServiceCategoryCollection
   serviceCtaCollection(limit: Int = 100, locale: String, order: [ServiceEntryServiceCtaCollectionOrder], preview: Boolean, skip: Int = 0, where: CallToActionFilter): ServiceEntryServiceCtaCollection
-  serviceDescriptionsCollection(limit: Int = 100, locale: String, order: [ServiceEntryServiceDescriptionsCollectionOrder], preview: Boolean, skip: Int = 0, where: ListWithTitleFilter): ServiceEntryServiceDescriptionsCollection
   subheading(locale: String): String
   sys: Sys!
 }
@@ -2352,10 +2783,29 @@ type ServiceEntryCollection {
 }
 
 type ServiceEntryContactInformationCollection {
-  items: [Entry]!
+  items: [Contact]!
   limit: Int!
   skip: Int!
   total: Int!
+}
+
+enum ServiceEntryContactInformationCollectionOrder {
+  email_ASC
+  email_DESC
+  entityName_ASC
+  entityName_DESC
+  phoneExt_ASC
+  phoneExt_DESC
+  phone_ASC
+  phone_DESC
+  sys_firstPublishedAt_ASC
+  sys_firstPublishedAt_DESC
+  sys_id_ASC
+  sys_id_DESC
+  sys_publishedAt_ASC
+  sys_publishedAt_DESC
+  sys_publishedVersion_ASC
+  sys_publishedVersion_DESC
 }
 
 type ServiceEntryDescription {
@@ -2377,11 +2827,17 @@ type ServiceEntryDescriptionEntries {
 type ServiceEntryDescriptionLinks {
   assets: ServiceEntryDescriptionAssets!
   entries: ServiceEntryDescriptionEntries!
+  resources: ServiceEntryDescriptionResources!
+}
+
+type ServiceEntryDescriptionResources {
+  block: [ResourceLink!]!
 }
 
 input ServiceEntryFilter {
   AND: [ServiceEntryFilter]
   OR: [ServiceEntryFilter]
+  contactInformation: cfContactNestedFilter
   contactInformationCollection_exists: Boolean
   contentfulMetadata: ContentfulMetadataFilter
   description_contains: String
@@ -2396,12 +2852,8 @@ input ServiceEntryFilter {
   entryTitle_not_in: [String]
   linkedDocument: cfDocumentWrapperNestedFilter
   linkedDocumentCollection_exists: Boolean
-  serviceCategory: cfCategoryNestedFilter
-  serviceCategoryCollection_exists: Boolean
   serviceCta: cfCallToActionNestedFilter
   serviceCtaCollection_exists: Boolean
-  serviceDescriptions: cfListWithTitleNestedFilter
-  serviceDescriptionsCollection_exists: Boolean
   subheading: String
   subheading_contains: String
   subheading_exists: Boolean
@@ -2434,8 +2886,23 @@ enum ServiceEntryLinkedDocumentCollectionOrder {
 
 type ServiceEntryLinkingCollections {
   entryCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): EntryCollection
+  homeCollection(limit: Int = 100, locale: String, order: [ServiceEntryLinkingCollectionsHomeCollectionOrder], preview: Boolean, skip: Int = 0): HomeCollection
   serviceGroupCollection(limit: Int = 100, locale: String, order: [ServiceEntryLinkingCollectionsServiceGroupCollectionOrder], preview: Boolean, skip: Int = 0): ServiceGroupCollection
-  topTierCollection(limit: Int = 100, locale: String, order: [ServiceEntryLinkingCollectionsTopTierCollectionOrder], preview: Boolean, skip: Int = 0): TopTierCollection
+}
+
+enum ServiceEntryLinkingCollectionsHomeCollectionOrder {
+  alertTitle_ASC
+  alertTitle_DESC
+  internalTitle_ASC
+  internalTitle_DESC
+  sys_firstPublishedAt_ASC
+  sys_firstPublishedAt_DESC
+  sys_id_ASC
+  sys_id_DESC
+  sys_publishedAt_ASC
+  sys_publishedAt_DESC
+  sys_publishedVersion_ASC
+  sys_publishedVersion_DESC
 }
 
 enum ServiceEntryLinkingCollectionsServiceGroupCollectionOrder {
@@ -2455,19 +2922,69 @@ enum ServiceEntryLinkingCollectionsServiceGroupCollectionOrder {
   title_DESC
 }
 
-enum ServiceEntryLinkingCollectionsTopTierCollectionOrder {
-  subheading_ASC
-  subheading_DESC
-  sys_firstPublishedAt_ASC
-  sys_firstPublishedAt_DESC
-  sys_id_ASC
-  sys_id_DESC
-  sys_publishedAt_ASC
-  sys_publishedAt_DESC
-  sys_publishedVersion_ASC
-  sys_publishedVersion_DESC
-  title_ASC
-  title_DESC
+"""
+[See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/serviceEntryOrServiceGroup)
+"""
+type ServiceEntryOrServiceGroup implements Entry {
+  contentfulMetadata: ContentfulMetadata!
+  description(locale: String): ServiceEntryOrServiceGroupDescription
+  linkedFrom(allowedLocales: [String]): ServiceEntryOrServiceGroupLinkingCollections
+  subheading(locale: String): String
+  sys: Sys!
+}
+
+type ServiceEntryOrServiceGroupCollection {
+  items: [ServiceEntryOrServiceGroup]!
+  limit: Int!
+  skip: Int!
+  total: Int!
+}
+
+type ServiceEntryOrServiceGroupDescription {
+  json: JSON!
+  links: ServiceEntryOrServiceGroupDescriptionLinks!
+}
+
+type ServiceEntryOrServiceGroupDescriptionAssets {
+  block: [Asset]!
+  hyperlink: [Asset]!
+}
+
+type ServiceEntryOrServiceGroupDescriptionEntries {
+  block: [Entry]!
+  hyperlink: [Entry]!
+  inline: [Entry]!
+}
+
+type ServiceEntryOrServiceGroupDescriptionLinks {
+  assets: ServiceEntryOrServiceGroupDescriptionAssets!
+  entries: ServiceEntryOrServiceGroupDescriptionEntries!
+  resources: ServiceEntryOrServiceGroupDescriptionResources!
+}
+
+type ServiceEntryOrServiceGroupDescriptionResources {
+  block: [ResourceLink!]!
+}
+
+input ServiceEntryOrServiceGroupFilter {
+  AND: [ServiceEntryOrServiceGroupFilter]
+  OR: [ServiceEntryOrServiceGroupFilter]
+  contentfulMetadata: ContentfulMetadataFilter
+  description_contains: String
+  description_exists: Boolean
+  description_not_contains: String
+  subheading: String
+  subheading_contains: String
+  subheading_exists: Boolean
+  subheading_in: [String]
+  subheading_not: String
+  subheading_not_contains: String
+  subheading_not_in: [String]
+  sys: SysFilter
+}
+
+type ServiceEntryOrServiceGroupLinkingCollections {
+  entryCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): EntryCollection
 }
 
 enum ServiceEntryOrder {
@@ -2475,28 +2992,6 @@ enum ServiceEntryOrder {
   entryTitle_DESC
   subheading_ASC
   subheading_DESC
-  sys_firstPublishedAt_ASC
-  sys_firstPublishedAt_DESC
-  sys_id_ASC
-  sys_id_DESC
-  sys_publishedAt_ASC
-  sys_publishedAt_DESC
-  sys_publishedVersion_ASC
-  sys_publishedVersion_DESC
-}
-
-type ServiceEntryServiceCategoryCollection {
-  items: [Category]!
-  limit: Int!
-  skip: Int!
-  total: Int!
-}
-
-enum ServiceEntryServiceCategoryCollectionOrder {
-  categoryDescription_ASC
-  categoryDescription_DESC
-  categoryName_ASC
-  categoryName_DESC
   sys_firstPublishedAt_ASC
   sys_firstPublishedAt_DESC
   sys_id_ASC
@@ -2515,44 +3010,8 @@ type ServiceEntryServiceCtaCollection {
 }
 
 enum ServiceEntryServiceCtaCollectionOrder {
-  callToActionMessage_ASC
-  callToActionMessage_DESC
   ctaInternalName_ASC
   ctaInternalName_DESC
-  ctaName_ASC
-  ctaName_DESC
-  ctaType_ASC
-  ctaType_DESC
-  internalOrExternal_ASC
-  internalOrExternal_DESC
-  linkText_ASC
-  linkText_DESC
-  phoneNumberCta_ASC
-  phoneNumberCta_DESC
-  sys_firstPublishedAt_ASC
-  sys_firstPublishedAt_DESC
-  sys_id_ASC
-  sys_id_DESC
-  sys_publishedAt_ASC
-  sys_publishedAt_DESC
-  sys_publishedVersion_ASC
-  sys_publishedVersion_DESC
-}
-
-type ServiceEntryServiceDescriptionsCollection {
-  items: [ListWithTitle]!
-  limit: Int!
-  skip: Int!
-  total: Int!
-}
-
-enum ServiceEntryServiceDescriptionsCollectionOrder {
-  customLabel_ASC
-  customLabel_DESC
-  dropdownChoices_ASC
-  dropdownChoices_DESC
-  internalTitle_ASC
-  internalTitle_DESC
   sys_firstPublishedAt_ASC
   sys_firstPublishedAt_DESC
   sys_id_ASC
@@ -2564,16 +3023,17 @@ enum ServiceEntryServiceDescriptionsCollectionOrder {
 }
 
 """
-Contains a group of related service entries [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/serviceGroup)
+Web page that usually contains a group of service entries, but doesn't have to. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/serviceGroup)
 """
 type ServiceGroup implements Entry {
   additionalResources(locale: String): ServiceGroupAdditionalResources
   contactInfoCollection(limit: Int = 100, locale: String, order: [ServiceGroupContactInfoCollectionOrder], preview: Boolean, skip: Int = 0, where: ContactFilter): ServiceGroupContactInfoCollection
   contentfulMetadata: ContentfulMetadata!
   description(locale: String): ServiceGroupDescription
+  heroImage(locale: String, preview: Boolean, where: HeroImageFilter): HeroImage
   linkedFrom(allowedLocales: [String]): ServiceGroupLinkingCollections
-  serviceEntriesCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): ServiceGroupServiceEntriesCollection
-  serviceGroupCategoryCollection(limit: Int = 100, locale: String, order: [ServiceGroupServiceGroupCategoryCollectionOrder], preview: Boolean, skip: Int = 0, where: CategoryFilter): ServiceGroupServiceGroupCategoryCollection
+  pageMetadata(locale: String, preview: Boolean, where: PageMetadataFilter): PageMetadata
+  serviceEntriesCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0, where: ServiceEntryOrServiceGroupFilter): ServiceGroupServiceEntriesCollection
   serviceListName(locale: String): String
   subheading(locale: String): String
   sys: Sys!
@@ -2599,6 +3059,11 @@ type ServiceGroupAdditionalResourcesEntries {
 type ServiceGroupAdditionalResourcesLinks {
   assets: ServiceGroupAdditionalResourcesAssets!
   entries: ServiceGroupAdditionalResourcesEntries!
+  resources: ServiceGroupAdditionalResourcesResources!
+}
+
+type ServiceGroupAdditionalResourcesResources {
+  block: [ResourceLink!]!
 }
 
 type ServiceGroupCollection {
@@ -2653,6 +3118,11 @@ type ServiceGroupDescriptionEntries {
 type ServiceGroupDescriptionLinks {
   assets: ServiceGroupDescriptionAssets!
   entries: ServiceGroupDescriptionEntries!
+  resources: ServiceGroupDescriptionResources!
+}
+
+type ServiceGroupDescriptionResources {
+  block: [ResourceLink!]!
 }
 
 input ServiceGroupFilter {
@@ -2667,9 +3137,12 @@ input ServiceGroupFilter {
   description_contains: String
   description_exists: Boolean
   description_not_contains: String
+  heroImage: cfHeroImageNestedFilter
+  heroImage_exists: Boolean
+  pageMetadata: cfPageMetadataNestedFilter
+  pageMetadata_exists: Boolean
+  serviceEntries: cfServiceEntryOrServiceGroupNestedFilter
   serviceEntriesCollection_exists: Boolean
-  serviceGroupCategory: cfCategoryNestedFilter
-  serviceGroupCategoryCollection_exists: Boolean
   serviceListName: String
   serviceListName_contains: String
   serviceListName_exists: Boolean
@@ -2696,8 +3169,24 @@ input ServiceGroupFilter {
 
 type ServiceGroupLinkingCollections {
   entryCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): EntryCollection
+  homeCollection(limit: Int = 100, locale: String, order: [ServiceGroupLinkingCollectionsHomeCollectionOrder], preview: Boolean, skip: Int = 0): HomeCollection
   serviceGroupCollection(limit: Int = 100, locale: String, order: [ServiceGroupLinkingCollectionsServiceGroupCollectionOrder], preview: Boolean, skip: Int = 0): ServiceGroupCollection
   topTierCollection(limit: Int = 100, locale: String, order: [ServiceGroupLinkingCollectionsTopTierCollectionOrder], preview: Boolean, skip: Int = 0): TopTierCollection
+}
+
+enum ServiceGroupLinkingCollectionsHomeCollectionOrder {
+  alertTitle_ASC
+  alertTitle_DESC
+  internalTitle_ASC
+  internalTitle_DESC
+  sys_firstPublishedAt_ASC
+  sys_firstPublishedAt_DESC
+  sys_id_ASC
+  sys_id_DESC
+  sys_publishedAt_ASC
+  sys_publishedAt_DESC
+  sys_publishedVersion_ASC
+  sys_publishedVersion_DESC
 }
 
 enum ServiceGroupLinkingCollectionsServiceGroupCollectionOrder {
@@ -2757,28 +3246,6 @@ type ServiceGroupServiceEntriesCollection {
 }
 
 union ServiceGroupServiceEntriesItem = ServiceEntry | ServiceGroup
-
-type ServiceGroupServiceGroupCategoryCollection {
-  items: [Category]!
-  limit: Int!
-  skip: Int!
-  total: Int!
-}
-
-enum ServiceGroupServiceGroupCategoryCollectionOrder {
-  categoryDescription_ASC
-  categoryDescription_DESC
-  categoryName_ASC
-  categoryName_DESC
-  sys_firstPublishedAt_ASC
-  sys_firstPublishedAt_DESC
-  sys_id_ASC
-  sys_id_DESC
-  sys_publishedAt_ASC
-  sys_publishedAt_DESC
-  sys_publishedVersion_ASC
-  sys_publishedVersion_DESC
-}
 
 type Sys {
   environmentId: String!
@@ -2857,6 +3324,11 @@ type TestRichTextBodyEntries {
 type TestRichTextBodyLinks {
   assets: TestRichTextBodyAssets!
   entries: TestRichTextBodyEntries!
+  resources: TestRichTextBodyResources!
+}
+
+type TestRichTextBodyResources {
+  block: [ResourceLink!]!
 }
 
 type TestRichTextCollection {
@@ -2902,18 +3374,19 @@ enum TestRichTextOrder {
 }
 
 """
-[See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/topTier)
+Top tier navigation pages group related service groups and services together. They also populate the navigation bar on the site. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/topTier)
 """
 type TopTier implements Entry {
   contentfulMetadata: ContentfulMetadata!
   description(locale: String): TopTierDescription
-  featuredServiceListCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): TopTierFeaturedServiceListCollection
+  featuredServiceListCollection(limit: Int = 100, locale: String, order: [TopTierFeaturedServiceListCollectionOrder], preview: Boolean, skip: Int = 0, where: ServiceGroupFilter): TopTierFeaturedServiceListCollection
+  heroImage(locale: String, preview: Boolean, where: HeroImageFilter): HeroImage
   linkedFrom(allowedLocales: [String]): TopTierLinkingCollections
-  metadata(locale: String, preview: Boolean): PageMetadata
+  pageMetadata(locale: String, preview: Boolean, where: PageMetadataFilter): PageMetadata
   subheading(locale: String): String
   sys: Sys!
   title(locale: String): String
-  video(locale: String, preview: Boolean): VideoWrapper
+  video(locale: String, preview: Boolean, where: VideoWrapperFilter): VideoWrapper
 }
 
 type TopTierCollection {
@@ -2942,16 +3415,36 @@ type TopTierDescriptionEntries {
 type TopTierDescriptionLinks {
   assets: TopTierDescriptionAssets!
   entries: TopTierDescriptionEntries!
+  resources: TopTierDescriptionResources!
+}
+
+type TopTierDescriptionResources {
+  block: [ResourceLink!]!
 }
 
 type TopTierFeaturedServiceListCollection {
-  items: [TopTierFeaturedServiceListItem]!
+  items: [ServiceGroup]!
   limit: Int!
   skip: Int!
   total: Int!
 }
 
-union TopTierFeaturedServiceListItem = ServiceEntry | ServiceGroup
+enum TopTierFeaturedServiceListCollectionOrder {
+  serviceListName_ASC
+  serviceListName_DESC
+  subheading_ASC
+  subheading_DESC
+  sys_firstPublishedAt_ASC
+  sys_firstPublishedAt_DESC
+  sys_id_ASC
+  sys_id_DESC
+  sys_publishedAt_ASC
+  sys_publishedAt_DESC
+  sys_publishedVersion_ASC
+  sys_publishedVersion_DESC
+  title_ASC
+  title_DESC
+}
 
 input TopTierFilter {
   AND: [TopTierFilter]
@@ -2960,9 +3453,12 @@ input TopTierFilter {
   description_contains: String
   description_exists: Boolean
   description_not_contains: String
+  featuredServiceList: cfServiceGroupNestedFilter
   featuredServiceListCollection_exists: Boolean
-  metadata: cfPageMetadataNestedFilter
-  metadata_exists: Boolean
+  heroImage: cfHeroImageNestedFilter
+  heroImage_exists: Boolean
+  pageMetadata: cfPageMetadataNestedFilter
+  pageMetadata_exists: Boolean
   subheading: String
   subheading_contains: String
   subheading_exists: Boolean
@@ -2984,6 +3480,22 @@ input TopTierFilter {
 
 type TopTierLinkingCollections {
   entryCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): EntryCollection
+  menuCollection(limit: Int = 100, locale: String, order: [TopTierLinkingCollectionsMenuCollectionOrder], preview: Boolean, skip: Int = 0): MenuCollection
+}
+
+enum TopTierLinkingCollectionsMenuCollectionOrder {
+  menuType_ASC
+  menuType_DESC
+  sys_firstPublishedAt_ASC
+  sys_firstPublishedAt_DESC
+  sys_id_ASC
+  sys_id_DESC
+  sys_publishedAt_ASC
+  sys_publishedAt_DESC
+  sys_publishedVersion_ASC
+  sys_publishedVersion_DESC
+  title_ASC
+  title_DESC
 }
 
 enum TopTierOrder {
@@ -3073,7 +3585,23 @@ input VideoWrapperFilter {
 
 type VideoWrapperLinkingCollections {
   entryCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): EntryCollection
+  homeCollection(limit: Int = 100, locale: String, order: [VideoWrapperLinkingCollectionsHomeCollectionOrder], preview: Boolean, skip: Int = 0): HomeCollection
   topTierCollection(limit: Int = 100, locale: String, order: [VideoWrapperLinkingCollectionsTopTierCollectionOrder], preview: Boolean, skip: Int = 0): TopTierCollection
+}
+
+enum VideoWrapperLinkingCollectionsHomeCollectionOrder {
+  alertTitle_ASC
+  alertTitle_DESC
+  internalTitle_ASC
+  internalTitle_DESC
+  sys_firstPublishedAt_ASC
+  sys_firstPublishedAt_DESC
+  sys_id_ASC
+  sys_id_DESC
+  sys_publishedAt_ASC
+  sys_publishedAt_DESC
+  sys_publishedVersion_ASC
+  sys_publishedVersion_DESC
 }
 
 enum VideoWrapperLinkingCollectionsTopTierCollectionOrder {
@@ -3153,18 +3681,19 @@ type VideoWrapperVideoLongerStoryEntries {
 type VideoWrapperVideoLongerStoryLinks {
   assets: VideoWrapperVideoLongerStoryAssets!
   entries: VideoWrapperVideoLongerStoryEntries!
+  resources: VideoWrapperVideoLongerStoryResources!
+}
+
+type VideoWrapperVideoLongerStoryResources {
+  block: [ResourceLink!]!
 }
 
 input cfCallToActionNestedFilter {
   AND: [cfCallToActionNestedFilter]
   OR: [cfCallToActionNestedFilter]
-  callToActionMessage: String
-  callToActionMessage_contains: String
-  callToActionMessage_exists: Boolean
-  callToActionMessage_in: [String]
-  callToActionMessage_not: String
-  callToActionMessage_not_contains: String
-  callToActionMessage_not_in: [String]
+  callToActionDestination_contains: String
+  callToActionDestination_exists: Boolean
+  callToActionDestination_not_contains: String
   contentfulMetadata: ContentfulMetadataFilter
   ctaInternalName: String
   ctaInternalName_contains: String
@@ -3173,41 +3702,6 @@ input cfCallToActionNestedFilter {
   ctaInternalName_not: String
   ctaInternalName_not_contains: String
   ctaInternalName_not_in: [String]
-  ctaLink: String
-  ctaLink_contains: String
-  ctaLink_exists: Boolean
-  ctaLink_in: [String]
-  ctaLink_not: String
-  ctaLink_not_contains: String
-  ctaLink_not_in: [String]
-  ctaName: String
-  ctaName_contains: String
-  ctaName_exists: Boolean
-  ctaName_in: [String]
-  ctaName_not: String
-  ctaName_not_contains: String
-  ctaName_not_in: [String]
-  ctaType: Boolean
-  ctaType_exists: Boolean
-  ctaType_not: Boolean
-  internalContentLink_exists: Boolean
-  internalOrExternal: Boolean
-  internalOrExternal_exists: Boolean
-  internalOrExternal_not: Boolean
-  linkText: String
-  linkText_contains: String
-  linkText_exists: Boolean
-  linkText_in: [String]
-  linkText_not: String
-  linkText_not_contains: String
-  linkText_not_in: [String]
-  phoneNumberCta: String
-  phoneNumberCta_contains: String
-  phoneNumberCta_exists: Boolean
-  phoneNumberCta_in: [String]
-  phoneNumberCta_not: String
-  phoneNumberCta_not_contains: String
-  phoneNumberCta_not_in: [String]
   sys: SysFilter
 }
 
@@ -3344,6 +3838,49 @@ input cfDocumentWrapperNestedFilter {
   wrappedDocumentName_exists: Boolean
 }
 
+input cfDraftNavigationLinkOrDraftNavigationMenuNestedFilter {
+  AND: [cfDraftNavigationLinkOrDraftNavigationMenuNestedFilter]
+  OR: [cfDraftNavigationLinkOrDraftNavigationMenuNestedFilter]
+  contentfulMetadata: ContentfulMetadataFilter
+  sys: SysFilter
+  text: String
+  text_contains: String
+  text_exists: Boolean
+  text_in: [String]
+  text_not: String
+  text_not_contains: String
+  text_not_in: [String]
+}
+
+input cfHeroImageNestedFilter {
+  AND: [cfHeroImageNestedFilter]
+  OR: [cfHeroImageNestedFilter]
+  altField: String
+  altField_contains: String
+  altField_exists: Boolean
+  altField_in: [String]
+  altField_not: String
+  altField_not_contains: String
+  altField_not_in: [String]
+  contentfulMetadata: ContentfulMetadataFilter
+  fotogCredit: String
+  fotogCredit_contains: String
+  fotogCredit_exists: Boolean
+  fotogCredit_in: [String]
+  fotogCredit_not: String
+  fotogCredit_not_contains: String
+  fotogCredit_not_in: [String]
+  imageSource_exists: Boolean
+  imageTitle: String
+  imageTitle_contains: String
+  imageTitle_exists: Boolean
+  imageTitle_in: [String]
+  imageTitle_not: String
+  imageTitle_not_contains: String
+  imageTitle_not_in: [String]
+  sys: SysFilter
+}
+
 input cfImageWrapperNestedFilter {
   AND: [cfImageWrapperNestedFilter]
   OR: [cfImageWrapperNestedFilter]
@@ -3367,48 +3904,35 @@ input cfImageWrapperNestedFilter {
   sys: SysFilter
 }
 
-input cfListWithTitleNestedFilter {
-  AND: [cfListWithTitleNestedFilter]
-  OR: [cfListWithTitleNestedFilter]
+input cfMenuOrMenuItemOrTopTierNestedFilter {
+  AND: [cfMenuOrMenuItemOrTopTierNestedFilter]
+  OR: [cfMenuOrMenuItemOrTopTierNestedFilter]
   contentfulMetadata: ContentfulMetadataFilter
-  customLabel: String
-  customLabel_contains: String
-  customLabel_exists: Boolean
-  customLabel_in: [String]
-  customLabel_not: String
-  customLabel_not_contains: String
-  customLabel_not_in: [String]
-  dropdownChoices: String
-  dropdownChoices_contains: String
-  dropdownChoices_exists: Boolean
-  dropdownChoices_in: [String]
-  dropdownChoices_not: String
-  dropdownChoices_not_contains: String
-  dropdownChoices_not_in: [String]
-  internalTitle: String
-  internalTitle_contains: String
-  internalTitle_exists: Boolean
-  internalTitle_in: [String]
-  internalTitle_not: String
-  internalTitle_not_contains: String
-  internalTitle_not_in: [String]
-  paragraphOrList_contains: String
-  paragraphOrList_exists: Boolean
-  paragraphOrList_not_contains: String
   sys: SysFilter
+  title: String
+  title_contains: String
+  title_exists: Boolean
+  title_in: [String]
+  title_not: String
+  title_not_contains: String
+  title_not_in: [String]
 }
 
 input cfPageMetadataNestedFilter {
   AND: [cfPageMetadataNestedFilter]
   OR: [cfPageMetadataNestedFilter]
   contentfulMetadata: ContentfulMetadataFilter
-  internalTitle: String
-  internalTitle_contains: String
-  internalTitle_exists: Boolean
-  internalTitle_in: [String]
-  internalTitle_not: String
-  internalTitle_not_contains: String
-  internalTitle_not_in: [String]
+  externalRedirect: String
+  externalRedirect_contains: String
+  externalRedirect_exists: Boolean
+  externalRedirect_in: [String]
+  externalRedirect_not: String
+  externalRedirect_not_contains: String
+  externalRedirect_not_in: [String]
+  internalRedirect_exists: Boolean
+  isRoot: Boolean
+  isRoot_exists: Boolean
+  isRoot_not: Boolean
   metaDescription: String
   metaDescription_contains: String
   metaDescription_exists: Boolean
@@ -3423,6 +3947,7 @@ input cfPageMetadataNestedFilter {
   metaTitle_not: String
   metaTitle_not_contains: String
   metaTitle_not_in: [String]
+  parent_exists: Boolean
   slug: String
   slug_contains: String
   slug_exists: Boolean
@@ -3431,6 +3956,85 @@ input cfPageMetadataNestedFilter {
   slug_not_contains: String
   slug_not_in: [String]
   sys: SysFilter
+  title: String
+  title_contains: String
+  title_exists: Boolean
+  title_in: [String]
+  title_not: String
+  title_not_contains: String
+  title_not_in: [String]
+}
+
+input cfPromoBannerWithCtaNestedFilter {
+  AND: [cfPromoBannerWithCtaNestedFilter]
+  OR: [cfPromoBannerWithCtaNestedFilter]
+  contentfulMetadata: ContentfulMetadataFilter
+  promoCategoryCollection_exists: Boolean
+  promoCta_exists: Boolean
+  promoHeroImage_exists: Boolean
+  promoInternalName: String
+  promoInternalName_contains: String
+  promoInternalName_exists: Boolean
+  promoInternalName_in: [String]
+  promoInternalName_not: String
+  promoInternalName_not_contains: String
+  promoInternalName_not_in: [String]
+  sys: SysFilter
+}
+
+input cfServiceEntryOrServiceGroupNestedFilter {
+  AND: [cfServiceEntryOrServiceGroupNestedFilter]
+  OR: [cfServiceEntryOrServiceGroupNestedFilter]
+  contentfulMetadata: ContentfulMetadataFilter
+  description_contains: String
+  description_exists: Boolean
+  description_not_contains: String
+  subheading: String
+  subheading_contains: String
+  subheading_exists: Boolean
+  subheading_in: [String]
+  subheading_not: String
+  subheading_not_contains: String
+  subheading_not_in: [String]
+  sys: SysFilter
+}
+
+input cfServiceGroupNestedFilter {
+  AND: [cfServiceGroupNestedFilter]
+  OR: [cfServiceGroupNestedFilter]
+  additionalResources_contains: String
+  additionalResources_exists: Boolean
+  additionalResources_not_contains: String
+  contactInfoCollection_exists: Boolean
+  contentfulMetadata: ContentfulMetadataFilter
+  description_contains: String
+  description_exists: Boolean
+  description_not_contains: String
+  heroImage_exists: Boolean
+  pageMetadata_exists: Boolean
+  serviceEntriesCollection_exists: Boolean
+  serviceListName: String
+  serviceListName_contains: String
+  serviceListName_exists: Boolean
+  serviceListName_in: [String]
+  serviceListName_not: String
+  serviceListName_not_contains: String
+  serviceListName_not_in: [String]
+  subheading: String
+  subheading_contains: String
+  subheading_exists: Boolean
+  subheading_in: [String]
+  subheading_not: String
+  subheading_not_contains: String
+  subheading_not_in: [String]
+  sys: SysFilter
+  title: String
+  title_contains: String
+  title_exists: Boolean
+  title_in: [String]
+  title_not: String
+  title_not_contains: String
+  title_not_in: [String]
 }
 
 input cfVideoWrapperNestedFilter {

--- a/src/lib/services/contentful/schema.ts
+++ b/src/lib/services/contentful/schema.ts
@@ -363,6 +363,7 @@ export type BoardsAndCommissionsOverviewArgs = {
 export type BoardsAndCommissionsPageMetadataArgs = {
   locale?: InputMaybe<Scalars['String']['input']>;
   preview?: InputMaybe<Scalars['Boolean']['input']>;
+  where?: InputMaybe<PageMetadataFilter>;
 };
 
 
@@ -400,6 +401,12 @@ export type BoardsAndCommissionsAdditionalInformationLinks = {
   __typename?: 'BoardsAndCommissionsAdditionalInformationLinks';
   assets: BoardsAndCommissionsAdditionalInformationAssets;
   entries: BoardsAndCommissionsAdditionalInformationEntries;
+  resources: BoardsAndCommissionsAdditionalInformationResources;
+};
+
+export type BoardsAndCommissionsAdditionalInformationResources = {
+  __typename?: 'BoardsAndCommissionsAdditionalInformationResources';
+  block: Array<ResourceLink>;
 };
 
 export type BoardsAndCommissionsCollection = {
@@ -510,6 +517,12 @@ export type BoardsAndCommissionsMeetingsLinks = {
   __typename?: 'BoardsAndCommissionsMeetingsLinks';
   assets: BoardsAndCommissionsMeetingsAssets;
   entries: BoardsAndCommissionsMeetingsEntries;
+  resources: BoardsAndCommissionsMeetingsResources;
+};
+
+export type BoardsAndCommissionsMeetingsResources = {
+  __typename?: 'BoardsAndCommissionsMeetingsResources';
+  block: Array<ResourceLink>;
 };
 
 export type BoardsAndCommissionsMembership = {
@@ -535,6 +548,12 @@ export type BoardsAndCommissionsMembershipLinks = {
   __typename?: 'BoardsAndCommissionsMembershipLinks';
   assets: BoardsAndCommissionsMembershipAssets;
   entries: BoardsAndCommissionsMembershipEntries;
+  resources: BoardsAndCommissionsMembershipResources;
+};
+
+export type BoardsAndCommissionsMembershipResources = {
+  __typename?: 'BoardsAndCommissionsMembershipResources';
+  block: Array<ResourceLink>;
 };
 
 export enum BoardsAndCommissionsOrder {
@@ -575,28 +594,27 @@ export type BoardsAndCommissionsOverviewLinks = {
   __typename?: 'BoardsAndCommissionsOverviewLinks';
   assets: BoardsAndCommissionsOverviewAssets;
   entries: BoardsAndCommissionsOverviewEntries;
+  resources: BoardsAndCommissionsOverviewResources;
+};
+
+export type BoardsAndCommissionsOverviewResources = {
+  __typename?: 'BoardsAndCommissionsOverviewResources';
+  block: Array<ResourceLink>;
 };
 
 /** Button or link to landing page with URL and description [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/callToAction) */
 export type CallToAction = Entry & {
   __typename?: 'CallToAction';
-  callToActionMessage?: Maybe<Scalars['String']['output']>;
+  callToActionDestination?: Maybe<CallToActionCallToActionDestination>;
   contentfulMetadata: ContentfulMetadata;
   ctaInternalName?: Maybe<Scalars['String']['output']>;
-  ctaLink?: Maybe<Scalars['String']['output']>;
-  ctaName?: Maybe<Scalars['String']['output']>;
-  ctaType?: Maybe<Scalars['Boolean']['output']>;
-  internalContentLink?: Maybe<PageMetadata>;
-  internalOrExternal?: Maybe<Scalars['Boolean']['output']>;
-  linkText?: Maybe<Scalars['String']['output']>;
   linkedFrom?: Maybe<CallToActionLinkingCollections>;
-  phoneNumberCta?: Maybe<Scalars['String']['output']>;
   sys: Sys;
 };
 
 
 /** Button or link to landing page with URL and description [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/callToAction) */
-export type CallToActionCallToActionMessageArgs = {
+export type CallToActionCallToActionDestinationArgs = {
   locale?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -608,51 +626,39 @@ export type CallToActionCtaInternalNameArgs = {
 
 
 /** Button or link to landing page with URL and description [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/callToAction) */
-export type CallToActionCtaLinkArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-/** Button or link to landing page with URL and description [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/callToAction) */
-export type CallToActionCtaNameArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-/** Button or link to landing page with URL and description [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/callToAction) */
-export type CallToActionCtaTypeArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-/** Button or link to landing page with URL and description [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/callToAction) */
-export type CallToActionInternalContentLinkArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-};
-
-
-/** Button or link to landing page with URL and description [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/callToAction) */
-export type CallToActionInternalOrExternalArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-/** Button or link to landing page with URL and description [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/callToAction) */
-export type CallToActionLinkTextArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-/** Button or link to landing page with URL and description [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/callToAction) */
 export type CallToActionLinkedFromArgs = {
   allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
 
+export type CallToActionCallToActionDestination = {
+  __typename?: 'CallToActionCallToActionDestination';
+  json: Scalars['JSON']['output'];
+  links: CallToActionCallToActionDestinationLinks;
+};
 
-/** Button or link to landing page with URL and description [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/callToAction) */
-export type CallToActionPhoneNumberCtaArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
+export type CallToActionCallToActionDestinationAssets = {
+  __typename?: 'CallToActionCallToActionDestinationAssets';
+  block: Array<Maybe<Asset>>;
+  hyperlink: Array<Maybe<Asset>>;
+};
+
+export type CallToActionCallToActionDestinationEntries = {
+  __typename?: 'CallToActionCallToActionDestinationEntries';
+  block: Array<Maybe<Entry>>;
+  hyperlink: Array<Maybe<Entry>>;
+  inline: Array<Maybe<Entry>>;
+};
+
+export type CallToActionCallToActionDestinationLinks = {
+  __typename?: 'CallToActionCallToActionDestinationLinks';
+  assets: CallToActionCallToActionDestinationAssets;
+  entries: CallToActionCallToActionDestinationEntries;
+  resources: CallToActionCallToActionDestinationResources;
+};
+
+export type CallToActionCallToActionDestinationResources = {
+  __typename?: 'CallToActionCallToActionDestinationResources';
+  block: Array<ResourceLink>;
 };
 
 export type CallToActionCollection = {
@@ -666,13 +672,9 @@ export type CallToActionCollection = {
 export type CallToActionFilter = {
   AND?: InputMaybe<Array<InputMaybe<CallToActionFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<CallToActionFilter>>>;
-  callToActionMessage?: InputMaybe<Scalars['String']['input']>;
-  callToActionMessage_contains?: InputMaybe<Scalars['String']['input']>;
-  callToActionMessage_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  callToActionMessage_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  callToActionMessage_not?: InputMaybe<Scalars['String']['input']>;
-  callToActionMessage_not_contains?: InputMaybe<Scalars['String']['input']>;
-  callToActionMessage_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  callToActionDestination_contains?: InputMaybe<Scalars['String']['input']>;
+  callToActionDestination_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  callToActionDestination_not_contains?: InputMaybe<Scalars['String']['input']>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
   ctaInternalName?: InputMaybe<Scalars['String']['input']>;
   ctaInternalName_contains?: InputMaybe<Scalars['String']['input']>;
@@ -681,42 +683,6 @@ export type CallToActionFilter = {
   ctaInternalName_not?: InputMaybe<Scalars['String']['input']>;
   ctaInternalName_not_contains?: InputMaybe<Scalars['String']['input']>;
   ctaInternalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  ctaLink?: InputMaybe<Scalars['String']['input']>;
-  ctaLink_contains?: InputMaybe<Scalars['String']['input']>;
-  ctaLink_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  ctaLink_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  ctaLink_not?: InputMaybe<Scalars['String']['input']>;
-  ctaLink_not_contains?: InputMaybe<Scalars['String']['input']>;
-  ctaLink_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  ctaName?: InputMaybe<Scalars['String']['input']>;
-  ctaName_contains?: InputMaybe<Scalars['String']['input']>;
-  ctaName_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  ctaName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  ctaName_not?: InputMaybe<Scalars['String']['input']>;
-  ctaName_not_contains?: InputMaybe<Scalars['String']['input']>;
-  ctaName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  ctaType?: InputMaybe<Scalars['Boolean']['input']>;
-  ctaType_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  ctaType_not?: InputMaybe<Scalars['Boolean']['input']>;
-  internalContentLink?: InputMaybe<CfPageMetadataNestedFilter>;
-  internalContentLink_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  internalOrExternal?: InputMaybe<Scalars['Boolean']['input']>;
-  internalOrExternal_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  internalOrExternal_not?: InputMaybe<Scalars['Boolean']['input']>;
-  linkText?: InputMaybe<Scalars['String']['input']>;
-  linkText_contains?: InputMaybe<Scalars['String']['input']>;
-  linkText_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  linkText_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  linkText_not?: InputMaybe<Scalars['String']['input']>;
-  linkText_not_contains?: InputMaybe<Scalars['String']['input']>;
-  linkText_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  phoneNumberCta?: InputMaybe<Scalars['String']['input']>;
-  phoneNumberCta_contains?: InputMaybe<Scalars['String']['input']>;
-  phoneNumberCta_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  phoneNumberCta_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  phoneNumberCta_not?: InputMaybe<Scalars['String']['input']>;
-  phoneNumberCta_not_contains?: InputMaybe<Scalars['String']['input']>;
-  phoneNumberCta_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   sys?: InputMaybe<SysFilter>;
 };
 
@@ -782,20 +748,8 @@ export enum CallToActionLinkingCollectionsServiceEntryCollectionOrder {
 }
 
 export enum CallToActionOrder {
-  CallToActionMessageAsc = 'callToActionMessage_ASC',
-  CallToActionMessageDesc = 'callToActionMessage_DESC',
   CtaInternalNameAsc = 'ctaInternalName_ASC',
   CtaInternalNameDesc = 'ctaInternalName_DESC',
-  CtaNameAsc = 'ctaName_ASC',
-  CtaNameDesc = 'ctaName_DESC',
-  CtaTypeAsc = 'ctaType_ASC',
-  CtaTypeDesc = 'ctaType_DESC',
-  InternalOrExternalAsc = 'internalOrExternal_ASC',
-  InternalOrExternalDesc = 'internalOrExternal_DESC',
-  LinkTextAsc = 'linkText_ASC',
-  LinkTextDesc = 'linkText_DESC',
-  PhoneNumberCtaAsc = 'phoneNumberCta_ASC',
-  PhoneNumberCtaDesc = 'phoneNumberCta_DESC',
   SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
   SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
   SysIdAsc = 'sys_id_ASC',
@@ -919,8 +873,6 @@ export type CategoryLinkingCollections = {
   eventEntryCollection?: Maybe<EventEntryCollection>;
   imageWrapperCollection?: Maybe<ImageWrapperCollection>;
   promoBannerWithCtaCollection?: Maybe<PromoBannerWithCtaCollection>;
-  serviceEntryCollection?: Maybe<ServiceEntryCollection>;
-  serviceGroupCollection?: Maybe<ServiceGroupCollection>;
   videoWrapperCollection?: Maybe<VideoWrapperCollection>;
 };
 
@@ -973,24 +925,6 @@ export type CategoryLinkingCollectionsPromoBannerWithCtaCollectionArgs = {
   limit?: InputMaybe<Scalars['Int']['input']>;
   locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<CategoryLinkingCollectionsPromoBannerWithCtaCollectionOrder>>>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-};
-
-
-export type CategoryLinkingCollectionsServiceEntryCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  order?: InputMaybe<Array<InputMaybe<CategoryLinkingCollectionsServiceEntryCollectionOrder>>>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-};
-
-
-export type CategoryLinkingCollectionsServiceGroupCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  order?: InputMaybe<Array<InputMaybe<CategoryLinkingCollectionsServiceGroupCollectionOrder>>>;
   preview?: InputMaybe<Scalars['Boolean']['input']>;
   skip?: InputMaybe<Scalars['Int']['input']>;
 };
@@ -1081,38 +1015,6 @@ export enum CategoryLinkingCollectionsPromoBannerWithCtaCollectionOrder {
   SysPublishedVersionDesc = 'sys_publishedVersion_DESC'
 }
 
-export enum CategoryLinkingCollectionsServiceEntryCollectionOrder {
-  EntryTitleAsc = 'entryTitle_ASC',
-  EntryTitleDesc = 'entryTitle_DESC',
-  SubheadingAsc = 'subheading_ASC',
-  SubheadingDesc = 'subheading_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC'
-}
-
-export enum CategoryLinkingCollectionsServiceGroupCollectionOrder {
-  ServiceListNameAsc = 'serviceListName_ASC',
-  ServiceListNameDesc = 'serviceListName_DESC',
-  SubheadingAsc = 'subheading_ASC',
-  SubheadingDesc = 'subheading_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
-  TitleAsc = 'title_ASC',
-  TitleDesc = 'title_DESC'
-}
-
 export enum CategoryLinkingCollectionsVideoWrapperCollectionOrder {
   InternalTitleAsc = 'internalTitle_ASC',
   InternalTitleDesc = 'internalTitle_DESC',
@@ -1149,7 +1051,7 @@ export enum CategoryOrder {
   SysPublishedVersionDesc = 'sys_publishedVersion_DESC'
 }
 
-/** The name, phone number and email of any person, office or program at LDAF. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/contact) */
+/** The name, phone number, and/or email of any person, office, or program at LDAF. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/contact) */
 export type Contact = Entry & {
   __typename?: 'Contact';
   contentfulMetadata: ContentfulMetadata;
@@ -1162,31 +1064,31 @@ export type Contact = Entry & {
 };
 
 
-/** The name, phone number and email of any person, office or program at LDAF. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/contact) */
+/** The name, phone number, and/or email of any person, office, or program at LDAF. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/contact) */
 export type ContactEmailArgs = {
   locale?: InputMaybe<Scalars['String']['input']>;
 };
 
 
-/** The name, phone number and email of any person, office or program at LDAF. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/contact) */
+/** The name, phone number, and/or email of any person, office, or program at LDAF. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/contact) */
 export type ContactEntityNameArgs = {
   locale?: InputMaybe<Scalars['String']['input']>;
 };
 
 
-/** The name, phone number and email of any person, office or program at LDAF. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/contact) */
+/** The name, phone number, and/or email of any person, office, or program at LDAF. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/contact) */
 export type ContactLinkedFromArgs = {
   allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
 
 
-/** The name, phone number and email of any person, office or program at LDAF. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/contact) */
+/** The name, phone number, and/or email of any person, office, or program at LDAF. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/contact) */
 export type ContactPhoneArgs = {
   locale?: InputMaybe<Scalars['String']['input']>;
 };
 
 
-/** The name, phone number and email of any person, office or program at LDAF. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/contact) */
+/** The name, phone number, and/or email of any person, office, or program at LDAF. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/contact) */
 export type ContactPhoneExtArgs = {
   locale?: InputMaybe<Scalars['String']['input']>;
 };
@@ -1239,6 +1141,7 @@ export type ContactLinkingCollections = {
   boardsAndCommissionsCollection?: Maybe<BoardsAndCommissionsCollection>;
   entryCollection?: Maybe<EntryCollection>;
   officePageCollection?: Maybe<OfficePageCollection>;
+  serviceEntryCollection?: Maybe<ServiceEntryCollection>;
   serviceGroupCollection?: Maybe<ServiceGroupCollection>;
 };
 
@@ -1264,6 +1167,15 @@ export type ContactLinkingCollectionsOfficePageCollectionArgs = {
   limit?: InputMaybe<Scalars['Int']['input']>;
   locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<ContactLinkingCollectionsOfficePageCollectionOrder>>>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type ContactLinkingCollectionsServiceEntryCollectionArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  order?: InputMaybe<Array<InputMaybe<ContactLinkingCollectionsServiceEntryCollectionOrder>>>;
   preview?: InputMaybe<Scalars['Boolean']['input']>;
   skip?: InputMaybe<Scalars['Int']['input']>;
 };
@@ -1307,6 +1219,21 @@ export enum ContactLinkingCollectionsOfficePageCollectionOrder {
   SysPublishedVersionDesc = 'sys_publishedVersion_DESC'
 }
 
+export enum ContactLinkingCollectionsServiceEntryCollectionOrder {
+  EntryTitleAsc = 'entryTitle_ASC',
+  EntryTitleDesc = 'entryTitle_DESC',
+  SubheadingAsc = 'subheading_ASC',
+  SubheadingDesc = 'subheading_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC'
+}
+
 export enum ContactLinkingCollectionsServiceGroupCollectionOrder {
   ServiceListNameAsc = 'serviceListName_ASC',
   ServiceListNameDesc = 'serviceListName_DESC',
@@ -1333,75 +1260,6 @@ export enum ContactOrder {
   PhoneExtDesc = 'phoneExt_DESC',
   PhoneAsc = 'phone_ASC',
   PhoneDesc = 'phone_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC'
-}
-
-/** Headline for block-level content, such as paragraphs, tables or cards within the body of the page [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/contentBlockHeader) */
-export type ContentBlockHeader = Entry & {
-  __typename?: 'ContentBlockHeader';
-  contentfulMetadata: ContentfulMetadata;
-  headlineText?: Maybe<Scalars['String']['output']>;
-  linkedFrom?: Maybe<ContentBlockHeaderLinkingCollections>;
-  sys: Sys;
-};
-
-
-/** Headline for block-level content, such as paragraphs, tables or cards within the body of the page [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/contentBlockHeader) */
-export type ContentBlockHeaderHeadlineTextArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-/** Headline for block-level content, such as paragraphs, tables or cards within the body of the page [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/contentBlockHeader) */
-export type ContentBlockHeaderLinkedFromArgs = {
-  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-};
-
-export type ContentBlockHeaderCollection = {
-  __typename?: 'ContentBlockHeaderCollection';
-  items: Array<Maybe<ContentBlockHeader>>;
-  limit: Scalars['Int']['output'];
-  skip: Scalars['Int']['output'];
-  total: Scalars['Int']['output'];
-};
-
-export type ContentBlockHeaderFilter = {
-  AND?: InputMaybe<Array<InputMaybe<ContentBlockHeaderFilter>>>;
-  OR?: InputMaybe<Array<InputMaybe<ContentBlockHeaderFilter>>>;
-  contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
-  headlineText?: InputMaybe<Scalars['String']['input']>;
-  headlineText_contains?: InputMaybe<Scalars['String']['input']>;
-  headlineText_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  headlineText_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  headlineText_not?: InputMaybe<Scalars['String']['input']>;
-  headlineText_not_contains?: InputMaybe<Scalars['String']['input']>;
-  headlineText_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  sys?: InputMaybe<SysFilter>;
-};
-
-export type ContentBlockHeaderLinkingCollections = {
-  __typename?: 'ContentBlockHeaderLinkingCollections';
-  entryCollection?: Maybe<EntryCollection>;
-};
-
-
-export type ContentBlockHeaderLinkingCollectionsEntryCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-};
-
-export enum ContentBlockHeaderOrder {
-  HeadlineTextAsc = 'headlineText_ASC',
-  HeadlineTextDesc = 'headlineText_DESC',
   SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
   SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
   SysIdAsc = 'sys_id_ASC',
@@ -1892,6 +1750,62 @@ export enum DraftNavigationLinkLinkingCollectionsDraftNavigationMenuCollectionOr
   TypeDesc = 'type_DESC'
 }
 
+/** [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/draftNavigationLinkOrDraftNavigationMenu) */
+export type DraftNavigationLinkOrDraftNavigationMenu = Entry & {
+  __typename?: 'DraftNavigationLinkOrDraftNavigationMenu';
+  contentfulMetadata: ContentfulMetadata;
+  linkedFrom?: Maybe<DraftNavigationLinkOrDraftNavigationMenuLinkingCollections>;
+  sys: Sys;
+  text?: Maybe<Scalars['String']['output']>;
+};
+
+
+/** [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/draftNavigationLinkOrDraftNavigationMenu) */
+export type DraftNavigationLinkOrDraftNavigationMenuLinkedFromArgs = {
+  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+/** [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/draftNavigationLinkOrDraftNavigationMenu) */
+export type DraftNavigationLinkOrDraftNavigationMenuTextArgs = {
+  locale?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type DraftNavigationLinkOrDraftNavigationMenuCollection = {
+  __typename?: 'DraftNavigationLinkOrDraftNavigationMenuCollection';
+  items: Array<Maybe<DraftNavigationLinkOrDraftNavigationMenu>>;
+  limit: Scalars['Int']['output'];
+  skip: Scalars['Int']['output'];
+  total: Scalars['Int']['output'];
+};
+
+export type DraftNavigationLinkOrDraftNavigationMenuFilter = {
+  AND?: InputMaybe<Array<InputMaybe<DraftNavigationLinkOrDraftNavigationMenuFilter>>>;
+  OR?: InputMaybe<Array<InputMaybe<DraftNavigationLinkOrDraftNavigationMenuFilter>>>;
+  contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
+  sys?: InputMaybe<SysFilter>;
+  text?: InputMaybe<Scalars['String']['input']>;
+  text_contains?: InputMaybe<Scalars['String']['input']>;
+  text_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  text_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  text_not?: InputMaybe<Scalars['String']['input']>;
+  text_not_contains?: InputMaybe<Scalars['String']['input']>;
+  text_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type DraftNavigationLinkOrDraftNavigationMenuLinkingCollections = {
+  __typename?: 'DraftNavigationLinkOrDraftNavigationMenuLinkingCollections';
+  entryCollection?: Maybe<EntryCollection>;
+};
+
+
+export type DraftNavigationLinkOrDraftNavigationMenuLinkingCollectionsEntryCollectionArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+};
+
 export enum DraftNavigationLinkOrder {
   LinkAsc = 'link_ASC',
   LinkDesc = 'link_DESC',
@@ -1925,6 +1839,7 @@ export type DraftNavigationMenuChildrenCollectionArgs = {
   locale?: InputMaybe<Scalars['String']['input']>;
   preview?: InputMaybe<Scalars['Boolean']['input']>;
   skip?: InputMaybe<Scalars['Int']['input']>;
+  where?: InputMaybe<DraftNavigationLinkOrDraftNavigationMenuFilter>;
 };
 
 
@@ -1966,6 +1881,7 @@ export type DraftNavigationMenuCollection = {
 export type DraftNavigationMenuFilter = {
   AND?: InputMaybe<Array<InputMaybe<DraftNavigationMenuFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<DraftNavigationMenuFilter>>>;
+  children?: InputMaybe<CfDraftNavigationLinkOrDraftNavigationMenuNestedFilter>;
   childrenCollection_exists?: InputMaybe<Scalars['Boolean']['input']>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
   sys?: InputMaybe<SysFilter>;
@@ -2069,7 +1985,7 @@ export enum EntryOrder {
   SysPublishedVersionDesc = 'sys_publishedVersion_DESC'
 }
 
-/** Consistent format for adding events to the system [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/eventEntry) */
+/** LDAF events such as board meetings, saddle microchipping events, etc. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/eventEntry) */
 export type EventEntry = Entry & {
   __typename?: 'EventEntry';
   contentfulMetadata: ContentfulMetadata;
@@ -2085,7 +2001,7 @@ export type EventEntry = Entry & {
 };
 
 
-/** Consistent format for adding events to the system [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/eventEntry) */
+/** LDAF events such as board meetings, saddle microchipping events, etc. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/eventEntry) */
 export type EventEntryEventCategoryCollectionArgs = {
   limit?: InputMaybe<Scalars['Int']['input']>;
   locale?: InputMaybe<Scalars['String']['input']>;
@@ -2096,19 +2012,19 @@ export type EventEntryEventCategoryCollectionArgs = {
 };
 
 
-/** Consistent format for adding events to the system [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/eventEntry) */
+/** LDAF events such as board meetings, saddle microchipping events, etc. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/eventEntry) */
 export type EventEntryEventDateAndTimeArgs = {
   locale?: InputMaybe<Scalars['String']['input']>;
 };
 
 
-/** Consistent format for adding events to the system [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/eventEntry) */
+/** LDAF events such as board meetings, saddle microchipping events, etc. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/eventEntry) */
 export type EventEntryEventDescriptionArgs = {
   locale?: InputMaybe<Scalars['String']['input']>;
 };
 
 
-/** Consistent format for adding events to the system [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/eventEntry) */
+/** LDAF events such as board meetings, saddle microchipping events, etc. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/eventEntry) */
 export type EventEntryEventDocumentsCollectionArgs = {
   limit?: InputMaybe<Scalars['Int']['input']>;
   locale?: InputMaybe<Scalars['String']['input']>;
@@ -2119,25 +2035,25 @@ export type EventEntryEventDocumentsCollectionArgs = {
 };
 
 
-/** Consistent format for adding events to the system [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/eventEntry) */
+/** LDAF events such as board meetings, saddle microchipping events, etc. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/eventEntry) */
 export type EventEntryInPersonOrOnlineArgs = {
   locale?: InputMaybe<Scalars['String']['input']>;
 };
 
 
-/** Consistent format for adding events to the system [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/eventEntry) */
+/** LDAF events such as board meetings, saddle microchipping events, etc. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/eventEntry) */
 export type EventEntryInternalNameArgs = {
   locale?: InputMaybe<Scalars['String']['input']>;
 };
 
 
-/** Consistent format for adding events to the system [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/eventEntry) */
+/** LDAF events such as board meetings, saddle microchipping events, etc. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/eventEntry) */
 export type EventEntryLinkedFromArgs = {
   allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
 
 
-/** Consistent format for adding events to the system [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/eventEntry) */
+/** LDAF events such as board meetings, saddle microchipping events, etc. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/eventEntry) */
 export type EventEntryShortTitleArgs = {
   locale?: InputMaybe<Scalars['String']['input']>;
 };
@@ -2276,7 +2192,7 @@ export enum EventEntryOrder {
   SysPublishedVersionDesc = 'sys_publishedVersion_DESC'
 }
 
-/** Big wide image on top of page [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/heroImage) */
+/** Big wide image intended for the top of a page. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/heroImage) */
 export type HeroImage = Entry & {
   __typename?: 'HeroImage';
   altField?: Maybe<Scalars['String']['output']>;
@@ -2289,32 +2205,32 @@ export type HeroImage = Entry & {
 };
 
 
-/** Big wide image on top of page [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/heroImage) */
+/** Big wide image intended for the top of a page. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/heroImage) */
 export type HeroImageAltFieldArgs = {
   locale?: InputMaybe<Scalars['String']['input']>;
 };
 
 
-/** Big wide image on top of page [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/heroImage) */
+/** Big wide image intended for the top of a page. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/heroImage) */
 export type HeroImageFotogCreditArgs = {
   locale?: InputMaybe<Scalars['String']['input']>;
 };
 
 
-/** Big wide image on top of page [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/heroImage) */
+/** Big wide image intended for the top of a page. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/heroImage) */
 export type HeroImageImageSourceArgs = {
   locale?: InputMaybe<Scalars['String']['input']>;
   preview?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 
-/** Big wide image on top of page [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/heroImage) */
+/** Big wide image intended for the top of a page. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/heroImage) */
 export type HeroImageImageTitleArgs = {
   locale?: InputMaybe<Scalars['String']['input']>;
 };
 
 
-/** Big wide image on top of page [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/heroImage) */
+/** Big wide image intended for the top of a page. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/heroImage) */
 export type HeroImageLinkedFromArgs = {
   allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
@@ -2359,6 +2275,8 @@ export type HeroImageFilter = {
 export type HeroImageLinkingCollections = {
   __typename?: 'HeroImageLinkingCollections';
   entryCollection?: Maybe<EntryCollection>;
+  serviceGroupCollection?: Maybe<ServiceGroupCollection>;
+  topTierCollection?: Maybe<TopTierCollection>;
 };
 
 
@@ -2369,6 +2287,56 @@ export type HeroImageLinkingCollectionsEntryCollectionArgs = {
   skip?: InputMaybe<Scalars['Int']['input']>;
 };
 
+
+export type HeroImageLinkingCollectionsServiceGroupCollectionArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  order?: InputMaybe<Array<InputMaybe<HeroImageLinkingCollectionsServiceGroupCollectionOrder>>>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type HeroImageLinkingCollectionsTopTierCollectionArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  order?: InputMaybe<Array<InputMaybe<HeroImageLinkingCollectionsTopTierCollectionOrder>>>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+};
+
+export enum HeroImageLinkingCollectionsServiceGroupCollectionOrder {
+  ServiceListNameAsc = 'serviceListName_ASC',
+  ServiceListNameDesc = 'serviceListName_DESC',
+  SubheadingAsc = 'subheading_ASC',
+  SubheadingDesc = 'subheading_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  TitleAsc = 'title_ASC',
+  TitleDesc = 'title_DESC'
+}
+
+export enum HeroImageLinkingCollectionsTopTierCollectionOrder {
+  SubheadingAsc = 'subheading_ASC',
+  SubheadingDesc = 'subheading_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  TitleAsc = 'title_ASC',
+  TitleDesc = 'title_DESC'
+}
+
 export enum HeroImageOrder {
   AltFieldAsc = 'altField_ASC',
   AltFieldDesc = 'altField_DESC',
@@ -2376,6 +2344,235 @@ export enum HeroImageOrder {
   FotogCreditDesc = 'fotogCredit_DESC',
   ImageTitleAsc = 'imageTitle_ASC',
   ImageTitleDesc = 'imageTitle_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC'
+}
+
+/** The home page for the ldaf.la.gov website [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/home) */
+export type Home = Entry & {
+  __typename?: 'Home';
+  alertMessage?: Maybe<HomeAlertMessage>;
+  alertTitle?: Maybe<Scalars['String']['output']>;
+  contentfulMetadata: ContentfulMetadata;
+  featuredServiceCardsCollection?: Maybe<HomeFeaturedServiceCardsCollection>;
+  heroVideo?: Maybe<VideoWrapper>;
+  internalTitle?: Maybe<Scalars['String']['output']>;
+  linkedFrom?: Maybe<HomeLinkingCollections>;
+  metadata?: Maybe<PageMetadata>;
+  popularResourcesListCollection?: Maybe<HomePopularResourcesListCollection>;
+  promotionalCardsCollection?: Maybe<HomePromotionalCardsCollection>;
+  sys: Sys;
+};
+
+
+/** The home page for the ldaf.la.gov website [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/home) */
+export type HomeAlertMessageArgs = {
+  locale?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** The home page for the ldaf.la.gov website [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/home) */
+export type HomeAlertTitleArgs = {
+  locale?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** The home page for the ldaf.la.gov website [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/home) */
+export type HomeFeaturedServiceCardsCollectionArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  where?: InputMaybe<ServiceEntryOrServiceGroupFilter>;
+};
+
+
+/** The home page for the ldaf.la.gov website [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/home) */
+export type HomeHeroVideoArgs = {
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  where?: InputMaybe<VideoWrapperFilter>;
+};
+
+
+/** The home page for the ldaf.la.gov website [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/home) */
+export type HomeInternalTitleArgs = {
+  locale?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** The home page for the ldaf.la.gov website [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/home) */
+export type HomeLinkedFromArgs = {
+  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+/** The home page for the ldaf.la.gov website [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/home) */
+export type HomeMetadataArgs = {
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  where?: InputMaybe<PageMetadataFilter>;
+};
+
+
+/** The home page for the ldaf.la.gov website [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/home) */
+export type HomePopularResourcesListCollectionArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  where?: InputMaybe<ServiceEntryOrServiceGroupFilter>;
+};
+
+
+/** The home page for the ldaf.la.gov website [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/home) */
+export type HomePromotionalCardsCollectionArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  order?: InputMaybe<Array<InputMaybe<HomePromotionalCardsCollectionOrder>>>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  where?: InputMaybe<PromoBannerWithCtaFilter>;
+};
+
+export type HomeAlertMessage = {
+  __typename?: 'HomeAlertMessage';
+  json: Scalars['JSON']['output'];
+  links: HomeAlertMessageLinks;
+};
+
+export type HomeAlertMessageAssets = {
+  __typename?: 'HomeAlertMessageAssets';
+  block: Array<Maybe<Asset>>;
+  hyperlink: Array<Maybe<Asset>>;
+};
+
+export type HomeAlertMessageEntries = {
+  __typename?: 'HomeAlertMessageEntries';
+  block: Array<Maybe<Entry>>;
+  hyperlink: Array<Maybe<Entry>>;
+  inline: Array<Maybe<Entry>>;
+};
+
+export type HomeAlertMessageLinks = {
+  __typename?: 'HomeAlertMessageLinks';
+  assets: HomeAlertMessageAssets;
+  entries: HomeAlertMessageEntries;
+  resources: HomeAlertMessageResources;
+};
+
+export type HomeAlertMessageResources = {
+  __typename?: 'HomeAlertMessageResources';
+  block: Array<ResourceLink>;
+};
+
+export type HomeCollection = {
+  __typename?: 'HomeCollection';
+  items: Array<Maybe<Home>>;
+  limit: Scalars['Int']['output'];
+  skip: Scalars['Int']['output'];
+  total: Scalars['Int']['output'];
+};
+
+export type HomeFeaturedServiceCardsCollection = {
+  __typename?: 'HomeFeaturedServiceCardsCollection';
+  items: Array<Maybe<HomeFeaturedServiceCardsItem>>;
+  limit: Scalars['Int']['output'];
+  skip: Scalars['Int']['output'];
+  total: Scalars['Int']['output'];
+};
+
+export type HomeFeaturedServiceCardsItem = ServiceEntry | ServiceGroup;
+
+export type HomeFilter = {
+  AND?: InputMaybe<Array<InputMaybe<HomeFilter>>>;
+  OR?: InputMaybe<Array<InputMaybe<HomeFilter>>>;
+  alertMessage_contains?: InputMaybe<Scalars['String']['input']>;
+  alertMessage_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  alertMessage_not_contains?: InputMaybe<Scalars['String']['input']>;
+  alertTitle?: InputMaybe<Scalars['String']['input']>;
+  alertTitle_contains?: InputMaybe<Scalars['String']['input']>;
+  alertTitle_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  alertTitle_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  alertTitle_not?: InputMaybe<Scalars['String']['input']>;
+  alertTitle_not_contains?: InputMaybe<Scalars['String']['input']>;
+  alertTitle_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
+  featuredServiceCards?: InputMaybe<CfServiceEntryOrServiceGroupNestedFilter>;
+  featuredServiceCardsCollection_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  heroVideo?: InputMaybe<CfVideoWrapperNestedFilter>;
+  heroVideo_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  internalTitle?: InputMaybe<Scalars['String']['input']>;
+  internalTitle_contains?: InputMaybe<Scalars['String']['input']>;
+  internalTitle_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  internalTitle_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  internalTitle_not?: InputMaybe<Scalars['String']['input']>;
+  internalTitle_not_contains?: InputMaybe<Scalars['String']['input']>;
+  internalTitle_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  metadata?: InputMaybe<CfPageMetadataNestedFilter>;
+  metadata_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  popularResourcesList?: InputMaybe<CfServiceEntryOrServiceGroupNestedFilter>;
+  popularResourcesListCollection_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  promotionalCards?: InputMaybe<CfPromoBannerWithCtaNestedFilter>;
+  promotionalCardsCollection_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  sys?: InputMaybe<SysFilter>;
+};
+
+export type HomeLinkingCollections = {
+  __typename?: 'HomeLinkingCollections';
+  entryCollection?: Maybe<EntryCollection>;
+};
+
+
+export type HomeLinkingCollectionsEntryCollectionArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+};
+
+export enum HomeOrder {
+  AlertTitleAsc = 'alertTitle_ASC',
+  AlertTitleDesc = 'alertTitle_DESC',
+  InternalTitleAsc = 'internalTitle_ASC',
+  InternalTitleDesc = 'internalTitle_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC'
+}
+
+export type HomePopularResourcesListCollection = {
+  __typename?: 'HomePopularResourcesListCollection';
+  items: Array<Maybe<HomePopularResourcesListItem>>;
+  limit: Scalars['Int']['output'];
+  skip: Scalars['Int']['output'];
+  total: Scalars['Int']['output'];
+};
+
+export type HomePopularResourcesListItem = ServiceEntry | ServiceGroup;
+
+export type HomePromotionalCardsCollection = {
+  __typename?: 'HomePromotionalCardsCollection';
+  items: Array<Maybe<PromoBannerWithCta>>;
+  limit: Scalars['Int']['output'];
+  skip: Scalars['Int']['output'];
+  total: Scalars['Int']['output'];
+};
+
+export enum HomePromotionalCardsCollectionOrder {
+  PromoInternalNameAsc = 'promoInternalName_ASC',
+  PromoInternalNameDesc = 'promoInternalName_DESC',
   SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
   SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
   SysIdAsc = 'sys_id_ASC',
@@ -2504,6 +2701,7 @@ export type ImageWrapperAltTextArgs = {
 export type ImageWrapperImageCategoryArgs = {
   locale?: InputMaybe<Scalars['String']['input']>;
   preview?: InputMaybe<Scalars['Boolean']['input']>;
+  where?: InputMaybe<CategoryFilter>;
 };
 
 
@@ -2692,7 +2890,6 @@ export type ListWithTitleFilter = {
 export type ListWithTitleLinkingCollections = {
   __typename?: 'ListWithTitleLinkingCollections';
   entryCollection?: Maybe<EntryCollection>;
-  serviceEntryCollection?: Maybe<ServiceEntryCollection>;
 };
 
 
@@ -2702,30 +2899,6 @@ export type ListWithTitleLinkingCollectionsEntryCollectionArgs = {
   preview?: InputMaybe<Scalars['Boolean']['input']>;
   skip?: InputMaybe<Scalars['Int']['input']>;
 };
-
-
-export type ListWithTitleLinkingCollectionsServiceEntryCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  order?: InputMaybe<Array<InputMaybe<ListWithTitleLinkingCollectionsServiceEntryCollectionOrder>>>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-};
-
-export enum ListWithTitleLinkingCollectionsServiceEntryCollectionOrder {
-  EntryTitleAsc = 'entryTitle_ASC',
-  EntryTitleDesc = 'entryTitle_DESC',
-  SubheadingAsc = 'subheading_ASC',
-  SubheadingDesc = 'subheading_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC'
-}
 
 export enum ListWithTitleOrder {
   CustomLabelAsc = 'customLabel_ASC',
@@ -2767,7 +2940,323 @@ export type ListWithTitleParagraphOrListLinks = {
   __typename?: 'ListWithTitleParagraphOrListLinks';
   assets: ListWithTitleParagraphOrListAssets;
   entries: ListWithTitleParagraphOrListEntries;
+  resources: ListWithTitleParagraphOrListResources;
 };
+
+export type ListWithTitleParagraphOrListResources = {
+  __typename?: 'ListWithTitleParagraphOrListResources';
+  block: Array<ResourceLink>;
+};
+
+/** Used to provide some structure to menus in the header and footer. The items in the menus in the header will be auto-generated (so this will only allow you to order the top menus, e.g. Animals, then Plants and crops, etc.), while the items in menus in the footer should be written out as Menu Item entries. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/menu) */
+export type Menu = Entry & {
+  __typename?: 'Menu';
+  childrenCollection?: Maybe<MenuChildrenCollection>;
+  contentfulMetadata: ContentfulMetadata;
+  linkedFrom?: Maybe<MenuLinkingCollections>;
+  menuType?: Maybe<Scalars['String']['output']>;
+  sys: Sys;
+  title?: Maybe<Scalars['String']['output']>;
+};
+
+
+/** Used to provide some structure to menus in the header and footer. The items in the menus in the header will be auto-generated (so this will only allow you to order the top menus, e.g. Animals, then Plants and crops, etc.), while the items in menus in the footer should be written out as Menu Item entries. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/menu) */
+export type MenuChildrenCollectionArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  where?: InputMaybe<MenuOrMenuItemOrTopTierFilter>;
+};
+
+
+/** Used to provide some structure to menus in the header and footer. The items in the menus in the header will be auto-generated (so this will only allow you to order the top menus, e.g. Animals, then Plants and crops, etc.), while the items in menus in the footer should be written out as Menu Item entries. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/menu) */
+export type MenuLinkedFromArgs = {
+  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+/** Used to provide some structure to menus in the header and footer. The items in the menus in the header will be auto-generated (so this will only allow you to order the top menus, e.g. Animals, then Plants and crops, etc.), while the items in menus in the footer should be written out as Menu Item entries. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/menu) */
+export type MenuMenuTypeArgs = {
+  locale?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** Used to provide some structure to menus in the header and footer. The items in the menus in the header will be auto-generated (so this will only allow you to order the top menus, e.g. Animals, then Plants and crops, etc.), while the items in menus in the footer should be written out as Menu Item entries. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/menu) */
+export type MenuTitleArgs = {
+  locale?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type MenuChildrenCollection = {
+  __typename?: 'MenuChildrenCollection';
+  items: Array<Maybe<MenuChildrenItem>>;
+  limit: Scalars['Int']['output'];
+  skip: Scalars['Int']['output'];
+  total: Scalars['Int']['output'];
+};
+
+export type MenuChildrenItem = Menu | MenuItem | TopTier;
+
+export type MenuCollection = {
+  __typename?: 'MenuCollection';
+  items: Array<Maybe<Menu>>;
+  limit: Scalars['Int']['output'];
+  skip: Scalars['Int']['output'];
+  total: Scalars['Int']['output'];
+};
+
+export type MenuFilter = {
+  AND?: InputMaybe<Array<InputMaybe<MenuFilter>>>;
+  OR?: InputMaybe<Array<InputMaybe<MenuFilter>>>;
+  children?: InputMaybe<CfMenuOrMenuItemOrTopTierNestedFilter>;
+  childrenCollection_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
+  menuType?: InputMaybe<Scalars['String']['input']>;
+  menuType_contains?: InputMaybe<Scalars['String']['input']>;
+  menuType_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  menuType_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  menuType_not?: InputMaybe<Scalars['String']['input']>;
+  menuType_not_contains?: InputMaybe<Scalars['String']['input']>;
+  menuType_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  sys?: InputMaybe<SysFilter>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  title_contains?: InputMaybe<Scalars['String']['input']>;
+  title_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  title_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  title_not?: InputMaybe<Scalars['String']['input']>;
+  title_not_contains?: InputMaybe<Scalars['String']['input']>;
+  title_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+/** A single internal or external link to be included in a Menu. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/menuItem) */
+export type MenuItem = Entry & {
+  __typename?: 'MenuItem';
+  contentfulMetadata: ContentfulMetadata;
+  externalLink?: Maybe<Scalars['String']['output']>;
+  internalLink?: Maybe<PageMetadata>;
+  linkedFrom?: Maybe<MenuItemLinkingCollections>;
+  sys: Sys;
+  title?: Maybe<Scalars['String']['output']>;
+};
+
+
+/** A single internal or external link to be included in a Menu. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/menuItem) */
+export type MenuItemExternalLinkArgs = {
+  locale?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** A single internal or external link to be included in a Menu. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/menuItem) */
+export type MenuItemInternalLinkArgs = {
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  where?: InputMaybe<PageMetadataFilter>;
+};
+
+
+/** A single internal or external link to be included in a Menu. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/menuItem) */
+export type MenuItemLinkedFromArgs = {
+  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+/** A single internal or external link to be included in a Menu. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/menuItem) */
+export type MenuItemTitleArgs = {
+  locale?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type MenuItemCollection = {
+  __typename?: 'MenuItemCollection';
+  items: Array<Maybe<MenuItem>>;
+  limit: Scalars['Int']['output'];
+  skip: Scalars['Int']['output'];
+  total: Scalars['Int']['output'];
+};
+
+export type MenuItemFilter = {
+  AND?: InputMaybe<Array<InputMaybe<MenuItemFilter>>>;
+  OR?: InputMaybe<Array<InputMaybe<MenuItemFilter>>>;
+  contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
+  externalLink?: InputMaybe<Scalars['String']['input']>;
+  externalLink_contains?: InputMaybe<Scalars['String']['input']>;
+  externalLink_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  externalLink_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  externalLink_not?: InputMaybe<Scalars['String']['input']>;
+  externalLink_not_contains?: InputMaybe<Scalars['String']['input']>;
+  externalLink_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  internalLink?: InputMaybe<CfPageMetadataNestedFilter>;
+  internalLink_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  sys?: InputMaybe<SysFilter>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  title_contains?: InputMaybe<Scalars['String']['input']>;
+  title_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  title_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  title_not?: InputMaybe<Scalars['String']['input']>;
+  title_not_contains?: InputMaybe<Scalars['String']['input']>;
+  title_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type MenuItemLinkingCollections = {
+  __typename?: 'MenuItemLinkingCollections';
+  entryCollection?: Maybe<EntryCollection>;
+  menuCollection?: Maybe<MenuCollection>;
+};
+
+
+export type MenuItemLinkingCollectionsEntryCollectionArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type MenuItemLinkingCollectionsMenuCollectionArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  order?: InputMaybe<Array<InputMaybe<MenuItemLinkingCollectionsMenuCollectionOrder>>>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+};
+
+export enum MenuItemLinkingCollectionsMenuCollectionOrder {
+  MenuTypeAsc = 'menuType_ASC',
+  MenuTypeDesc = 'menuType_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  TitleAsc = 'title_ASC',
+  TitleDesc = 'title_DESC'
+}
+
+export enum MenuItemOrder {
+  ExternalLinkAsc = 'externalLink_ASC',
+  ExternalLinkDesc = 'externalLink_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  TitleAsc = 'title_ASC',
+  TitleDesc = 'title_DESC'
+}
+
+export type MenuLinkingCollections = {
+  __typename?: 'MenuLinkingCollections';
+  entryCollection?: Maybe<EntryCollection>;
+  menuCollection?: Maybe<MenuCollection>;
+};
+
+
+export type MenuLinkingCollectionsEntryCollectionArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type MenuLinkingCollectionsMenuCollectionArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  order?: InputMaybe<Array<InputMaybe<MenuLinkingCollectionsMenuCollectionOrder>>>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+};
+
+export enum MenuLinkingCollectionsMenuCollectionOrder {
+  MenuTypeAsc = 'menuType_ASC',
+  MenuTypeDesc = 'menuType_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  TitleAsc = 'title_ASC',
+  TitleDesc = 'title_DESC'
+}
+
+/** [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/menuOrMenuItemOrTopTier) */
+export type MenuOrMenuItemOrTopTier = Entry & {
+  __typename?: 'MenuOrMenuItemOrTopTier';
+  contentfulMetadata: ContentfulMetadata;
+  linkedFrom?: Maybe<MenuOrMenuItemOrTopTierLinkingCollections>;
+  sys: Sys;
+  title?: Maybe<Scalars['String']['output']>;
+};
+
+
+/** [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/menuOrMenuItemOrTopTier) */
+export type MenuOrMenuItemOrTopTierLinkedFromArgs = {
+  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+/** [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/menuOrMenuItemOrTopTier) */
+export type MenuOrMenuItemOrTopTierTitleArgs = {
+  locale?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type MenuOrMenuItemOrTopTierCollection = {
+  __typename?: 'MenuOrMenuItemOrTopTierCollection';
+  items: Array<Maybe<MenuOrMenuItemOrTopTier>>;
+  limit: Scalars['Int']['output'];
+  skip: Scalars['Int']['output'];
+  total: Scalars['Int']['output'];
+};
+
+export type MenuOrMenuItemOrTopTierFilter = {
+  AND?: InputMaybe<Array<InputMaybe<MenuOrMenuItemOrTopTierFilter>>>;
+  OR?: InputMaybe<Array<InputMaybe<MenuOrMenuItemOrTopTierFilter>>>;
+  contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
+  sys?: InputMaybe<SysFilter>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  title_contains?: InputMaybe<Scalars['String']['input']>;
+  title_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  title_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  title_not?: InputMaybe<Scalars['String']['input']>;
+  title_not_contains?: InputMaybe<Scalars['String']['input']>;
+  title_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type MenuOrMenuItemOrTopTierLinkingCollections = {
+  __typename?: 'MenuOrMenuItemOrTopTierLinkingCollections';
+  entryCollection?: Maybe<EntryCollection>;
+};
+
+
+export type MenuOrMenuItemOrTopTierLinkingCollectionsEntryCollectionArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+};
+
+export enum MenuOrder {
+  MenuTypeAsc = 'menuType_ASC',
+  MenuTypeDesc = 'menuType_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  TitleAsc = 'title_ASC',
+  TitleDesc = 'title_DESC'
+}
 
 /** Overview pages for LDAF offices. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/officePage) */
 export type OfficePage = Entry & {
@@ -2777,7 +3266,7 @@ export type OfficePage = Entry & {
   description?: Maybe<OfficePageDescription>;
   linkedFrom?: Maybe<OfficePageLinkingCollections>;
   mailingAddress?: Maybe<ContentTypeLocation>;
-  metadata?: Maybe<PageMetadata>;
+  pageMetadata?: Maybe<PageMetadata>;
   pageTitle?: Maybe<Scalars['String']['output']>;
   servicesAndPrograms?: Maybe<OfficePageServicesAndPrograms>;
   subheading?: Maybe<Scalars['String']['output']>;
@@ -2812,13 +3301,15 @@ export type OfficePageLinkedFromArgs = {
 export type OfficePageMailingAddressArgs = {
   locale?: InputMaybe<Scalars['String']['input']>;
   preview?: InputMaybe<Scalars['Boolean']['input']>;
+  where?: InputMaybe<ContentTypeLocationFilter>;
 };
 
 
 /** Overview pages for LDAF offices. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/officePage) */
-export type OfficePageMetadataArgs = {
+export type OfficePagePageMetadataArgs = {
   locale?: InputMaybe<Scalars['String']['input']>;
   preview?: InputMaybe<Scalars['Boolean']['input']>;
+  where?: InputMaybe<PageMetadataFilter>;
 };
 
 
@@ -2897,6 +3388,12 @@ export type OfficePageDescriptionLinks = {
   __typename?: 'OfficePageDescriptionLinks';
   assets: OfficePageDescriptionAssets;
   entries: OfficePageDescriptionEntries;
+  resources: OfficePageDescriptionResources;
+};
+
+export type OfficePageDescriptionResources = {
+  __typename?: 'OfficePageDescriptionResources';
+  block: Array<ResourceLink>;
 };
 
 export type OfficePageFilter = {
@@ -2910,8 +3407,8 @@ export type OfficePageFilter = {
   description_not_contains?: InputMaybe<Scalars['String']['input']>;
   mailingAddress?: InputMaybe<CfContentTypeLocationNestedFilter>;
   mailingAddress_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  metadata?: InputMaybe<CfPageMetadataNestedFilter>;
-  metadata_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  pageMetadata?: InputMaybe<CfPageMetadataNestedFilter>;
+  pageMetadata_exists?: InputMaybe<Scalars['Boolean']['input']>;
   pageTitle?: InputMaybe<Scalars['String']['input']>;
   pageTitle_contains?: InputMaybe<Scalars['String']['input']>;
   pageTitle_exists?: InputMaybe<Scalars['Boolean']['input']>;
@@ -2983,47 +3480,85 @@ export type OfficePageServicesAndProgramsLinks = {
   __typename?: 'OfficePageServicesAndProgramsLinks';
   assets: OfficePageServicesAndProgramsAssets;
   entries: OfficePageServicesAndProgramsEntries;
+  resources: OfficePageServicesAndProgramsResources;
 };
 
-/** Metadata about a page for setting the URL and for helping with SEO (search engine optimization). [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/pageMetadata) */
+export type OfficePageServicesAndProgramsResources = {
+  __typename?: 'OfficePageServicesAndProgramsResources';
+  block: Array<ResourceLink>;
+};
+
+/** Metadata about a page for setting its URL, for linking to it from menus and other pages, and for setting up a redirect. Also contains additional fields for improving SEO (search engine optimization). A page will not appear on the site unless it has a corresponding Page metadata entry. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/pageMetadata) */
 export type PageMetadata = Entry & {
   __typename?: 'PageMetadata';
   contentfulMetadata: ContentfulMetadata;
-  internalTitle?: Maybe<Scalars['String']['output']>;
+  externalRedirect?: Maybe<Scalars['String']['output']>;
+  internalRedirect?: Maybe<PageMetadata>;
+  isRoot?: Maybe<Scalars['Boolean']['output']>;
   linkedFrom?: Maybe<PageMetadataLinkingCollections>;
   metaDescription?: Maybe<Scalars['String']['output']>;
   metaTitle?: Maybe<Scalars['String']['output']>;
+  parent?: Maybe<PageMetadata>;
   slug?: Maybe<Scalars['String']['output']>;
   sys: Sys;
+  title?: Maybe<Scalars['String']['output']>;
 };
 
 
-/** Metadata about a page for setting the URL and for helping with SEO (search engine optimization). [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/pageMetadata) */
-export type PageMetadataInternalTitleArgs = {
+/** Metadata about a page for setting its URL, for linking to it from menus and other pages, and for setting up a redirect. Also contains additional fields for improving SEO (search engine optimization). A page will not appear on the site unless it has a corresponding Page metadata entry. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/pageMetadata) */
+export type PageMetadataExternalRedirectArgs = {
   locale?: InputMaybe<Scalars['String']['input']>;
 };
 
 
-/** Metadata about a page for setting the URL and for helping with SEO (search engine optimization). [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/pageMetadata) */
+/** Metadata about a page for setting its URL, for linking to it from menus and other pages, and for setting up a redirect. Also contains additional fields for improving SEO (search engine optimization). A page will not appear on the site unless it has a corresponding Page metadata entry. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/pageMetadata) */
+export type PageMetadataInternalRedirectArgs = {
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  where?: InputMaybe<PageMetadataFilter>;
+};
+
+
+/** Metadata about a page for setting its URL, for linking to it from menus and other pages, and for setting up a redirect. Also contains additional fields for improving SEO (search engine optimization). A page will not appear on the site unless it has a corresponding Page metadata entry. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/pageMetadata) */
+export type PageMetadataIsRootArgs = {
+  locale?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** Metadata about a page for setting its URL, for linking to it from menus and other pages, and for setting up a redirect. Also contains additional fields for improving SEO (search engine optimization). A page will not appear on the site unless it has a corresponding Page metadata entry. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/pageMetadata) */
 export type PageMetadataLinkedFromArgs = {
   allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
 
 
-/** Metadata about a page for setting the URL and for helping with SEO (search engine optimization). [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/pageMetadata) */
+/** Metadata about a page for setting its URL, for linking to it from menus and other pages, and for setting up a redirect. Also contains additional fields for improving SEO (search engine optimization). A page will not appear on the site unless it has a corresponding Page metadata entry. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/pageMetadata) */
 export type PageMetadataMetaDescriptionArgs = {
   locale?: InputMaybe<Scalars['String']['input']>;
 };
 
 
-/** Metadata about a page for setting the URL and for helping with SEO (search engine optimization). [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/pageMetadata) */
+/** Metadata about a page for setting its URL, for linking to it from menus and other pages, and for setting up a redirect. Also contains additional fields for improving SEO (search engine optimization). A page will not appear on the site unless it has a corresponding Page metadata entry. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/pageMetadata) */
 export type PageMetadataMetaTitleArgs = {
   locale?: InputMaybe<Scalars['String']['input']>;
 };
 
 
-/** Metadata about a page for setting the URL and for helping with SEO (search engine optimization). [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/pageMetadata) */
+/** Metadata about a page for setting its URL, for linking to it from menus and other pages, and for setting up a redirect. Also contains additional fields for improving SEO (search engine optimization). A page will not appear on the site unless it has a corresponding Page metadata entry. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/pageMetadata) */
+export type PageMetadataParentArgs = {
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  where?: InputMaybe<PageMetadataFilter>;
+};
+
+
+/** Metadata about a page for setting its URL, for linking to it from menus and other pages, and for setting up a redirect. Also contains additional fields for improving SEO (search engine optimization). A page will not appear on the site unless it has a corresponding Page metadata entry. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/pageMetadata) */
 export type PageMetadataSlugArgs = {
+  locale?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** Metadata about a page for setting its URL, for linking to it from menus and other pages, and for setting up a redirect. Also contains additional fields for improving SEO (search engine optimization). A page will not appear on the site unless it has a corresponding Page metadata entry. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/pageMetadata) */
+export type PageMetadataTitleArgs = {
   locale?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -3039,13 +3574,18 @@ export type PageMetadataFilter = {
   AND?: InputMaybe<Array<InputMaybe<PageMetadataFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<PageMetadataFilter>>>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
-  internalTitle?: InputMaybe<Scalars['String']['input']>;
-  internalTitle_contains?: InputMaybe<Scalars['String']['input']>;
-  internalTitle_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  internalTitle_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  internalTitle_not?: InputMaybe<Scalars['String']['input']>;
-  internalTitle_not_contains?: InputMaybe<Scalars['String']['input']>;
-  internalTitle_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  externalRedirect?: InputMaybe<Scalars['String']['input']>;
+  externalRedirect_contains?: InputMaybe<Scalars['String']['input']>;
+  externalRedirect_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  externalRedirect_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  externalRedirect_not?: InputMaybe<Scalars['String']['input']>;
+  externalRedirect_not_contains?: InputMaybe<Scalars['String']['input']>;
+  externalRedirect_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  internalRedirect?: InputMaybe<CfPageMetadataNestedFilter>;
+  internalRedirect_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  isRoot?: InputMaybe<Scalars['Boolean']['input']>;
+  isRoot_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  isRoot_not?: InputMaybe<Scalars['Boolean']['input']>;
   metaDescription?: InputMaybe<Scalars['String']['input']>;
   metaDescription_contains?: InputMaybe<Scalars['String']['input']>;
   metaDescription_exists?: InputMaybe<Scalars['Boolean']['input']>;
@@ -3060,6 +3600,8 @@ export type PageMetadataFilter = {
   metaTitle_not?: InputMaybe<Scalars['String']['input']>;
   metaTitle_not_contains?: InputMaybe<Scalars['String']['input']>;
   metaTitle_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  parent?: InputMaybe<CfPageMetadataNestedFilter>;
+  parent_exists?: InputMaybe<Scalars['Boolean']['input']>;
   slug?: InputMaybe<Scalars['String']['input']>;
   slug_contains?: InputMaybe<Scalars['String']['input']>;
   slug_exists?: InputMaybe<Scalars['Boolean']['input']>;
@@ -3068,14 +3610,24 @@ export type PageMetadataFilter = {
   slug_not_contains?: InputMaybe<Scalars['String']['input']>;
   slug_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   sys?: InputMaybe<SysFilter>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  title_contains?: InputMaybe<Scalars['String']['input']>;
+  title_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  title_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  title_not?: InputMaybe<Scalars['String']['input']>;
+  title_not_contains?: InputMaybe<Scalars['String']['input']>;
+  title_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
 
 export type PageMetadataLinkingCollections = {
   __typename?: 'PageMetadataLinkingCollections';
   boardsAndCommissionsCollection?: Maybe<BoardsAndCommissionsCollection>;
-  callToActionCollection?: Maybe<CallToActionCollection>;
   entryCollection?: Maybe<EntryCollection>;
+  homeCollection?: Maybe<HomeCollection>;
+  menuItemCollection?: Maybe<MenuItemCollection>;
   officePageCollection?: Maybe<OfficePageCollection>;
+  pageMetadataCollection?: Maybe<PageMetadataCollection>;
+  serviceGroupCollection?: Maybe<ServiceGroupCollection>;
   topTierCollection?: Maybe<TopTierCollection>;
 };
 
@@ -3089,18 +3641,27 @@ export type PageMetadataLinkingCollectionsBoardsAndCommissionsCollectionArgs = {
 };
 
 
-export type PageMetadataLinkingCollectionsCallToActionCollectionArgs = {
+export type PageMetadataLinkingCollectionsEntryCollectionArgs = {
   limit?: InputMaybe<Scalars['Int']['input']>;
   locale?: InputMaybe<Scalars['String']['input']>;
-  order?: InputMaybe<Array<InputMaybe<PageMetadataLinkingCollectionsCallToActionCollectionOrder>>>;
   preview?: InputMaybe<Scalars['Boolean']['input']>;
   skip?: InputMaybe<Scalars['Int']['input']>;
 };
 
 
-export type PageMetadataLinkingCollectionsEntryCollectionArgs = {
+export type PageMetadataLinkingCollectionsHomeCollectionArgs = {
   limit?: InputMaybe<Scalars['Int']['input']>;
   locale?: InputMaybe<Scalars['String']['input']>;
+  order?: InputMaybe<Array<InputMaybe<PageMetadataLinkingCollectionsHomeCollectionOrder>>>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type PageMetadataLinkingCollectionsMenuItemCollectionArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  order?: InputMaybe<Array<InputMaybe<PageMetadataLinkingCollectionsMenuItemCollectionOrder>>>;
   preview?: InputMaybe<Scalars['Boolean']['input']>;
   skip?: InputMaybe<Scalars['Int']['input']>;
 };
@@ -3110,6 +3671,24 @@ export type PageMetadataLinkingCollectionsOfficePageCollectionArgs = {
   limit?: InputMaybe<Scalars['Int']['input']>;
   locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<PageMetadataLinkingCollectionsOfficePageCollectionOrder>>>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type PageMetadataLinkingCollectionsPageMetadataCollectionArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  order?: InputMaybe<Array<InputMaybe<PageMetadataLinkingCollectionsPageMetadataCollectionOrder>>>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type PageMetadataLinkingCollectionsServiceGroupCollectionArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  order?: InputMaybe<Array<InputMaybe<PageMetadataLinkingCollectionsServiceGroupCollectionOrder>>>;
   preview?: InputMaybe<Scalars['Boolean']['input']>;
   skip?: InputMaybe<Scalars['Int']['input']>;
 };
@@ -3138,21 +3717,11 @@ export enum PageMetadataLinkingCollectionsBoardsAndCommissionsCollectionOrder {
   TitleDesc = 'title_DESC'
 }
 
-export enum PageMetadataLinkingCollectionsCallToActionCollectionOrder {
-  CallToActionMessageAsc = 'callToActionMessage_ASC',
-  CallToActionMessageDesc = 'callToActionMessage_DESC',
-  CtaInternalNameAsc = 'ctaInternalName_ASC',
-  CtaInternalNameDesc = 'ctaInternalName_DESC',
-  CtaNameAsc = 'ctaName_ASC',
-  CtaNameDesc = 'ctaName_DESC',
-  CtaTypeAsc = 'ctaType_ASC',
-  CtaTypeDesc = 'ctaType_DESC',
-  InternalOrExternalAsc = 'internalOrExternal_ASC',
-  InternalOrExternalDesc = 'internalOrExternal_DESC',
-  LinkTextAsc = 'linkText_ASC',
-  LinkTextDesc = 'linkText_DESC',
-  PhoneNumberCtaAsc = 'phoneNumberCta_ASC',
-  PhoneNumberCtaDesc = 'phoneNumberCta_DESC',
+export enum PageMetadataLinkingCollectionsHomeCollectionOrder {
+  AlertTitleAsc = 'alertTitle_ASC',
+  AlertTitleDesc = 'alertTitle_DESC',
+  InternalTitleAsc = 'internalTitle_ASC',
+  InternalTitleDesc = 'internalTitle_DESC',
   SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
   SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
   SysIdAsc = 'sys_id_ASC',
@@ -3161,6 +3730,21 @@ export enum PageMetadataLinkingCollectionsCallToActionCollectionOrder {
   SysPublishedAtDesc = 'sys_publishedAt_DESC',
   SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
   SysPublishedVersionDesc = 'sys_publishedVersion_DESC'
+}
+
+export enum PageMetadataLinkingCollectionsMenuItemCollectionOrder {
+  ExternalLinkAsc = 'externalLink_ASC',
+  ExternalLinkDesc = 'externalLink_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  TitleAsc = 'title_ASC',
+  TitleDesc = 'title_DESC'
 }
 
 export enum PageMetadataLinkingCollectionsOfficePageCollectionOrder {
@@ -3176,6 +3760,44 @@ export enum PageMetadataLinkingCollectionsOfficePageCollectionOrder {
   SysPublishedAtDesc = 'sys_publishedAt_DESC',
   SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
   SysPublishedVersionDesc = 'sys_publishedVersion_DESC'
+}
+
+export enum PageMetadataLinkingCollectionsPageMetadataCollectionOrder {
+  ExternalRedirectAsc = 'externalRedirect_ASC',
+  ExternalRedirectDesc = 'externalRedirect_DESC',
+  IsRootAsc = 'isRoot_ASC',
+  IsRootDesc = 'isRoot_DESC',
+  MetaTitleAsc = 'metaTitle_ASC',
+  MetaTitleDesc = 'metaTitle_DESC',
+  SlugAsc = 'slug_ASC',
+  SlugDesc = 'slug_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  TitleAsc = 'title_ASC',
+  TitleDesc = 'title_DESC'
+}
+
+export enum PageMetadataLinkingCollectionsServiceGroupCollectionOrder {
+  ServiceListNameAsc = 'serviceListName_ASC',
+  ServiceListNameDesc = 'serviceListName_DESC',
+  SubheadingAsc = 'subheading_ASC',
+  SubheadingDesc = 'subheading_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  TitleAsc = 'title_ASC',
+  TitleDesc = 'title_DESC'
 }
 
 export enum PageMetadataLinkingCollectionsTopTierCollectionOrder {
@@ -3194,8 +3816,10 @@ export enum PageMetadataLinkingCollectionsTopTierCollectionOrder {
 }
 
 export enum PageMetadataOrder {
-  InternalTitleAsc = 'internalTitle_ASC',
-  InternalTitleDesc = 'internalTitle_DESC',
+  ExternalRedirectAsc = 'externalRedirect_ASC',
+  ExternalRedirectDesc = 'externalRedirect_DESC',
+  IsRootAsc = 'isRoot_ASC',
+  IsRootDesc = 'isRoot_DESC',
   MetaTitleAsc = 'metaTitle_ASC',
   MetaTitleDesc = 'metaTitle_DESC',
   SlugAsc = 'slug_ASC',
@@ -3207,7 +3831,9 @@ export enum PageMetadataOrder {
   SysPublishedAtAsc = 'sys_publishedAt_ASC',
   SysPublishedAtDesc = 'sys_publishedAt_DESC',
   SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC'
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  TitleAsc = 'title_ASC',
+  TitleDesc = 'title_DESC'
 }
 
 /** Mostly for the front page. Designed for large clickable images. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/promoBannerWithCta) */
@@ -3244,6 +3870,7 @@ export type PromoBannerWithCtaPromoCategoryCollectionArgs = {
 export type PromoBannerWithCtaPromoCtaArgs = {
   locale?: InputMaybe<Scalars['String']['input']>;
   preview?: InputMaybe<Scalars['Boolean']['input']>;
+  where?: InputMaybe<CallToActionFilter>;
 };
 
 
@@ -3251,6 +3878,7 @@ export type PromoBannerWithCtaPromoCtaArgs = {
 export type PromoBannerWithCtaPromoHeroImageArgs = {
   locale?: InputMaybe<Scalars['String']['input']>;
   preview?: InputMaybe<Scalars['Boolean']['input']>;
+  where?: InputMaybe<ImageWrapperFilter>;
 };
 
 
@@ -3290,6 +3918,7 @@ export type PromoBannerWithCtaFilter = {
 export type PromoBannerWithCtaLinkingCollections = {
   __typename?: 'PromoBannerWithCtaLinkingCollections';
   entryCollection?: Maybe<EntryCollection>;
+  homeCollection?: Maybe<HomeCollection>;
 };
 
 
@@ -3299,6 +3928,30 @@ export type PromoBannerWithCtaLinkingCollectionsEntryCollectionArgs = {
   preview?: InputMaybe<Scalars['Boolean']['input']>;
   skip?: InputMaybe<Scalars['Int']['input']>;
 };
+
+
+export type PromoBannerWithCtaLinkingCollectionsHomeCollectionArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  order?: InputMaybe<Array<InputMaybe<PromoBannerWithCtaLinkingCollectionsHomeCollectionOrder>>>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+};
+
+export enum PromoBannerWithCtaLinkingCollectionsHomeCollectionOrder {
+  AlertTitleAsc = 'alertTitle_ASC',
+  AlertTitleDesc = 'alertTitle_DESC',
+  InternalTitleAsc = 'internalTitle_ASC',
+  InternalTitleDesc = 'internalTitle_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC'
+}
 
 export enum PromoBannerWithCtaOrder {
   PromoInternalNameAsc = 'promoInternalName_ASC',
@@ -3348,14 +4001,14 @@ export type Query = {
   categoryCollection?: Maybe<CategoryCollection>;
   contact?: Maybe<Contact>;
   contactCollection?: Maybe<ContactCollection>;
-  contentBlockHeader?: Maybe<ContentBlockHeader>;
-  contentBlockHeaderCollection?: Maybe<ContentBlockHeaderCollection>;
   contentTypeLocation?: Maybe<ContentTypeLocation>;
   contentTypeLocationCollection?: Maybe<ContentTypeLocationCollection>;
   documentWrapper?: Maybe<DocumentWrapper>;
   documentWrapperCollection?: Maybe<DocumentWrapperCollection>;
   draftNavigationLink?: Maybe<DraftNavigationLink>;
   draftNavigationLinkCollection?: Maybe<DraftNavigationLinkCollection>;
+  draftNavigationLinkOrDraftNavigationMenu?: Maybe<DraftNavigationLinkOrDraftNavigationMenu>;
+  draftNavigationLinkOrDraftNavigationMenuCollection?: Maybe<DraftNavigationLinkOrDraftNavigationMenuCollection>;
   draftNavigationMenu?: Maybe<DraftNavigationMenu>;
   draftNavigationMenuCollection?: Maybe<DraftNavigationMenuCollection>;
   entryCollection?: Maybe<EntryCollection>;
@@ -3363,10 +4016,18 @@ export type Query = {
   eventEntryCollection?: Maybe<EventEntryCollection>;
   heroImage?: Maybe<HeroImage>;
   heroImageCollection?: Maybe<HeroImageCollection>;
+  home?: Maybe<Home>;
+  homeCollection?: Maybe<HomeCollection>;
   imageWrapper?: Maybe<ImageWrapper>;
   imageWrapperCollection?: Maybe<ImageWrapperCollection>;
   listWithTitle?: Maybe<ListWithTitle>;
   listWithTitleCollection?: Maybe<ListWithTitleCollection>;
+  menu?: Maybe<Menu>;
+  menuCollection?: Maybe<MenuCollection>;
+  menuItem?: Maybe<MenuItem>;
+  menuItemCollection?: Maybe<MenuItemCollection>;
+  menuOrMenuItemOrTopTier?: Maybe<MenuOrMenuItemOrTopTier>;
+  menuOrMenuItemOrTopTierCollection?: Maybe<MenuOrMenuItemOrTopTierCollection>;
   officePage?: Maybe<OfficePage>;
   officePageCollection?: Maybe<OfficePageCollection>;
   pageMetadata?: Maybe<PageMetadata>;
@@ -3375,6 +4036,8 @@ export type Query = {
   promoBannerWithCtaCollection?: Maybe<PromoBannerWithCtaCollection>;
   serviceEntry?: Maybe<ServiceEntry>;
   serviceEntryCollection?: Maybe<ServiceEntryCollection>;
+  serviceEntryOrServiceGroup?: Maybe<ServiceEntryOrServiceGroup>;
+  serviceEntryOrServiceGroupCollection?: Maybe<ServiceEntryOrServiceGroupCollection>;
   serviceGroup?: Maybe<ServiceGroup>;
   serviceGroupCollection?: Maybe<ServiceGroupCollection>;
   testRichText?: Maybe<TestRichText>;
@@ -3471,23 +4134,6 @@ export type QueryContactCollectionArgs = {
 };
 
 
-export type QueryContentBlockHeaderArgs = {
-  id: Scalars['String']['input'];
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-};
-
-
-export type QueryContentBlockHeaderCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  order?: InputMaybe<Array<InputMaybe<ContentBlockHeaderOrder>>>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  where?: InputMaybe<ContentBlockHeaderFilter>;
-};
-
-
 export type QueryContentTypeLocationArgs = {
   id: Scalars['String']['input'];
   locale?: InputMaybe<Scalars['String']['input']>;
@@ -3536,6 +4182,22 @@ export type QueryDraftNavigationLinkCollectionArgs = {
   preview?: InputMaybe<Scalars['Boolean']['input']>;
   skip?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<DraftNavigationLinkFilter>;
+};
+
+
+export type QueryDraftNavigationLinkOrDraftNavigationMenuArgs = {
+  id: Scalars['String']['input'];
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+
+export type QueryDraftNavigationLinkOrDraftNavigationMenuCollectionArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  where?: InputMaybe<DraftNavigationLinkOrDraftNavigationMenuFilter>;
 };
 
 
@@ -3600,6 +4262,23 @@ export type QueryHeroImageCollectionArgs = {
 };
 
 
+export type QueryHomeArgs = {
+  id: Scalars['String']['input'];
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+
+export type QueryHomeCollectionArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  order?: InputMaybe<Array<InputMaybe<HomeOrder>>>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  where?: InputMaybe<HomeFilter>;
+};
+
+
 export type QueryImageWrapperArgs = {
   id: Scalars['String']['input'];
   locale?: InputMaybe<Scalars['String']['input']>;
@@ -3631,6 +4310,56 @@ export type QueryListWithTitleCollectionArgs = {
   preview?: InputMaybe<Scalars['Boolean']['input']>;
   skip?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<ListWithTitleFilter>;
+};
+
+
+export type QueryMenuArgs = {
+  id: Scalars['String']['input'];
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+
+export type QueryMenuCollectionArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  order?: InputMaybe<Array<InputMaybe<MenuOrder>>>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  where?: InputMaybe<MenuFilter>;
+};
+
+
+export type QueryMenuItemArgs = {
+  id: Scalars['String']['input'];
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+
+export type QueryMenuItemCollectionArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  order?: InputMaybe<Array<InputMaybe<MenuItemOrder>>>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  where?: InputMaybe<MenuItemFilter>;
+};
+
+
+export type QueryMenuOrMenuItemOrTopTierArgs = {
+  id: Scalars['String']['input'];
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+
+export type QueryMenuOrMenuItemOrTopTierCollectionArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  where?: InputMaybe<MenuOrMenuItemOrTopTierFilter>;
 };
 
 
@@ -3702,6 +4431,22 @@ export type QueryServiceEntryCollectionArgs = {
 };
 
 
+export type QueryServiceEntryOrServiceGroupArgs = {
+  id: Scalars['String']['input'];
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+
+export type QueryServiceEntryOrServiceGroupCollectionArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  where?: InputMaybe<ServiceEntryOrServiceGroupFilter>;
+};
+
+
 export type QueryServiceGroupArgs = {
   id: Scalars['String']['input'];
   locale?: InputMaybe<Scalars['String']['input']>;
@@ -3769,7 +4514,19 @@ export type QueryVideoWrapperCollectionArgs = {
   where?: InputMaybe<VideoWrapperFilter>;
 };
 
-/** Description of a program's task-related service [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/serviceEntry) */
+export type ResourceLink = {
+  __typename?: 'ResourceLink';
+  sys: ResourceSys;
+};
+
+export type ResourceSys = {
+  __typename?: 'ResourceSys';
+  linkType: Scalars['String']['output'];
+  type: Scalars['String']['output'];
+  urn: Scalars['String']['output'];
+};
+
+/** Service content that will show up as an accordion on a service group page. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/serviceEntry) */
 export type ServiceEntry = Entry & {
   __typename?: 'ServiceEntry';
   contactInformationCollection?: Maybe<ServiceEntryContactInformationCollection>;
@@ -3778,36 +4535,36 @@ export type ServiceEntry = Entry & {
   entryTitle?: Maybe<Scalars['String']['output']>;
   linkedDocumentCollection?: Maybe<ServiceEntryLinkedDocumentCollection>;
   linkedFrom?: Maybe<ServiceEntryLinkingCollections>;
-  serviceCategoryCollection?: Maybe<ServiceEntryServiceCategoryCollection>;
   serviceCtaCollection?: Maybe<ServiceEntryServiceCtaCollection>;
-  serviceDescriptionsCollection?: Maybe<ServiceEntryServiceDescriptionsCollection>;
   subheading?: Maybe<Scalars['String']['output']>;
   sys: Sys;
 };
 
 
-/** Description of a program's task-related service [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/serviceEntry) */
+/** Service content that will show up as an accordion on a service group page. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/serviceEntry) */
 export type ServiceEntryContactInformationCollectionArgs = {
   limit?: InputMaybe<Scalars['Int']['input']>;
   locale?: InputMaybe<Scalars['String']['input']>;
+  order?: InputMaybe<Array<InputMaybe<ServiceEntryContactInformationCollectionOrder>>>;
   preview?: InputMaybe<Scalars['Boolean']['input']>;
   skip?: InputMaybe<Scalars['Int']['input']>;
+  where?: InputMaybe<ContactFilter>;
 };
 
 
-/** Description of a program's task-related service [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/serviceEntry) */
+/** Service content that will show up as an accordion on a service group page. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/serviceEntry) */
 export type ServiceEntryDescriptionArgs = {
   locale?: InputMaybe<Scalars['String']['input']>;
 };
 
 
-/** Description of a program's task-related service [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/serviceEntry) */
+/** Service content that will show up as an accordion on a service group page. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/serviceEntry) */
 export type ServiceEntryEntryTitleArgs = {
   locale?: InputMaybe<Scalars['String']['input']>;
 };
 
 
-/** Description of a program's task-related service [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/serviceEntry) */
+/** Service content that will show up as an accordion on a service group page. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/serviceEntry) */
 export type ServiceEntryLinkedDocumentCollectionArgs = {
   limit?: InputMaybe<Scalars['Int']['input']>;
   locale?: InputMaybe<Scalars['String']['input']>;
@@ -3818,24 +4575,13 @@ export type ServiceEntryLinkedDocumentCollectionArgs = {
 };
 
 
-/** Description of a program's task-related service [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/serviceEntry) */
+/** Service content that will show up as an accordion on a service group page. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/serviceEntry) */
 export type ServiceEntryLinkedFromArgs = {
   allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
 
 
-/** Description of a program's task-related service [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/serviceEntry) */
-export type ServiceEntryServiceCategoryCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  order?: InputMaybe<Array<InputMaybe<ServiceEntryServiceCategoryCollectionOrder>>>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  where?: InputMaybe<CategoryFilter>;
-};
-
-
-/** Description of a program's task-related service [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/serviceEntry) */
+/** Service content that will show up as an accordion on a service group page. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/serviceEntry) */
 export type ServiceEntryServiceCtaCollectionArgs = {
   limit?: InputMaybe<Scalars['Int']['input']>;
   locale?: InputMaybe<Scalars['String']['input']>;
@@ -3846,18 +4592,7 @@ export type ServiceEntryServiceCtaCollectionArgs = {
 };
 
 
-/** Description of a program's task-related service [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/serviceEntry) */
-export type ServiceEntryServiceDescriptionsCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  order?: InputMaybe<Array<InputMaybe<ServiceEntryServiceDescriptionsCollectionOrder>>>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  where?: InputMaybe<ListWithTitleFilter>;
-};
-
-
-/** Description of a program's task-related service [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/serviceEntry) */
+/** Service content that will show up as an accordion on a service group page. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/serviceEntry) */
 export type ServiceEntrySubheadingArgs = {
   locale?: InputMaybe<Scalars['String']['input']>;
 };
@@ -3872,11 +4607,30 @@ export type ServiceEntryCollection = {
 
 export type ServiceEntryContactInformationCollection = {
   __typename?: 'ServiceEntryContactInformationCollection';
-  items: Array<Maybe<Entry>>;
+  items: Array<Maybe<Contact>>;
   limit: Scalars['Int']['output'];
   skip: Scalars['Int']['output'];
   total: Scalars['Int']['output'];
 };
+
+export enum ServiceEntryContactInformationCollectionOrder {
+  EmailAsc = 'email_ASC',
+  EmailDesc = 'email_DESC',
+  EntityNameAsc = 'entityName_ASC',
+  EntityNameDesc = 'entityName_DESC',
+  PhoneExtAsc = 'phoneExt_ASC',
+  PhoneExtDesc = 'phoneExt_DESC',
+  PhoneAsc = 'phone_ASC',
+  PhoneDesc = 'phone_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC'
+}
 
 export type ServiceEntryDescription = {
   __typename?: 'ServiceEntryDescription';
@@ -3901,11 +4655,18 @@ export type ServiceEntryDescriptionLinks = {
   __typename?: 'ServiceEntryDescriptionLinks';
   assets: ServiceEntryDescriptionAssets;
   entries: ServiceEntryDescriptionEntries;
+  resources: ServiceEntryDescriptionResources;
+};
+
+export type ServiceEntryDescriptionResources = {
+  __typename?: 'ServiceEntryDescriptionResources';
+  block: Array<ResourceLink>;
 };
 
 export type ServiceEntryFilter = {
   AND?: InputMaybe<Array<InputMaybe<ServiceEntryFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<ServiceEntryFilter>>>;
+  contactInformation?: InputMaybe<CfContactNestedFilter>;
   contactInformationCollection_exists?: InputMaybe<Scalars['Boolean']['input']>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
   description_contains?: InputMaybe<Scalars['String']['input']>;
@@ -3920,12 +4681,8 @@ export type ServiceEntryFilter = {
   entryTitle_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   linkedDocument?: InputMaybe<CfDocumentWrapperNestedFilter>;
   linkedDocumentCollection_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  serviceCategory?: InputMaybe<CfCategoryNestedFilter>;
-  serviceCategoryCollection_exists?: InputMaybe<Scalars['Boolean']['input']>;
   serviceCta?: InputMaybe<CfCallToActionNestedFilter>;
   serviceCtaCollection_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  serviceDescriptions?: InputMaybe<CfListWithTitleNestedFilter>;
-  serviceDescriptionsCollection_exists?: InputMaybe<Scalars['Boolean']['input']>;
   subheading?: InputMaybe<Scalars['String']['input']>;
   subheading_contains?: InputMaybe<Scalars['String']['input']>;
   subheading_exists?: InputMaybe<Scalars['Boolean']['input']>;
@@ -3960,14 +4717,23 @@ export enum ServiceEntryLinkedDocumentCollectionOrder {
 export type ServiceEntryLinkingCollections = {
   __typename?: 'ServiceEntryLinkingCollections';
   entryCollection?: Maybe<EntryCollection>;
+  homeCollection?: Maybe<HomeCollection>;
   serviceGroupCollection?: Maybe<ServiceGroupCollection>;
-  topTierCollection?: Maybe<TopTierCollection>;
 };
 
 
 export type ServiceEntryLinkingCollectionsEntryCollectionArgs = {
   limit?: InputMaybe<Scalars['Int']['input']>;
   locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type ServiceEntryLinkingCollectionsHomeCollectionArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  order?: InputMaybe<Array<InputMaybe<ServiceEntryLinkingCollectionsHomeCollectionOrder>>>;
   preview?: InputMaybe<Scalars['Boolean']['input']>;
   skip?: InputMaybe<Scalars['Int']['input']>;
 };
@@ -3981,14 +4747,20 @@ export type ServiceEntryLinkingCollectionsServiceGroupCollectionArgs = {
   skip?: InputMaybe<Scalars['Int']['input']>;
 };
 
-
-export type ServiceEntryLinkingCollectionsTopTierCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  order?: InputMaybe<Array<InputMaybe<ServiceEntryLinkingCollectionsTopTierCollectionOrder>>>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-};
+export enum ServiceEntryLinkingCollectionsHomeCollectionOrder {
+  AlertTitleAsc = 'alertTitle_ASC',
+  AlertTitleDesc = 'alertTitle_DESC',
+  InternalTitleAsc = 'internalTitle_ASC',
+  InternalTitleDesc = 'internalTitle_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC'
+}
 
 export enum ServiceEntryLinkingCollectionsServiceGroupCollectionOrder {
   ServiceListNameAsc = 'serviceListName_ASC',
@@ -4007,49 +4779,108 @@ export enum ServiceEntryLinkingCollectionsServiceGroupCollectionOrder {
   TitleDesc = 'title_DESC'
 }
 
-export enum ServiceEntryLinkingCollectionsTopTierCollectionOrder {
-  SubheadingAsc = 'subheading_ASC',
-  SubheadingDesc = 'subheading_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
-  TitleAsc = 'title_ASC',
-  TitleDesc = 'title_DESC'
-}
+/** [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/serviceEntryOrServiceGroup) */
+export type ServiceEntryOrServiceGroup = Entry & {
+  __typename?: 'ServiceEntryOrServiceGroup';
+  contentfulMetadata: ContentfulMetadata;
+  description?: Maybe<ServiceEntryOrServiceGroupDescription>;
+  linkedFrom?: Maybe<ServiceEntryOrServiceGroupLinkingCollections>;
+  subheading?: Maybe<Scalars['String']['output']>;
+  sys: Sys;
+};
+
+
+/** [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/serviceEntryOrServiceGroup) */
+export type ServiceEntryOrServiceGroupDescriptionArgs = {
+  locale?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/serviceEntryOrServiceGroup) */
+export type ServiceEntryOrServiceGroupLinkedFromArgs = {
+  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+/** [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/serviceEntryOrServiceGroup) */
+export type ServiceEntryOrServiceGroupSubheadingArgs = {
+  locale?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type ServiceEntryOrServiceGroupCollection = {
+  __typename?: 'ServiceEntryOrServiceGroupCollection';
+  items: Array<Maybe<ServiceEntryOrServiceGroup>>;
+  limit: Scalars['Int']['output'];
+  skip: Scalars['Int']['output'];
+  total: Scalars['Int']['output'];
+};
+
+export type ServiceEntryOrServiceGroupDescription = {
+  __typename?: 'ServiceEntryOrServiceGroupDescription';
+  json: Scalars['JSON']['output'];
+  links: ServiceEntryOrServiceGroupDescriptionLinks;
+};
+
+export type ServiceEntryOrServiceGroupDescriptionAssets = {
+  __typename?: 'ServiceEntryOrServiceGroupDescriptionAssets';
+  block: Array<Maybe<Asset>>;
+  hyperlink: Array<Maybe<Asset>>;
+};
+
+export type ServiceEntryOrServiceGroupDescriptionEntries = {
+  __typename?: 'ServiceEntryOrServiceGroupDescriptionEntries';
+  block: Array<Maybe<Entry>>;
+  hyperlink: Array<Maybe<Entry>>;
+  inline: Array<Maybe<Entry>>;
+};
+
+export type ServiceEntryOrServiceGroupDescriptionLinks = {
+  __typename?: 'ServiceEntryOrServiceGroupDescriptionLinks';
+  assets: ServiceEntryOrServiceGroupDescriptionAssets;
+  entries: ServiceEntryOrServiceGroupDescriptionEntries;
+  resources: ServiceEntryOrServiceGroupDescriptionResources;
+};
+
+export type ServiceEntryOrServiceGroupDescriptionResources = {
+  __typename?: 'ServiceEntryOrServiceGroupDescriptionResources';
+  block: Array<ResourceLink>;
+};
+
+export type ServiceEntryOrServiceGroupFilter = {
+  AND?: InputMaybe<Array<InputMaybe<ServiceEntryOrServiceGroupFilter>>>;
+  OR?: InputMaybe<Array<InputMaybe<ServiceEntryOrServiceGroupFilter>>>;
+  contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
+  description_contains?: InputMaybe<Scalars['String']['input']>;
+  description_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  description_not_contains?: InputMaybe<Scalars['String']['input']>;
+  subheading?: InputMaybe<Scalars['String']['input']>;
+  subheading_contains?: InputMaybe<Scalars['String']['input']>;
+  subheading_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  subheading_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  subheading_not?: InputMaybe<Scalars['String']['input']>;
+  subheading_not_contains?: InputMaybe<Scalars['String']['input']>;
+  subheading_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  sys?: InputMaybe<SysFilter>;
+};
+
+export type ServiceEntryOrServiceGroupLinkingCollections = {
+  __typename?: 'ServiceEntryOrServiceGroupLinkingCollections';
+  entryCollection?: Maybe<EntryCollection>;
+};
+
+
+export type ServiceEntryOrServiceGroupLinkingCollectionsEntryCollectionArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+};
 
 export enum ServiceEntryOrder {
   EntryTitleAsc = 'entryTitle_ASC',
   EntryTitleDesc = 'entryTitle_DESC',
   SubheadingAsc = 'subheading_ASC',
   SubheadingDesc = 'subheading_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC'
-}
-
-export type ServiceEntryServiceCategoryCollection = {
-  __typename?: 'ServiceEntryServiceCategoryCollection';
-  items: Array<Maybe<Category>>;
-  limit: Scalars['Int']['output'];
-  skip: Scalars['Int']['output'];
-  total: Scalars['Int']['output'];
-};
-
-export enum ServiceEntryServiceCategoryCollectionOrder {
-  CategoryDescriptionAsc = 'categoryDescription_ASC',
-  CategoryDescriptionDesc = 'categoryDescription_DESC',
-  CategoryNameAsc = 'categoryName_ASC',
-  CategoryNameDesc = 'categoryName_DESC',
   SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
   SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
   SysIdAsc = 'sys_id_ASC',
@@ -4069,20 +4900,8 @@ export type ServiceEntryServiceCtaCollection = {
 };
 
 export enum ServiceEntryServiceCtaCollectionOrder {
-  CallToActionMessageAsc = 'callToActionMessage_ASC',
-  CallToActionMessageDesc = 'callToActionMessage_DESC',
   CtaInternalNameAsc = 'ctaInternalName_ASC',
   CtaInternalNameDesc = 'ctaInternalName_DESC',
-  CtaNameAsc = 'ctaName_ASC',
-  CtaNameDesc = 'ctaName_DESC',
-  CtaTypeAsc = 'ctaType_ASC',
-  CtaTypeDesc = 'ctaType_DESC',
-  InternalOrExternalAsc = 'internalOrExternal_ASC',
-  InternalOrExternalDesc = 'internalOrExternal_DESC',
-  LinkTextAsc = 'linkText_ASC',
-  LinkTextDesc = 'linkText_DESC',
-  PhoneNumberCtaAsc = 'phoneNumberCta_ASC',
-  PhoneNumberCtaDesc = 'phoneNumberCta_DESC',
   SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
   SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
   SysIdAsc = 'sys_id_ASC',
@@ -4093,41 +4912,17 @@ export enum ServiceEntryServiceCtaCollectionOrder {
   SysPublishedVersionDesc = 'sys_publishedVersion_DESC'
 }
 
-export type ServiceEntryServiceDescriptionsCollection = {
-  __typename?: 'ServiceEntryServiceDescriptionsCollection';
-  items: Array<Maybe<ListWithTitle>>;
-  limit: Scalars['Int']['output'];
-  skip: Scalars['Int']['output'];
-  total: Scalars['Int']['output'];
-};
-
-export enum ServiceEntryServiceDescriptionsCollectionOrder {
-  CustomLabelAsc = 'customLabel_ASC',
-  CustomLabelDesc = 'customLabel_DESC',
-  DropdownChoicesAsc = 'dropdownChoices_ASC',
-  DropdownChoicesDesc = 'dropdownChoices_DESC',
-  InternalTitleAsc = 'internalTitle_ASC',
-  InternalTitleDesc = 'internalTitle_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC'
-}
-
-/** Contains a group of related service entries [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/serviceGroup) */
+/** Web page that usually contains a group of service entries, but doesn't have to. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/serviceGroup) */
 export type ServiceGroup = Entry & {
   __typename?: 'ServiceGroup';
   additionalResources?: Maybe<ServiceGroupAdditionalResources>;
   contactInfoCollection?: Maybe<ServiceGroupContactInfoCollection>;
   contentfulMetadata: ContentfulMetadata;
   description?: Maybe<ServiceGroupDescription>;
+  heroImage?: Maybe<HeroImage>;
   linkedFrom?: Maybe<ServiceGroupLinkingCollections>;
+  pageMetadata?: Maybe<PageMetadata>;
   serviceEntriesCollection?: Maybe<ServiceGroupServiceEntriesCollection>;
-  serviceGroupCategoryCollection?: Maybe<ServiceGroupServiceGroupCategoryCollection>;
   serviceListName?: Maybe<Scalars['String']['output']>;
   subheading?: Maybe<Scalars['String']['output']>;
   sys: Sys;
@@ -4135,13 +4930,13 @@ export type ServiceGroup = Entry & {
 };
 
 
-/** Contains a group of related service entries [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/serviceGroup) */
+/** Web page that usually contains a group of service entries, but doesn't have to. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/serviceGroup) */
 export type ServiceGroupAdditionalResourcesArgs = {
   locale?: InputMaybe<Scalars['String']['input']>;
 };
 
 
-/** Contains a group of related service entries [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/serviceGroup) */
+/** Web page that usually contains a group of service entries, but doesn't have to. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/serviceGroup) */
 export type ServiceGroupContactInfoCollectionArgs = {
   limit?: InputMaybe<Scalars['Int']['input']>;
   locale?: InputMaybe<Scalars['String']['input']>;
@@ -4152,51 +4947,57 @@ export type ServiceGroupContactInfoCollectionArgs = {
 };
 
 
-/** Contains a group of related service entries [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/serviceGroup) */
+/** Web page that usually contains a group of service entries, but doesn't have to. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/serviceGroup) */
 export type ServiceGroupDescriptionArgs = {
   locale?: InputMaybe<Scalars['String']['input']>;
 };
 
 
-/** Contains a group of related service entries [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/serviceGroup) */
+/** Web page that usually contains a group of service entries, but doesn't have to. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/serviceGroup) */
+export type ServiceGroupHeroImageArgs = {
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  where?: InputMaybe<HeroImageFilter>;
+};
+
+
+/** Web page that usually contains a group of service entries, but doesn't have to. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/serviceGroup) */
 export type ServiceGroupLinkedFromArgs = {
   allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
 
 
-/** Contains a group of related service entries [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/serviceGroup) */
+/** Web page that usually contains a group of service entries, but doesn't have to. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/serviceGroup) */
+export type ServiceGroupPageMetadataArgs = {
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  where?: InputMaybe<PageMetadataFilter>;
+};
+
+
+/** Web page that usually contains a group of service entries, but doesn't have to. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/serviceGroup) */
 export type ServiceGroupServiceEntriesCollectionArgs = {
   limit?: InputMaybe<Scalars['Int']['input']>;
   locale?: InputMaybe<Scalars['String']['input']>;
   preview?: InputMaybe<Scalars['Boolean']['input']>;
   skip?: InputMaybe<Scalars['Int']['input']>;
+  where?: InputMaybe<ServiceEntryOrServiceGroupFilter>;
 };
 
 
-/** Contains a group of related service entries [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/serviceGroup) */
-export type ServiceGroupServiceGroupCategoryCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  order?: InputMaybe<Array<InputMaybe<ServiceGroupServiceGroupCategoryCollectionOrder>>>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  where?: InputMaybe<CategoryFilter>;
-};
-
-
-/** Contains a group of related service entries [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/serviceGroup) */
+/** Web page that usually contains a group of service entries, but doesn't have to. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/serviceGroup) */
 export type ServiceGroupServiceListNameArgs = {
   locale?: InputMaybe<Scalars['String']['input']>;
 };
 
 
-/** Contains a group of related service entries [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/serviceGroup) */
+/** Web page that usually contains a group of service entries, but doesn't have to. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/serviceGroup) */
 export type ServiceGroupSubheadingArgs = {
   locale?: InputMaybe<Scalars['String']['input']>;
 };
 
 
-/** Contains a group of related service entries [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/serviceGroup) */
+/** Web page that usually contains a group of service entries, but doesn't have to. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/serviceGroup) */
 export type ServiceGroupTitleArgs = {
   locale?: InputMaybe<Scalars['String']['input']>;
 };
@@ -4224,6 +5025,12 @@ export type ServiceGroupAdditionalResourcesLinks = {
   __typename?: 'ServiceGroupAdditionalResourcesLinks';
   assets: ServiceGroupAdditionalResourcesAssets;
   entries: ServiceGroupAdditionalResourcesEntries;
+  resources: ServiceGroupAdditionalResourcesResources;
+};
+
+export type ServiceGroupAdditionalResourcesResources = {
+  __typename?: 'ServiceGroupAdditionalResourcesResources';
+  block: Array<ResourceLink>;
 };
 
 export type ServiceGroupCollection = {
@@ -4284,6 +5091,12 @@ export type ServiceGroupDescriptionLinks = {
   __typename?: 'ServiceGroupDescriptionLinks';
   assets: ServiceGroupDescriptionAssets;
   entries: ServiceGroupDescriptionEntries;
+  resources: ServiceGroupDescriptionResources;
+};
+
+export type ServiceGroupDescriptionResources = {
+  __typename?: 'ServiceGroupDescriptionResources';
+  block: Array<ResourceLink>;
 };
 
 export type ServiceGroupFilter = {
@@ -4298,9 +5111,12 @@ export type ServiceGroupFilter = {
   description_contains?: InputMaybe<Scalars['String']['input']>;
   description_exists?: InputMaybe<Scalars['Boolean']['input']>;
   description_not_contains?: InputMaybe<Scalars['String']['input']>;
+  heroImage?: InputMaybe<CfHeroImageNestedFilter>;
+  heroImage_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  pageMetadata?: InputMaybe<CfPageMetadataNestedFilter>;
+  pageMetadata_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  serviceEntries?: InputMaybe<CfServiceEntryOrServiceGroupNestedFilter>;
   serviceEntriesCollection_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  serviceGroupCategory?: InputMaybe<CfCategoryNestedFilter>;
-  serviceGroupCategoryCollection_exists?: InputMaybe<Scalars['Boolean']['input']>;
   serviceListName?: InputMaybe<Scalars['String']['input']>;
   serviceListName_contains?: InputMaybe<Scalars['String']['input']>;
   serviceListName_exists?: InputMaybe<Scalars['Boolean']['input']>;
@@ -4328,6 +5144,7 @@ export type ServiceGroupFilter = {
 export type ServiceGroupLinkingCollections = {
   __typename?: 'ServiceGroupLinkingCollections';
   entryCollection?: Maybe<EntryCollection>;
+  homeCollection?: Maybe<HomeCollection>;
   serviceGroupCollection?: Maybe<ServiceGroupCollection>;
   topTierCollection?: Maybe<TopTierCollection>;
 };
@@ -4336,6 +5153,15 @@ export type ServiceGroupLinkingCollections = {
 export type ServiceGroupLinkingCollectionsEntryCollectionArgs = {
   limit?: InputMaybe<Scalars['Int']['input']>;
   locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type ServiceGroupLinkingCollectionsHomeCollectionArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  order?: InputMaybe<Array<InputMaybe<ServiceGroupLinkingCollectionsHomeCollectionOrder>>>;
   preview?: InputMaybe<Scalars['Boolean']['input']>;
   skip?: InputMaybe<Scalars['Int']['input']>;
 };
@@ -4357,6 +5183,21 @@ export type ServiceGroupLinkingCollectionsTopTierCollectionArgs = {
   preview?: InputMaybe<Scalars['Boolean']['input']>;
   skip?: InputMaybe<Scalars['Int']['input']>;
 };
+
+export enum ServiceGroupLinkingCollectionsHomeCollectionOrder {
+  AlertTitleAsc = 'alertTitle_ASC',
+  AlertTitleDesc = 'alertTitle_DESC',
+  InternalTitleAsc = 'internalTitle_ASC',
+  InternalTitleDesc = 'internalTitle_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC'
+}
 
 export enum ServiceGroupLinkingCollectionsServiceGroupCollectionOrder {
   ServiceListNameAsc = 'serviceListName_ASC',
@@ -4416,29 +5257,6 @@ export type ServiceGroupServiceEntriesCollection = {
 };
 
 export type ServiceGroupServiceEntriesItem = ServiceEntry | ServiceGroup;
-
-export type ServiceGroupServiceGroupCategoryCollection = {
-  __typename?: 'ServiceGroupServiceGroupCategoryCollection';
-  items: Array<Maybe<Category>>;
-  limit: Scalars['Int']['output'];
-  skip: Scalars['Int']['output'];
-  total: Scalars['Int']['output'];
-};
-
-export enum ServiceGroupServiceGroupCategoryCollectionOrder {
-  CategoryDescriptionAsc = 'categoryDescription_ASC',
-  CategoryDescriptionDesc = 'categoryDescription_DESC',
-  CategoryNameAsc = 'categoryName_ASC',
-  CategoryNameDesc = 'categoryName_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC'
-}
 
 export type Sys = {
   __typename?: 'Sys';
@@ -4546,6 +5364,12 @@ export type TestRichTextBodyLinks = {
   __typename?: 'TestRichTextBodyLinks';
   assets: TestRichTextBodyAssets;
   entries: TestRichTextBodyEntries;
+  resources: TestRichTextBodyResources;
+};
+
+export type TestRichTextBodyResources = {
+  __typename?: 'TestRichTextBodyResources';
+  block: Array<ResourceLink>;
 };
 
 export type TestRichTextCollection = {
@@ -4600,14 +5424,15 @@ export enum TestRichTextOrder {
   TitleDesc = 'title_DESC'
 }
 
-/** [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/topTier) */
+/** Top tier navigation pages group related service groups and services together. They also populate the navigation bar on the site. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/topTier) */
 export type TopTier = Entry & {
   __typename?: 'TopTier';
   contentfulMetadata: ContentfulMetadata;
   description?: Maybe<TopTierDescription>;
   featuredServiceListCollection?: Maybe<TopTierFeaturedServiceListCollection>;
+  heroImage?: Maybe<HeroImage>;
   linkedFrom?: Maybe<TopTierLinkingCollections>;
-  metadata?: Maybe<PageMetadata>;
+  pageMetadata?: Maybe<PageMetadata>;
   subheading?: Maybe<Scalars['String']['output']>;
   sys: Sys;
   title?: Maybe<Scalars['String']['output']>;
@@ -4615,50 +5440,62 @@ export type TopTier = Entry & {
 };
 
 
-/** [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/topTier) */
+/** Top tier navigation pages group related service groups and services together. They also populate the navigation bar on the site. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/topTier) */
 export type TopTierDescriptionArgs = {
   locale?: InputMaybe<Scalars['String']['input']>;
 };
 
 
-/** [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/topTier) */
+/** Top tier navigation pages group related service groups and services together. They also populate the navigation bar on the site. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/topTier) */
 export type TopTierFeaturedServiceListCollectionArgs = {
   limit?: InputMaybe<Scalars['Int']['input']>;
   locale?: InputMaybe<Scalars['String']['input']>;
+  order?: InputMaybe<Array<InputMaybe<TopTierFeaturedServiceListCollectionOrder>>>;
   preview?: InputMaybe<Scalars['Boolean']['input']>;
   skip?: InputMaybe<Scalars['Int']['input']>;
+  where?: InputMaybe<ServiceGroupFilter>;
 };
 
 
-/** [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/topTier) */
+/** Top tier navigation pages group related service groups and services together. They also populate the navigation bar on the site. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/topTier) */
+export type TopTierHeroImageArgs = {
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  where?: InputMaybe<HeroImageFilter>;
+};
+
+
+/** Top tier navigation pages group related service groups and services together. They also populate the navigation bar on the site. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/topTier) */
 export type TopTierLinkedFromArgs = {
   allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
 
 
-/** [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/topTier) */
-export type TopTierMetadataArgs = {
+/** Top tier navigation pages group related service groups and services together. They also populate the navigation bar on the site. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/topTier) */
+export type TopTierPageMetadataArgs = {
   locale?: InputMaybe<Scalars['String']['input']>;
   preview?: InputMaybe<Scalars['Boolean']['input']>;
+  where?: InputMaybe<PageMetadataFilter>;
 };
 
 
-/** [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/topTier) */
+/** Top tier navigation pages group related service groups and services together. They also populate the navigation bar on the site. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/topTier) */
 export type TopTierSubheadingArgs = {
   locale?: InputMaybe<Scalars['String']['input']>;
 };
 
 
-/** [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/topTier) */
+/** Top tier navigation pages group related service groups and services together. They also populate the navigation bar on the site. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/topTier) */
 export type TopTierTitleArgs = {
   locale?: InputMaybe<Scalars['String']['input']>;
 };
 
 
-/** [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/topTier) */
+/** Top tier navigation pages group related service groups and services together. They also populate the navigation bar on the site. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/topTier) */
 export type TopTierVideoArgs = {
   locale?: InputMaybe<Scalars['String']['input']>;
   preview?: InputMaybe<Scalars['Boolean']['input']>;
+  where?: InputMaybe<VideoWrapperFilter>;
 };
 
 export type TopTierCollection = {
@@ -4692,17 +5529,38 @@ export type TopTierDescriptionLinks = {
   __typename?: 'TopTierDescriptionLinks';
   assets: TopTierDescriptionAssets;
   entries: TopTierDescriptionEntries;
+  resources: TopTierDescriptionResources;
+};
+
+export type TopTierDescriptionResources = {
+  __typename?: 'TopTierDescriptionResources';
+  block: Array<ResourceLink>;
 };
 
 export type TopTierFeaturedServiceListCollection = {
   __typename?: 'TopTierFeaturedServiceListCollection';
-  items: Array<Maybe<TopTierFeaturedServiceListItem>>;
+  items: Array<Maybe<ServiceGroup>>;
   limit: Scalars['Int']['output'];
   skip: Scalars['Int']['output'];
   total: Scalars['Int']['output'];
 };
 
-export type TopTierFeaturedServiceListItem = ServiceEntry | ServiceGroup;
+export enum TopTierFeaturedServiceListCollectionOrder {
+  ServiceListNameAsc = 'serviceListName_ASC',
+  ServiceListNameDesc = 'serviceListName_DESC',
+  SubheadingAsc = 'subheading_ASC',
+  SubheadingDesc = 'subheading_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  TitleAsc = 'title_ASC',
+  TitleDesc = 'title_DESC'
+}
 
 export type TopTierFilter = {
   AND?: InputMaybe<Array<InputMaybe<TopTierFilter>>>;
@@ -4711,9 +5569,12 @@ export type TopTierFilter = {
   description_contains?: InputMaybe<Scalars['String']['input']>;
   description_exists?: InputMaybe<Scalars['Boolean']['input']>;
   description_not_contains?: InputMaybe<Scalars['String']['input']>;
+  featuredServiceList?: InputMaybe<CfServiceGroupNestedFilter>;
   featuredServiceListCollection_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  metadata?: InputMaybe<CfPageMetadataNestedFilter>;
-  metadata_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  heroImage?: InputMaybe<CfHeroImageNestedFilter>;
+  heroImage_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  pageMetadata?: InputMaybe<CfPageMetadataNestedFilter>;
+  pageMetadata_exists?: InputMaybe<Scalars['Boolean']['input']>;
   subheading?: InputMaybe<Scalars['String']['input']>;
   subheading_contains?: InputMaybe<Scalars['String']['input']>;
   subheading_exists?: InputMaybe<Scalars['Boolean']['input']>;
@@ -4736,6 +5597,7 @@ export type TopTierFilter = {
 export type TopTierLinkingCollections = {
   __typename?: 'TopTierLinkingCollections';
   entryCollection?: Maybe<EntryCollection>;
+  menuCollection?: Maybe<MenuCollection>;
 };
 
 
@@ -4745,6 +5607,30 @@ export type TopTierLinkingCollectionsEntryCollectionArgs = {
   preview?: InputMaybe<Scalars['Boolean']['input']>;
   skip?: InputMaybe<Scalars['Int']['input']>;
 };
+
+
+export type TopTierLinkingCollectionsMenuCollectionArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  order?: InputMaybe<Array<InputMaybe<TopTierLinkingCollectionsMenuCollectionOrder>>>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+};
+
+export enum TopTierLinkingCollectionsMenuCollectionOrder {
+  MenuTypeAsc = 'menuType_ASC',
+  MenuTypeDesc = 'menuType_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  TitleAsc = 'title_ASC',
+  TitleDesc = 'title_DESC'
+}
 
 export enum TopTierOrder {
   SubheadingAsc = 'subheading_ASC',
@@ -4887,6 +5773,7 @@ export type VideoWrapperFilter = {
 export type VideoWrapperLinkingCollections = {
   __typename?: 'VideoWrapperLinkingCollections';
   entryCollection?: Maybe<EntryCollection>;
+  homeCollection?: Maybe<HomeCollection>;
   topTierCollection?: Maybe<TopTierCollection>;
 };
 
@@ -4899,6 +5786,15 @@ export type VideoWrapperLinkingCollectionsEntryCollectionArgs = {
 };
 
 
+export type VideoWrapperLinkingCollectionsHomeCollectionArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  order?: InputMaybe<Array<InputMaybe<VideoWrapperLinkingCollectionsHomeCollectionOrder>>>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
 export type VideoWrapperLinkingCollectionsTopTierCollectionArgs = {
   limit?: InputMaybe<Scalars['Int']['input']>;
   locale?: InputMaybe<Scalars['String']['input']>;
@@ -4906,6 +5802,21 @@ export type VideoWrapperLinkingCollectionsTopTierCollectionArgs = {
   preview?: InputMaybe<Scalars['Boolean']['input']>;
   skip?: InputMaybe<Scalars['Int']['input']>;
 };
+
+export enum VideoWrapperLinkingCollectionsHomeCollectionOrder {
+  AlertTitleAsc = 'alertTitle_ASC',
+  AlertTitleDesc = 'alertTitle_DESC',
+  InternalTitleAsc = 'internalTitle_ASC',
+  InternalTitleDesc = 'internalTitle_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC'
+}
 
 export enum VideoWrapperLinkingCollectionsTopTierCollectionOrder {
   SubheadingAsc = 'subheading_ASC',
@@ -4989,18 +5900,20 @@ export type VideoWrapperVideoLongerStoryLinks = {
   __typename?: 'VideoWrapperVideoLongerStoryLinks';
   assets: VideoWrapperVideoLongerStoryAssets;
   entries: VideoWrapperVideoLongerStoryEntries;
+  resources: VideoWrapperVideoLongerStoryResources;
+};
+
+export type VideoWrapperVideoLongerStoryResources = {
+  __typename?: 'VideoWrapperVideoLongerStoryResources';
+  block: Array<ResourceLink>;
 };
 
 export type CfCallToActionNestedFilter = {
   AND?: InputMaybe<Array<InputMaybe<CfCallToActionNestedFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<CfCallToActionNestedFilter>>>;
-  callToActionMessage?: InputMaybe<Scalars['String']['input']>;
-  callToActionMessage_contains?: InputMaybe<Scalars['String']['input']>;
-  callToActionMessage_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  callToActionMessage_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  callToActionMessage_not?: InputMaybe<Scalars['String']['input']>;
-  callToActionMessage_not_contains?: InputMaybe<Scalars['String']['input']>;
-  callToActionMessage_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  callToActionDestination_contains?: InputMaybe<Scalars['String']['input']>;
+  callToActionDestination_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  callToActionDestination_not_contains?: InputMaybe<Scalars['String']['input']>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
   ctaInternalName?: InputMaybe<Scalars['String']['input']>;
   ctaInternalName_contains?: InputMaybe<Scalars['String']['input']>;
@@ -5009,41 +5922,6 @@ export type CfCallToActionNestedFilter = {
   ctaInternalName_not?: InputMaybe<Scalars['String']['input']>;
   ctaInternalName_not_contains?: InputMaybe<Scalars['String']['input']>;
   ctaInternalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  ctaLink?: InputMaybe<Scalars['String']['input']>;
-  ctaLink_contains?: InputMaybe<Scalars['String']['input']>;
-  ctaLink_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  ctaLink_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  ctaLink_not?: InputMaybe<Scalars['String']['input']>;
-  ctaLink_not_contains?: InputMaybe<Scalars['String']['input']>;
-  ctaLink_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  ctaName?: InputMaybe<Scalars['String']['input']>;
-  ctaName_contains?: InputMaybe<Scalars['String']['input']>;
-  ctaName_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  ctaName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  ctaName_not?: InputMaybe<Scalars['String']['input']>;
-  ctaName_not_contains?: InputMaybe<Scalars['String']['input']>;
-  ctaName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  ctaType?: InputMaybe<Scalars['Boolean']['input']>;
-  ctaType_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  ctaType_not?: InputMaybe<Scalars['Boolean']['input']>;
-  internalContentLink_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  internalOrExternal?: InputMaybe<Scalars['Boolean']['input']>;
-  internalOrExternal_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  internalOrExternal_not?: InputMaybe<Scalars['Boolean']['input']>;
-  linkText?: InputMaybe<Scalars['String']['input']>;
-  linkText_contains?: InputMaybe<Scalars['String']['input']>;
-  linkText_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  linkText_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  linkText_not?: InputMaybe<Scalars['String']['input']>;
-  linkText_not_contains?: InputMaybe<Scalars['String']['input']>;
-  linkText_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  phoneNumberCta?: InputMaybe<Scalars['String']['input']>;
-  phoneNumberCta_contains?: InputMaybe<Scalars['String']['input']>;
-  phoneNumberCta_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  phoneNumberCta_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  phoneNumberCta_not?: InputMaybe<Scalars['String']['input']>;
-  phoneNumberCta_not_contains?: InputMaybe<Scalars['String']['input']>;
-  phoneNumberCta_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   sys?: InputMaybe<SysFilter>;
 };
 
@@ -5180,6 +6058,49 @@ export type CfDocumentWrapperNestedFilter = {
   wrappedDocumentName_exists?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
+export type CfDraftNavigationLinkOrDraftNavigationMenuNestedFilter = {
+  AND?: InputMaybe<Array<InputMaybe<CfDraftNavigationLinkOrDraftNavigationMenuNestedFilter>>>;
+  OR?: InputMaybe<Array<InputMaybe<CfDraftNavigationLinkOrDraftNavigationMenuNestedFilter>>>;
+  contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
+  sys?: InputMaybe<SysFilter>;
+  text?: InputMaybe<Scalars['String']['input']>;
+  text_contains?: InputMaybe<Scalars['String']['input']>;
+  text_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  text_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  text_not?: InputMaybe<Scalars['String']['input']>;
+  text_not_contains?: InputMaybe<Scalars['String']['input']>;
+  text_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type CfHeroImageNestedFilter = {
+  AND?: InputMaybe<Array<InputMaybe<CfHeroImageNestedFilter>>>;
+  OR?: InputMaybe<Array<InputMaybe<CfHeroImageNestedFilter>>>;
+  altField?: InputMaybe<Scalars['String']['input']>;
+  altField_contains?: InputMaybe<Scalars['String']['input']>;
+  altField_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  altField_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  altField_not?: InputMaybe<Scalars['String']['input']>;
+  altField_not_contains?: InputMaybe<Scalars['String']['input']>;
+  altField_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
+  fotogCredit?: InputMaybe<Scalars['String']['input']>;
+  fotogCredit_contains?: InputMaybe<Scalars['String']['input']>;
+  fotogCredit_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  fotogCredit_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  fotogCredit_not?: InputMaybe<Scalars['String']['input']>;
+  fotogCredit_not_contains?: InputMaybe<Scalars['String']['input']>;
+  fotogCredit_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  imageSource_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  imageTitle?: InputMaybe<Scalars['String']['input']>;
+  imageTitle_contains?: InputMaybe<Scalars['String']['input']>;
+  imageTitle_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  imageTitle_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  imageTitle_not?: InputMaybe<Scalars['String']['input']>;
+  imageTitle_not_contains?: InputMaybe<Scalars['String']['input']>;
+  imageTitle_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  sys?: InputMaybe<SysFilter>;
+};
+
 export type CfImageWrapperNestedFilter = {
   AND?: InputMaybe<Array<InputMaybe<CfImageWrapperNestedFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<CfImageWrapperNestedFilter>>>;
@@ -5203,48 +6124,35 @@ export type CfImageWrapperNestedFilter = {
   sys?: InputMaybe<SysFilter>;
 };
 
-export type CfListWithTitleNestedFilter = {
-  AND?: InputMaybe<Array<InputMaybe<CfListWithTitleNestedFilter>>>;
-  OR?: InputMaybe<Array<InputMaybe<CfListWithTitleNestedFilter>>>;
+export type CfMenuOrMenuItemOrTopTierNestedFilter = {
+  AND?: InputMaybe<Array<InputMaybe<CfMenuOrMenuItemOrTopTierNestedFilter>>>;
+  OR?: InputMaybe<Array<InputMaybe<CfMenuOrMenuItemOrTopTierNestedFilter>>>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
-  customLabel?: InputMaybe<Scalars['String']['input']>;
-  customLabel_contains?: InputMaybe<Scalars['String']['input']>;
-  customLabel_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  customLabel_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  customLabel_not?: InputMaybe<Scalars['String']['input']>;
-  customLabel_not_contains?: InputMaybe<Scalars['String']['input']>;
-  customLabel_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  dropdownChoices?: InputMaybe<Scalars['String']['input']>;
-  dropdownChoices_contains?: InputMaybe<Scalars['String']['input']>;
-  dropdownChoices_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  dropdownChoices_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  dropdownChoices_not?: InputMaybe<Scalars['String']['input']>;
-  dropdownChoices_not_contains?: InputMaybe<Scalars['String']['input']>;
-  dropdownChoices_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  internalTitle?: InputMaybe<Scalars['String']['input']>;
-  internalTitle_contains?: InputMaybe<Scalars['String']['input']>;
-  internalTitle_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  internalTitle_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  internalTitle_not?: InputMaybe<Scalars['String']['input']>;
-  internalTitle_not_contains?: InputMaybe<Scalars['String']['input']>;
-  internalTitle_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  paragraphOrList_contains?: InputMaybe<Scalars['String']['input']>;
-  paragraphOrList_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  paragraphOrList_not_contains?: InputMaybe<Scalars['String']['input']>;
   sys?: InputMaybe<SysFilter>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  title_contains?: InputMaybe<Scalars['String']['input']>;
+  title_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  title_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  title_not?: InputMaybe<Scalars['String']['input']>;
+  title_not_contains?: InputMaybe<Scalars['String']['input']>;
+  title_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
 
 export type CfPageMetadataNestedFilter = {
   AND?: InputMaybe<Array<InputMaybe<CfPageMetadataNestedFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<CfPageMetadataNestedFilter>>>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
-  internalTitle?: InputMaybe<Scalars['String']['input']>;
-  internalTitle_contains?: InputMaybe<Scalars['String']['input']>;
-  internalTitle_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  internalTitle_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  internalTitle_not?: InputMaybe<Scalars['String']['input']>;
-  internalTitle_not_contains?: InputMaybe<Scalars['String']['input']>;
-  internalTitle_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  externalRedirect?: InputMaybe<Scalars['String']['input']>;
+  externalRedirect_contains?: InputMaybe<Scalars['String']['input']>;
+  externalRedirect_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  externalRedirect_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  externalRedirect_not?: InputMaybe<Scalars['String']['input']>;
+  externalRedirect_not_contains?: InputMaybe<Scalars['String']['input']>;
+  externalRedirect_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  internalRedirect_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  isRoot?: InputMaybe<Scalars['Boolean']['input']>;
+  isRoot_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  isRoot_not?: InputMaybe<Scalars['Boolean']['input']>;
   metaDescription?: InputMaybe<Scalars['String']['input']>;
   metaDescription_contains?: InputMaybe<Scalars['String']['input']>;
   metaDescription_exists?: InputMaybe<Scalars['Boolean']['input']>;
@@ -5259,6 +6167,7 @@ export type CfPageMetadataNestedFilter = {
   metaTitle_not?: InputMaybe<Scalars['String']['input']>;
   metaTitle_not_contains?: InputMaybe<Scalars['String']['input']>;
   metaTitle_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  parent_exists?: InputMaybe<Scalars['Boolean']['input']>;
   slug?: InputMaybe<Scalars['String']['input']>;
   slug_contains?: InputMaybe<Scalars['String']['input']>;
   slug_exists?: InputMaybe<Scalars['Boolean']['input']>;
@@ -5267,6 +6176,85 @@ export type CfPageMetadataNestedFilter = {
   slug_not_contains?: InputMaybe<Scalars['String']['input']>;
   slug_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   sys?: InputMaybe<SysFilter>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  title_contains?: InputMaybe<Scalars['String']['input']>;
+  title_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  title_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  title_not?: InputMaybe<Scalars['String']['input']>;
+  title_not_contains?: InputMaybe<Scalars['String']['input']>;
+  title_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type CfPromoBannerWithCtaNestedFilter = {
+  AND?: InputMaybe<Array<InputMaybe<CfPromoBannerWithCtaNestedFilter>>>;
+  OR?: InputMaybe<Array<InputMaybe<CfPromoBannerWithCtaNestedFilter>>>;
+  contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
+  promoCategoryCollection_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  promoCta_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  promoHeroImage_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  promoInternalName?: InputMaybe<Scalars['String']['input']>;
+  promoInternalName_contains?: InputMaybe<Scalars['String']['input']>;
+  promoInternalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  promoInternalName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  promoInternalName_not?: InputMaybe<Scalars['String']['input']>;
+  promoInternalName_not_contains?: InputMaybe<Scalars['String']['input']>;
+  promoInternalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  sys?: InputMaybe<SysFilter>;
+};
+
+export type CfServiceEntryOrServiceGroupNestedFilter = {
+  AND?: InputMaybe<Array<InputMaybe<CfServiceEntryOrServiceGroupNestedFilter>>>;
+  OR?: InputMaybe<Array<InputMaybe<CfServiceEntryOrServiceGroupNestedFilter>>>;
+  contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
+  description_contains?: InputMaybe<Scalars['String']['input']>;
+  description_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  description_not_contains?: InputMaybe<Scalars['String']['input']>;
+  subheading?: InputMaybe<Scalars['String']['input']>;
+  subheading_contains?: InputMaybe<Scalars['String']['input']>;
+  subheading_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  subheading_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  subheading_not?: InputMaybe<Scalars['String']['input']>;
+  subheading_not_contains?: InputMaybe<Scalars['String']['input']>;
+  subheading_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  sys?: InputMaybe<SysFilter>;
+};
+
+export type CfServiceGroupNestedFilter = {
+  AND?: InputMaybe<Array<InputMaybe<CfServiceGroupNestedFilter>>>;
+  OR?: InputMaybe<Array<InputMaybe<CfServiceGroupNestedFilter>>>;
+  additionalResources_contains?: InputMaybe<Scalars['String']['input']>;
+  additionalResources_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  additionalResources_not_contains?: InputMaybe<Scalars['String']['input']>;
+  contactInfoCollection_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
+  description_contains?: InputMaybe<Scalars['String']['input']>;
+  description_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  description_not_contains?: InputMaybe<Scalars['String']['input']>;
+  heroImage_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  pageMetadata_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  serviceEntriesCollection_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  serviceListName?: InputMaybe<Scalars['String']['input']>;
+  serviceListName_contains?: InputMaybe<Scalars['String']['input']>;
+  serviceListName_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  serviceListName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  serviceListName_not?: InputMaybe<Scalars['String']['input']>;
+  serviceListName_not_contains?: InputMaybe<Scalars['String']['input']>;
+  serviceListName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  subheading?: InputMaybe<Scalars['String']['input']>;
+  subheading_contains?: InputMaybe<Scalars['String']['input']>;
+  subheading_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  subheading_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  subheading_not?: InputMaybe<Scalars['String']['input']>;
+  subheading_not_contains?: InputMaybe<Scalars['String']['input']>;
+  subheading_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  sys?: InputMaybe<SysFilter>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  title_contains?: InputMaybe<Scalars['String']['input']>;
+  title_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  title_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  title_not?: InputMaybe<Scalars['String']['input']>;
+  title_not_contains?: InputMaybe<Scalars['String']['input']>;
+  title_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
 
 export type CfVideoWrapperNestedFilter = {

--- a/src/routes/about/organization/[slug]/+page.server.ts
+++ b/src/routes/about/organization/[slug]/+page.server.ts
@@ -47,7 +47,7 @@ const query = gql`
             }
           }
         }
-        metadata {
+        pageMetadata {
           ... on PageMetadata {
             slug
             metaTitle
@@ -70,7 +70,7 @@ export const load = (async ({ params }): Promise<OfficePage> => {
     if (data) {
       const officePages = data?.officePageCollection?.items as OfficePage[];
       const matchedOfficePage = officePages.find(
-        (officePage) => officePage.metadata?.slug === slug
+        (officePage) => officePage.pageMetadata?.slug === slug
       );
       if (matchedOfficePage) {
         return matchedOfficePage;

--- a/src/routes/about/organization/[slug]/__tests__/OfficePageTestContent.ts
+++ b/src/routes/about/organization/[slug]/__tests__/OfficePageTestContent.ts
@@ -1,3 +1,4 @@
+import type { OfficePage } from "$lib/services/contentful/schema";
 import documentWithParagraphData from "$lib/components/ContentfulRichText/__tests__/documents";
 
 export default {
@@ -11,6 +12,7 @@ export default {
     links: {
       assets: { block: [], hyperlink: [] },
       entries: { block: [], hyperlink: [], inline: [] },
+      resources: { block: [] },
     },
   },
   servicesAndPrograms: {
@@ -18,6 +20,7 @@ export default {
     links: {
       assets: { block: [], hyperlink: [] },
       entries: { block: [], hyperlink: [], inline: [] },
+      resources: { block: [] },
     },
   },
   mailingAddress: {
@@ -56,4 +59,4 @@ export default {
       },
     ],
   },
-};
+} satisfies OfficePage;


### PR DESCRIPTION
In an effort to standardize references to Page Metadata entries, I renamed a bunch of fields in Contentful, which broke the current Office Page implementation. This is a quick fix to get it working again.