### PR TITLE
LDAF-350 Populate main menu using page metadata.

### DIFF
--- a/src/lib/components/Header/Nav/Nav.server.ts
+++ b/src/lib/components/Header/Nav/Nav.server.ts
@@ -1,39 +1,42 @@
 import gql from "graphql-tag";
 import { print as printQuery } from "graphql";
+
 import { CONTENTFUL_SPACE_ID, CONTENTFUL_DELIVERY_API_TOKEN } from "$env/static/private";
 import getContentfulClient from "$lib/services/contentful";
 import mainNavTestContent from "./__tests__/MainNavTestContent";
 import secondaryNavTestContent from "./__tests__/SecondaryNavTestContent";
-import type {
-  DraftNavigationLink,
-  DraftNavigationMenu,
-  DraftNavigationMenuChildrenItem,
-} from "$lib/services/contentful/schema";
-import type { NavLinkType, NavMenuType } from "./types";
-import type { NavQuery } from "./$queries.generated";
 
-export const loadMainNav = async () => {
-  if (CONTENTFUL_SPACE_ID && CONTENTFUL_DELIVERY_API_TOKEN) {
-    const query = gql`
-      query Nav {
-        draftNavigationMenuCollection(where: { type: "Main Menu" }, limit: 1) {
+import type { HeaderMainMenuQuery } from "./$queries.generated";
+import type { NavLinkType, NavMenuType } from "./types";
+import type { PageMetadataMap } from "../../../../routes/loadPageMetadataMap";
+
+const headerMainMenuQuery = gql`
+  query HeaderMainMenu {
+    menuCollection(limit: 1, where: { menuType: "Header Main Menu" }) {
+      items {
+        childrenCollection(limit: 10) {
           items {
-            text
-            childrenCollection {
-              items {
-                ... on DraftNavigationMenu {
+            ... on TopTier {
+              __typename
+              sys {
+                id
+              }
+              pageMetadata {
+                ... on PageMetadata {
                   sys {
                     id
                   }
-                  text
-                  childrenCollection {
-                    items {
-                      ... on DraftNavigationLink {
+                }
+              }
+              featuredServiceListCollection(limit: 7) {
+                items {
+                  ... on ServiceGroup {
+                    pageMetadata {
+                      ... on PageMetadata {
                         sys {
+                          # eslint-disable-next-line @graphql-eslint/selection-set-depth
                           id
                         }
-                        text
-                        link
                       }
                     }
                   }
@@ -43,36 +46,96 @@ export const loadMainNav = async () => {
           }
         }
       }
-    `;
+    }
+  }
+`;
+
+export const loadMainNav = async (pageMetadataMap: PageMetadataMap): Promise<NavMenuType[]> => {
+  const mainMenu: NavMenuType[] = [];
+  if (CONTENTFUL_SPACE_ID && CONTENTFUL_DELIVERY_API_TOKEN) {
     const client = getContentfulClient({
       spaceID: CONTENTFUL_SPACE_ID,
       token: CONTENTFUL_DELIVERY_API_TOKEN,
     });
-    const data = await client.fetch<NavQuery>(printQuery(query));
-    const mainMenu = data?.draftNavigationMenuCollection?.items[0] as DraftNavigationMenu;
-    const mainMenuChildren = mainMenu?.childrenCollection
-      ?.items as DraftNavigationMenuChildrenItem[];
-    // Convert DraftNavigationMenuChildrenItem[] to NavItem[]
-    return mainMenuChildren.map((mainMenuChild): NavMenuType => {
-      // Treat all children of the main menu as submenus.
-      // TODO: Update this if we decide we want normal links as children.
-      const subMenu = mainMenuChild as DraftNavigationMenu;
-      const subMenuChildren = subMenu?.childrenCollection
-        ?.items as DraftNavigationMenuChildrenItem[];
-      const transformedSubMenuNavItems = subMenuChildren.map((subMenuChild): NavLinkType => {
-        const navLink = subMenuChild as DraftNavigationLink;
-        return {
-          id: navLink.sys.id,
-          name: navLink.text || undefined,
-          link: navLink.link || undefined,
-        };
-      });
-      return {
-        id: subMenu.sys.id,
-        name: subMenu.text || undefined,
-        children: transformedSubMenuNavItems,
-      };
-    });
+    const data = await client.fetch<HeaderMainMenuQuery>(printQuery(headerMainMenuQuery));
+    if (data?.menuCollection?.items?.length === 1) {
+      const menuData = data.menuCollection.items[0]?.childrenCollection?.items;
+      if (menuData) {
+        menuData.forEach((topTier) => {
+          if (topTier?.__typename === "TopTier") {
+            const topTierMetadataId = topTier.pageMetadata?.sys?.id;
+            if (topTierMetadataId) {
+              const topTierMetadata = pageMetadataMap.get(topTierMetadataId);
+              if (topTierMetadata && topTierMetadata.title && topTierMetadata.url) {
+                // construct the top tier menu items, with the first child of each linking to relevant Top Tier page
+                const menu: NavMenuType = {
+                  id: topTierMetadataId,
+                  name: topTierMetadata.title,
+                  children: [
+                    {
+                      id: topTierMetadataId,
+                      name: `View ${topTierMetadata.title}`,
+                      link: topTierMetadata.url,
+                    },
+                  ],
+                };
+                // the next set of links for each menu should be the featured Service Groups on the Top Tier page
+                const featuredServiceGroupMetadataIds =
+                  topTier?.featuredServiceListCollection?.items?.map(
+                    (featuredServiceGroup) => featuredServiceGroup?.pageMetadata?.sys?.id
+                  );
+                if (featuredServiceGroupMetadataIds && featuredServiceGroupMetadataIds.length > 0) {
+                  featuredServiceGroupMetadataIds.forEach((id) => {
+                    if (id) {
+                      const metadata = pageMetadataMap.get(id);
+                      if (metadata) {
+                        const { sys, title, url } = metadata;
+                        if (sys?.id && title && url) {
+                          menu?.children?.push({
+                            id: sys.id,
+                            name: title,
+                            link: url,
+                          });
+                        }
+                      }
+                    }
+                  });
+                }
+                // the last set of links are all second-tier pages not already included from the featured services
+                const secondTierMenuItems: NavLinkType[] = [];
+                topTierMetadata.children?.forEach((secondTierMetadataId) => {
+                  const foundDuplicateIndex = menu?.children?.findIndex(
+                    (page) => page.id === secondTierMetadataId
+                  );
+                  if (foundDuplicateIndex && foundDuplicateIndex < 0) {
+                    const secondTierMetadata = pageMetadataMap.get(secondTierMetadataId);
+                    if (secondTierMetadata) {
+                      const { sys, title, url } = secondTierMetadata;
+                      if (sys?.id && title && url) {
+                        secondTierMenuItems.push({
+                          id: sys.id,
+                          name: title,
+                          link: url,
+                        });
+                      }
+                    }
+                  }
+                });
+                // sort alphabetically by the link name
+                secondTierMenuItems.sort(({ name: a }, { name: b }) => {
+                  return a && b ? a.localeCompare(b) : -1;
+                });
+                secondTierMenuItems.forEach((item) => {
+                  menu?.children?.push(item);
+                });
+                mainMenu.push(menu);
+              }
+            }
+          }
+        });
+      }
+    }
+    return mainMenu;
   } else {
     return mainNavTestContent;
   }

--- a/src/routes/(infoPages)/[topTierPage]/+page.server.ts
+++ b/src/routes/(infoPages)/[topTierPage]/+page.server.ts
@@ -42,6 +42,10 @@ export const load = async ({ parent, params }) => {
       if (pageMetadata) {
         return { pageMetadata };
       }
+    } else {
+      console.warn(
+        `A Top Tier entry with the slug "${topTierSlug}" could not be found. If this page was reached via a link, it is likely that the Page Metadata entry is published but the Top Tier entry is not.`
+      );
     }
   }
   throw error(404);

--- a/src/routes/(infoPages)/[topTierPage]/[...serviceGroupPage]/+page.server.ts
+++ b/src/routes/(infoPages)/[topTierPage]/[...serviceGroupPage]/+page.server.ts
@@ -44,7 +44,7 @@ export const load = async ({ parent, params }) => {
         return serviceGroup?.pageMetadata?.slug === slug;
       }
     );
-    if (matchedServiceGroupsFromSlug) {
+    if (matchedServiceGroupsFromSlug && matchedServiceGroupsFromSlug.length > 0) {
       // account for possibility that two service groups have the same ending slug
       const matchedServiceGroupsMetadata = matchedServiceGroupsFromSlug.map((group) => {
         const serviceGroupMetadataId = group?.pageMetadata?.sys?.id;
@@ -59,6 +59,10 @@ export const load = async ({ parent, params }) => {
       if (matchedPageMetadata) {
         return { pageMetadata: matchedPageMetadata };
       }
+    } else {
+      console.warn(
+        `A Service Group entry with the slug "${slug}" could not be found. If this page was reached via a link, it is likely that the Page Metadata entry is published but the Service Group entry is not.`
+      );
     }
   }
   throw error(404);

--- a/src/routes/(infoPages)/about/boards-commissions/[boardCommissionPage]/+page.server.ts
+++ b/src/routes/(infoPages)/about/boards-commissions/[boardCommissionPage]/+page.server.ts
@@ -48,6 +48,10 @@ export const load = async ({ parent, params }) => {
             };
           }
         }
+      } else {
+        console.warn(
+          `A Board or Commission entry with the slug "${slug}" could not be found. If this page was reached via a link, it is likely that the Page Metadata entry is published but the Board or Commission entry is not.`
+        );
       }
     }
   }

--- a/src/routes/(infoPages)/about/organization/[officePage]/+page.server.ts
+++ b/src/routes/(infoPages)/about/organization/[officePage]/+page.server.ts
@@ -86,5 +86,8 @@ export const load = async ({ parent, params }) => {
       }
     }
   }
+  console.warn(
+    `An Office Page entry with the slug "${slug}" could not be found. If this page was reached via a link, it is likely that the Page Metadata entry is published but the Office Page entry is not.`
+  );
   throw error(404);
 };

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -2,9 +2,12 @@ import { loadPageMetadataMap } from "./loadPageMetadataMap";
 import { loadSiteTitle } from "$lib/components/Header/Title/Title.server";
 import { loadMainNav, loadSecondaryNav } from "$lib/components/Header/Nav/Nav.server";
 
-export const load = async () => ({
-  pageMetadataMap: loadPageMetadataMap(),
-  siteTitle: loadSiteTitle(),
-  secondaryNavItems: loadSecondaryNav(),
-  navItems: await loadMainNav(),
-});
+export const load = async () => {
+  const pageMetadataMap = await loadPageMetadataMap();
+  return {
+    pageMetadataMap,
+    siteTitle: loadSiteTitle(),
+    navItems: loadMainNav(pageMetadataMap),
+    secondaryNavItems: loadSecondaryNav(),
+  };
+};

--- a/src/routes/loadPageMetadataMap.ts
+++ b/src/routes/loadPageMetadataMap.ts
@@ -15,6 +15,8 @@ export type PageMetadataMapItem = NonNullable<
   breadcrumbs?: Breadcrumbs;
 };
 
+export type PageMetadataMap = Map<string, PageMetadataMapItem>;
+
 // might want to move this type def if we want to use it elsewhere
 type Breadcrumb = {
   id: string;
@@ -23,7 +25,7 @@ type Breadcrumb = {
 };
 type Breadcrumbs = Array<Breadcrumb>;
 
-const pageMetadataMap = new Map<string, PageMetadataMapItem>();
+const pageMetadataMap: PageMetadataMap = new Map();
 
 const query = gql`
   query PageMetadataCollection {


### PR DESCRIPTION
Jira ticket: [LDAF-350](https://ldaf.atlassian.net/browse/LDAF-350)

## Proposed changes

This PR is only focused on populating the main menu; there are no changes to the nav components or design (this will come later). Most of the changes are to one file, `src/lib/components/Header/Nav/Nav.server.ts`, where we're replacing our query for Draft Navigation content with one for Menu content. The main difference between these approaches is that Draft Navigation made editors explicitly provide all menus and menu children, whereas Menu just collects the Top Tier pages (so that we can order them appropriately) and from there we use the existing `PageMetadataMap` and the featured service groups on the Top Tier pages to construct the menus with very minimal editor interaction.

The structure for each menu (i.e. the children under Animals, Plants and crops, etc.) is:
* the first link is a link to the Top Tier page for that menu (this will eventually render with an image, and will be a standalone column if we're using a mega menu)
* the next set of links are links to Service Groups featured on the Top Tier page; this allows editors to add pages that are lower in the hierarchy (e.g. `/land/fire/safety`) or from a different Top Tier altogether 
* the last set of links are all pages that are in the "second tier" of the hierarchy (e.g. `/animals/branding`), sorted alphabetically by their title (if a page is both a featured service group and a second-tier, we don't repeat them here)

## Acceptance criteria validation

This PR accomplishes one of the A/C from the ticket:

- [x] Update megamenu

[LDAF-350]: https://ldaf.atlassian.net/browse/LDAF-350?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ