### PR TITLE
Suppress @rollup/plugin-typescript warnings on +page.server.ts files.

### DIFF
--- a/vite-plugin-import-as-bundle-string/index.ts
+++ b/vite-plugin-import-as-bundle-string/index.ts
@@ -24,6 +24,13 @@ export default () => {
       const bundle = await rollup({
         input: path,
         plugins,
+        // Suppress some TS warnings that we know are irrelevant.
+        onwarn: (warning, handler) => {
+          const { pluginCode } = warning;
+          // TS7031 - https://github.com/microsoft/TypeScript/blob/cbf3c63ef3bb85e235092eaf5aa6035dad04b185/src/compiler/diagnosticMessages.json#L6382-L6385
+          if (pluginCode === "TS7031") return;
+          handler(warning);
+        },
       });
       const { output } = await bundle.generate({
         sourcemap: process.env.NODE_ENV === "production" ? false : "inline",


### PR DESCRIPTION
The irrelevant `@rollup/plugin-typescript` warnings we're getting when running `dev` are coming from one of our custom Vite plugins, so for now we can just suppress the one that's causing the most false positives (the implicit type warning). In the future we may want to suppress all warnings coming from the TS plugin, since it doesn't have the full view of the application (nor should it).