### PR TITLE
LDAF-341 Create Top Tier pages

### DIFF
--- a/src/lib/components/Button/Button.scss
+++ b/src/lib/components/Button/Button.scss
@@ -5,6 +5,9 @@ $colors: (
   "primary": #0051ad,
   "primary-dark": #063c7a,
   "primary-darker": #00284d,
+  "secondary": #ffc745,
+  "secondary-dark": #ffb200,
+  "secondary-darker": #d49400,
   "disabled": #c9c9c9,
   "disabled-dark": #adadad,
   "base-lightest": #f2f1f0,
@@ -23,15 +26,66 @@ $colors: (
   "unstyled-inverse-active": #fff,
 );
 
+/* TODO: Handle Icon coloring separately once https://ldaf.atlassian.net/browse/LDAF-327 is done. */
+/* Filters generated based on hexes using https://isotropic.co/tool/hex-color-to-css-filter/ */
+$filters: (
+  "white": invert(99%) sepia(0%) saturate(2%) hue-rotate(301deg) brightness(107%) contrast(100%),
+  "primary": invert(17%) sepia(56%) saturate(4186%) hue-rotate(201deg) brightness(98%)
+    contrast(102%),
+  "primary-dark": invert(14%) sepia(71%) saturate(2991%) hue-rotate(202deg) brightness(91%)
+    contrast(95%),
+  "disabled": invert(88%) sepia(0%) saturate(135%) hue-rotate(146deg) brightness(86%) contrast(110%),
+  "disabled-dark": invert(73%) sepia(17%) saturate(0%) hue-rotate(174deg) brightness(91%)
+    contrast(95%),
+  "base-lightest": invert(93%) sepia(6%) saturate(32%) hue-rotate(349deg) brightness(104%)
+    contrast(92%),
+  "base-darker": invert(23%) sepia(14%) saturate(719%) hue-rotate(177deg) brightness(93%)
+    contrast(84%),
+  "outline-inverse": invert(96%) sepia(9%) saturate(44%) hue-rotate(169deg) brightness(90%)
+    contrast(99%),
+  "unstyled-fg": invert(17%) sepia(91%) saturate(2870%) hue-rotate(191deg) brightness(95%)
+    contrast(101%),
+  "unstyled-fg-hover": invert(20%) sepia(50%) saturate(2048%) hue-rotate(195deg) brightness(92%)
+    contrast(91%),
+  "unstyled-fg-active": invert(14%) sepia(69%) saturate(725%) hue-rotate(180deg) brightness(95%)
+    contrast(95%),
+  "unstyled-inverse": invert(99%) sepia(0%) saturate(6899%) hue-rotate(225deg) brightness(122%)
+    contrast(80%),
+  "unstyled-inverse-active": invert(99%) sepia(0%) saturate(2%) hue-rotate(301deg) brightness(107%)
+    contrast(100%),
+);
+
 .usa-button {
   width: auto;
   color: #fff;
   background: map.get($colors, "primary");
+  .usa-icon {
+    filter: map.get($filters, "white");
+  }
   &:hover {
     background: map.get($colors, "primary-dark");
   }
   &:active {
     background: map.get($colors, "primary-darker");
+  }
+  &:disabled,
+  &:disabled:hover,
+  &:disabled:active {
+    background: map.get($colors, "disabled-dark");
+  }
+}
+
+.usa-button.usa-button--secondary {
+  color: map.get($colors, "primary");
+  background: map.get($colors, "secondary");
+  .usa-icon {
+    filter: map.get($filters, "primary");
+  }
+  &:hover {
+    background: map.get($colors, "secondary-dark");
+  }
+  &:active {
+    background: map.get($colors, "secondary-darker");
   }
   &:disabled,
   &:disabled:hover,
@@ -58,80 +112,115 @@ $colors: (
 .usa-button.usa-button--inverse {
   color: map.get($colors, "primary");
   background: #fff;
+  .usa-icon {
+    filter: map.get($filters, "primary");
+  }
   &:hover {
     color: map.get($colors, "primary");
     background: map.get($colors, "gray-05");
+    .usa-icon {
+      filter: map.get($filters, "primary");
+    }
   }
   &:active {
     color: map.get($colors, "primary");
     background: map.get($colors, "primary-lightest");
+    .usa-icon {
+      filter: map.get($filters, "primary");
+    }
   }
   &:disabled,
   &:disabled:hover,
   &:disabled:active {
     color: #fff;
     background: map.get($colors, "disabled-dark");
+    .usa-icon {
+      filter: map.get($filters, "white");
+    }
   }
 }
 
 .usa-button.usa-button--text-only {
   color: map.get($colors, "primary");
   background: none;
+  .usa-icon {
+    filter: map.get($filters, "primary");
+  }
   &:hover {
     color: map.get($colors, "primary");
     background: map.get($colors, "text-only-hover");
+    .usa-icon {
+      filter: map.get($filters, "primary");
+    }
   }
   &:active {
     color: map.get($colors, "primary");
     background: map.get($colors, "text-only-active");
+    .usa-icon {
+      filter: map.get($filters, "primary");
+    }
   }
   &:disabled,
   &:disabled:hover,
   &:disabled:active {
     background: none;
     color: map.get($colors, "disabled");
-  }
-}
-
-.usa-button.usa-button--outline {
-  background: none;
-  color: map.get($colors, "outline");
-  &:disabled,
-  &:disabled:hover,
-  &:disabled:active {
-    background: none;
+    .usa-icon {
+      filter: map.get($filters, "disabled");
+    }
   }
 }
 
 .usa-button.usa-button--outline {
   background: none;
   color: map.get($colors, "primary");
+  .usa-icon {
+    filter: map.get($filters, "primary");
+  }
   &:hover {
     background: none;
     color: map.get($colors, "primary-dark");
+    .usa-icon {
+      filter: map.get($filters, "primary-dark");
+    }
   }
   &:active {
     background: none;
     color: map.get($colors, "base-darker");
+    .usa-icon {
+      filter: map.get($filters, "base-darker");
+    }
   }
   &:disabled,
   &:disabled:hover,
   &:disabled:active {
     color: map.get($colors, "disabled");
     background: none;
+    .usa-icon {
+      filter: map.get($filters, "disabled");
+    }
   }
 }
 
 .usa-button.usa-button--outline-inverse {
   color: map.get($colors, "outline-inverse");
   box-shadow: inset 0 0 0 2px map.get($colors, "base-light");
+  .usa-icon {
+    filter: map.get($filters, "outline-inverse");
+  }
   &:hover {
     color: map.get($colors, "base-lightest");
     box-shadow: inset 0 0 0 2px map.get($colors, "base-lightest");
+    .usa-icon {
+      filter: map.get($filters, "base-lightest");
+    }
   }
   &:active {
     color: #fff;
     box-shadow: inset 0 0 0 2px #fff;
+    .usa-icon {
+      filter: map.get($filters, "white");
+    }
   }
   &:disabled,
   &:disabled:hover,
@@ -139,12 +228,18 @@ $colors: (
     background: none;
     color: map.get($colors, "disabled-dark");
     box-shadow: inset 0 0 0 2px map.get($colors, "disabled-dark");
+    .usa-icon {
+      filter: map.get($filters, "disabled-dark");
+    }
   }
 }
 
 .usa-button.usa-button--big {
   background: map.get($colors, "primary");
   color: #fff;
+  .usa-icon {
+    filter: map.get($filters, "white");
+  }
   &:hover {
     background: map.get($colors, "primary-dark");
   }
@@ -159,19 +254,31 @@ $colors: (
 .usa-button.usa-button--big-inverse {
   background: #fff;
   color: map.get($colors, "primary");
+  .usa-icon {
+    filter: map.get($filters, "primary");
+  }
   &:hover {
     background: map.get($colors, "gray-05");
     color: map.get($colors, "primary");
+    .usa-icon {
+      filter: map.get($filters, "primary");
+    }
   }
   &:active {
     background: map.get($colors, "primary-lightest");
     color: map.get($colors, "primary");
+    .usa-icon {
+      filter: map.get($filters, "primary");
+    }
   }
   &:disabled,
   &:disabled:hover,
   &:disabled:active {
     background: map.get($colors, "disabled-dark");
     color: #fff;
+    .usa-icon {
+      filter: map.get($filters, "white");
+    }
   }
 }
 
@@ -179,15 +286,24 @@ $colors: (
   background: none;
   color: map.get($colors, "unstyled-fg");
   box-shadow: none;
+  .usa-icon {
+    filter: map.get($filters, "unstyled-fg");
+  }
   &:hover {
     background: none;
     color: map.get($colors, "unstyled-fg-hover");
     box-shadow: none;
+    .usa-icon {
+      filter: map.get($filters, "unstyled-fg-hover");
+    }
   }
   &:active {
     background: none;
     color: map.get($colors, "unstyled-fg-active");
     box-shadow: none;
+    .usa-icon {
+      filter: map.get($filters, "unstyled-fg-active");
+    }
   }
 
   &:disabled,
@@ -196,6 +312,9 @@ $colors: (
     box-shadow: none;
     background: none;
     color: map.get($colors, "disabled");
+    .usa-icon {
+      filter: map.get($filters, "disabled");
+    }
   }
 
   &.usa-button--inverse,
@@ -203,19 +322,31 @@ $colors: (
   &.usa-button--big-inverse {
     background: none;
     color: map.get($colors, "unstyled-inverse");
+    .usa-icon {
+      filter: map.get($filters, "unstyled-inverse");
+    }
     &:hover {
       background: none;
       color: map.get($colors, "unstyled-inverse");
+      .usa-icon {
+        filter: map.get($filters, "unstyled-inverse");
+      }
     }
     &:active {
       background: none;
       color: map.get($colors, "unstyled-inverse-active");
+      .usa-icon {
+        filter: map.get($filters, "unstyled-inverse-active");
+      }
     }
     &:disabled,
     &:disabled:hover,
     &:disabled:active {
       background: none;
       color: map.get($colors, "disabled-dark");
+      .usa-icon {
+        filter: map.get($filters, "disabled-dark");
+      }
     }
   }
 }

--- a/src/lib/components/Button/Button.svelte
+++ b/src/lib/components/Button/Button.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
   import "./Button.scss";
+  import Link from "$lib/components/Link";
   import classNames from "$lib/util/classNames";
   import type { Variant, Type } from "./buttonOptions";
+
+  export let isLink = false;
 
   export let disabled = false;
 
@@ -11,6 +14,7 @@
 
   const variantClassesDict: Record<Variant, string[]> = {
     primary: [],
+    secondary: ["usa-button--secondary"],
     base: ["usa-button--base"],
     inverse: ["usa-button--inverse"],
     "text-only": ["usa-button--text-only"],
@@ -34,6 +38,12 @@
   );
 </script>
 
-<button {type} {disabled} aria-disabled={disabled} class={classes} on:click>
-  <slot>Button</slot>
-</button>
+{#if isLink}
+  <Link class={classes} {...$$restProps}>
+    <slot>Link</slot>
+  </Link>
+{:else}
+  <button {type} {disabled} aria-disabled={disabled} class={classes} on:click>
+    <slot>Button</slot>
+  </button>
+{/if}

--- a/src/lib/components/Button/buttonOptions.ts
+++ b/src/lib/components/Button/buttonOptions.ts
@@ -1,5 +1,6 @@
 export const variants = [
   "primary",
+  "secondary",
   "base",
   "inverse",
   "text-only",

--- a/src/lib/components/VideoCard/VideoCard.svelte
+++ b/src/lib/components/VideoCard/VideoCard.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+  export let url: string;
+  // TODO: Support fetching title and description from YouTube if title and description are not provided.
+  // TODO: Use let, actually use values in card.
+  export const title: string | null | undefined = undefined;
+  export const description: string | null | undefined = undefined;
+
+  let youtubeVideoId: string | null;
+  $: {
+    const videoUrl = new URL(url);
+    if (videoUrl.hostname.includes("youtube.com")) {
+      youtubeVideoId = videoUrl.searchParams.get("v");
+    } else if (videoUrl.hostname.includes("youtu.be")) {
+      youtubeVideoId = videoUrl.pathname.split("/")[1];
+    } else {
+      youtubeVideoId = null;
+      console.warn("Unsupported video type; could not embed video.");
+    }
+  }
+</script>
+
+<!-- TODO: Build out card instead of just embedding video directly in page. -->
+<!-- TODO: Make embed responsive. -->
+{#if youtubeVideoId}
+  <iframe
+    width="560"
+    height="315"
+    src={`https://www.youtube.com/embed/${youtubeVideoId}`}
+    title="Embedded YouTube video"
+    frameborder="0"
+    allowfullscreen
+  />
+{/if}

--- a/src/lib/components/VideoCard/index.ts
+++ b/src/lib/components/VideoCard/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./VideoCard.svelte";

--- a/src/routes/(infoPages)/+layout.svelte
+++ b/src/routes/(infoPages)/+layout.svelte
@@ -11,24 +11,34 @@
   $: sideNavTree = sideNavMap.get(topTierSlug).children;
 </script>
 
+<div class="grid-container">
+  <Breadcrumbs path={breadcrumbs} />
+</div>
+<!-- Top Tier pages have a slightly different layout, with a hero image and title above the rest of the layout. -->
 {#if __typename === "TopTier"}
-  <div class="grid-container">
-    <Breadcrumbs path={breadcrumbs} />
-  </div>
   {#if topTierPage?.heroImage}
     <!-- TODO: Update this to use a proper Hero/Image Component
        (pending merge of https://github.com/la-ldaf/ldaf-site/pull/279) -->
     <div
-      style={`background-image:url(${topTierPage?.heroImage?.imageSource?.url}); background-size: cover; background-position: center;
-  background-repeat: no-repeat; height: 33vh; width: 100%;`}
+      style={`
+        background-image:url(${topTierPage.heroImage?.imageSource?.url});
+        background-size: cover;
+        background-position: center;
+        background-repeat: no-repeat;
+        height: 33vh;
+        width: 100%;
+      `}
     />
+    {#if topTierPage.heroImage?.fotogCredit}
+      <div class="grid-container">
+        <p class="font-sans-3xs text-base-dark">
+          Photo credit: {topTierPage.heroImage.fotogCredit}
+        </p>
+      </div>
+    {/if}
   {/if}
   <div class="grid-container">
     <h1>{topTierPage?.title}</h1>
-  </div>
-{:else}
-  <div class="grid-container">
-    <Breadcrumbs path={breadcrumbs} />
   </div>
 {/if}
 <div class="grid-container">

--- a/src/routes/(infoPages)/+layout.svelte
+++ b/src/routes/(infoPages)/+layout.svelte
@@ -5,15 +5,33 @@
   import SideNav from "$lib/components/SideNav";
 
   $: ({ pathname } = $page.url);
-  $: ({ pageMetadata, sideNavMap } = $page.data);
+  $: ({ pageMetadata, sideNavMap, __typename, topTierPage } = $page.data);
   $: ({ breadcrumbs } = pageMetadata);
   $: topTierSlug = pathname.split("/")[1];
   $: sideNavTree = sideNavMap.get(topTierSlug).children;
 </script>
 
-<!-- TODO: Support variation of layout for Top Tier pages (includes hero image above breadcrumbs) -->
+{#if __typename === "TopTier"}
+  <div class="grid-container">
+    <Breadcrumbs path={breadcrumbs} />
+  </div>
+  {#if topTierPage?.heroImage}
+    <!-- TODO: Update this to use a proper Hero/Image Component
+       (pending merge of https://github.com/la-ldaf/ldaf-site/pull/279) -->
+    <div
+      style={`background-image:url(${topTierPage?.heroImage?.imageSource?.url}); background-size: cover; background-position: center;
+  background-repeat: no-repeat; height: 33vh; width: 100%;`}
+    />
+  {/if}
+  <div class="grid-container">
+    <h1>{topTierPage?.title}</h1>
+  </div>
+{:else}
+  <div class="grid-container">
+    <Breadcrumbs path={breadcrumbs} />
+  </div>
+{/if}
 <div class="grid-container">
-  <Breadcrumbs path={breadcrumbs} />
   <div class="grid-row grid-gap">
     <div class="desktop:grid-col-3 margin-bottom-2">
       <SideNav tree={sideNavTree} currentPath={pathname} />

--- a/src/routes/(infoPages)/[topTierPage]/+page.server.ts
+++ b/src/routes/(infoPages)/[topTierPage]/+page.server.ts
@@ -101,6 +101,7 @@ export const load = async ({ parent, params }) => {
     if (matchedTopTierId) {
       const pageMetadata = pageMetadataMap.get(matchedTopTierId);
       if (pageMetadata) {
+        // Get the URLs for these features from the pageMetadataMap
         const featuredServices = matchedTopTier.featuredServiceListCollection?.items.map(
           (featuredItem) => {
             const featuredItemMetadata = pageMetadataMap.get(

--- a/src/routes/(infoPages)/[topTierPage]/+page.server.ts
+++ b/src/routes/(infoPages)/[topTierPage]/+page.server.ts
@@ -10,6 +10,67 @@ const query = gql`
   query TopTierCollection {
     topTierCollection(limit: 10) {
       items {
+        __typename
+        title
+        subheading
+        heroImage {
+          ... on HeroImage {
+            imageSource {
+              ... on Asset {
+                title
+                description
+                contentType
+                fileName
+                size
+                url
+                width
+                height
+              }
+            }
+            imageTitle
+            altField
+            fotogCredit
+          }
+        }
+        video {
+          ... on VideoWrapper {
+            videoTitle
+            videoSubhead
+            videoUrl
+          }
+        }
+        description {
+          json
+        }
+        featuredServiceListCollection {
+          items {
+            ... on ServiceGroup {
+              title
+              subheading
+              heroImage {
+                ... on HeroImage {
+                  imageSource {
+                    title
+                    description
+                    contentType
+                    fileName
+                    size
+                    url
+                    width
+                    height
+                  }
+                }
+              }
+              pageMetadata {
+                ... on PageMetadata {
+                  sys {
+                    id
+                  }
+                }
+              }
+            }
+          }
+        }
         pageMetadata {
           ... on PageMetadata {
             sys {
@@ -40,7 +101,19 @@ export const load = async ({ parent, params }) => {
     if (matchedTopTierId) {
       const pageMetadata = pageMetadataMap.get(matchedTopTierId);
       if (pageMetadata) {
-        return { pageMetadata };
+        const featuredServices = matchedTopTier.featuredServiceListCollection?.items.map(
+          (featuredItem) => {
+            const featuredItemMetadata = pageMetadataMap.get(
+              featuredItem?.pageMetadata?.sys.id || ""
+            );
+            return { ...featuredItem, url: featuredItemMetadata?.url };
+          }
+        );
+        return {
+          __typename: matchedTopTier.__typename,
+          topTierPage: { ...matchedTopTier, featuredServices },
+          pageMetadata,
+        };
       }
     } else {
       console.warn(

--- a/src/routes/(infoPages)/[topTierPage]/+page.svelte
+++ b/src/routes/(infoPages)/[topTierPage]/+page.svelte
@@ -1,7 +1,81 @@
 <script lang="ts">
+  import { url as arrowIcon } from "$icons/arrow_forward";
+
+  import Card from "$lib/components/Card";
+  import ContentfulRichText from "$lib/components/ContentfulRichText";
+  import Icon from "$lib/components/Icon";
+
   export let data;
-  $: ({ pageMetadata } = data);
+  $: ({ topTierPage, pageMetadata } = data);
+  $: ({ subheading, video, description, featuredServices } = topTierPage);
 </script>
 
-<h1>{pageMetadata?.title}</h1>
-<p>This is a stub for a Top Tier page!</p>
+<h2>
+  {subheading}
+</h2>
+{#if description}
+  <ContentfulRichText document={description?.json} />
+{/if}
+{#if video?.videoUrl}
+  <div>
+    <!-- TODO: Perform some querystring parsing to get the video ID -->
+    <iframe
+      width="560"
+      height="315"
+      src={`https://www.youtube.com/embed/${video.videoUrl.slice(-11)}`}
+      title="YouTube video player"
+      frameborder="0"
+      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+      allowfullscreen
+    />
+  </div>
+{/if}
+{#if featuredServices}
+  <ul class="ldaf-card-list">
+    {#each featuredServices as item}
+      {#if item?.heroImage?.imageSource?.url}
+        <Card>
+          <h3 class="usa-card__heading" slot="header">{item.title}</h3>
+          <img
+            slot="image"
+            src={item.heroImage.imageSource.url}
+            alt={item.heroImage.imageSource.title}
+          />
+          <svelte:fragment slot="body">
+            {#if item.subheading}
+              {item.subheading}
+            {/if}
+          </svelte:fragment>
+          <!-- TODO: Use <Link /> pending LDAF-301 (link styled as button support) -->
+          <a slot="footer" href={item?.url} class="usa-button ldaf-card-button">
+            <Icon src={arrowIcon} size={3} />
+          </a>
+        </Card>
+      {:else}
+        <Card>
+          <h3 class="usa-card__heading" slot="header">{item.title}</h3>
+          <svelte:fragment slot="body">
+            {#if item.subheading}
+              {item.subheading}
+            {/if}
+          </svelte:fragment>
+          <!-- TODO: Use <Link /> pending LDAF-301 (link styled as button support) -->
+          <a slot="footer" href={item.url} class="usa-button ldaf-card-button">
+            <Icon src={arrowIcon} size={3} />
+          </a>
+        </Card>
+      {/if}
+    {/each}
+  </ul>
+{/if}
+
+<style>
+  .ldaf-card-list {
+    padding-inline-start: 0;
+    list-style: none;
+  }
+  .ldaf-card-button {
+    background: white;
+    border: 2px solid black;
+  }
+</style>

--- a/src/routes/(infoPages)/[topTierPage]/+page.svelte
+++ b/src/routes/(infoPages)/[topTierPage]/+page.svelte
@@ -8,7 +8,8 @@
   import VideoCard from "$lib/components/VideoCard";
 
   export let data;
-  $: ({ subheading, video, description, featuredServices } = data?.topTierPage);
+  $: ({ topTierPage } = data);
+  $: ({ subheading, video, description, featuredServices } = topTierPage);
 
   const getButtonVariant = (index: number): Variant => {
     switch (index) {

--- a/src/routes/(infoPages)/[topTierPage]/+page.svelte
+++ b/src/routes/(infoPages)/[topTierPage]/+page.svelte
@@ -5,6 +5,7 @@
   import Card from "$lib/components/Card";
   import ContentfulRichText from "$lib/components/ContentfulRichText";
   import Icon from "$lib/components/Icon";
+  import VideoCard from "$lib/components/VideoCard";
 
   export let data;
   $: ({ topTierPage, pageMetadata } = data);
@@ -29,18 +30,7 @@
   <ContentfulRichText document={description?.json} />
 {/if}
 {#if video?.videoUrl}
-  <div>
-    <!-- TODO: Perform some querystring parsing to get the video ID -->
-    <iframe
-      width="560"
-      height="315"
-      src={`https://www.youtube.com/embed/${video.videoUrl.slice(-11)}`}
-      title="YouTube video player"
-      frameborder="0"
-      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-      allowfullscreen
-    />
-  </div>
+  <VideoCard url={video.videoUrl} title={video.videoTitle} description={video.videoSubhead} />
 {/if}
 {#if featuredServices}
   <ul class="ldaf-card-list">

--- a/src/routes/(infoPages)/[topTierPage]/+page.svelte
+++ b/src/routes/(infoPages)/[topTierPage]/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { url as arrowIcon } from "$icons/arrow_forward";
 
+  import Button, { type Variant } from "$lib/components/Button";
   import Card from "$lib/components/Card";
   import ContentfulRichText from "$lib/components/ContentfulRichText";
   import Icon from "$lib/components/Icon";
@@ -8,6 +9,17 @@
   export let data;
   $: ({ topTierPage, pageMetadata } = data);
   $: ({ subheading, video, description, featuredServices } = topTierPage);
+
+  const getButtonVariant = (index: number): Variant => {
+    switch (index) {
+      case 0:
+        return "primary";
+      case 1:
+        return "secondary";
+      default:
+        return "outline";
+    }
+  };
 </script>
 
 <h2>
@@ -32,7 +44,7 @@
 {/if}
 {#if featuredServices}
   <ul class="ldaf-card-list">
-    {#each featuredServices as item}
+    {#each featuredServices as item, index (item?.pageMetadata?.sys.id)}
       {#if item?.heroImage?.imageSource?.url}
         <Card>
           <h3 class="usa-card__heading" slot="header">{item.title}</h3>
@@ -47,9 +59,15 @@
             {/if}
           </svelte:fragment>
           <!-- TODO: Use <Link /> pending LDAF-301 (link styled as button support) -->
-          <a slot="footer" href={item?.url} class="usa-button ldaf-card-button">
+          <Button
+            slot="footer"
+            isLink={true}
+            variant={getButtonVariant(index)}
+            href={item.url}
+            class="usa-button ldaf-card-button"
+          >
             <Icon src={arrowIcon} size={3} />
-          </a>
+          </Button>
         </Card>
       {:else}
         <Card>
@@ -60,9 +78,15 @@
             {/if}
           </svelte:fragment>
           <!-- TODO: Use <Link /> pending LDAF-301 (link styled as button support) -->
-          <a slot="footer" href={item.url} class="usa-button ldaf-card-button">
+          <Button
+            slot="footer"
+            isLink={true}
+            variant={getButtonVariant(index)}
+            href={item.url}
+            class="usa-button ldaf-card-button"
+          >
             <Icon src={arrowIcon} size={3} />
-          </a>
+          </Button>
         </Card>
       {/if}
     {/each}
@@ -73,9 +97,5 @@
   .ldaf-card-list {
     padding-inline-start: 0;
     list-style: none;
-  }
-  .ldaf-card-button {
-    background: white;
-    border: 2px solid black;
   }
 </style>

--- a/src/routes/(infoPages)/[topTierPage]/+page.svelte
+++ b/src/routes/(infoPages)/[topTierPage]/+page.svelte
@@ -73,10 +73,3 @@
     {/each}
   </ul>
 {/if}
-
-<style>
-  .ldaf-card-list {
-    padding-inline-start: 0;
-    list-style: none;
-  }
-</style>

--- a/src/routes/(infoPages)/[topTierPage]/+page.svelte
+++ b/src/routes/(infoPages)/[topTierPage]/+page.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import "./page.scss";
+
   import { url as arrowIcon } from "$icons/arrow_forward";
 
   import Button, { type Variant } from "$lib/components/Button";
@@ -35,7 +37,7 @@
   <VideoCard url={video.videoUrl} title={video.videoTitle} description={video.videoSubhead} />
 {/if}
 {#if featuredServices}
-  <ul class="ldaf-card-list">
+  <ul class="service-group-list">
     {#each featuredServices as item, index (item?.pageMetadata?.sys.id)}
       <!-- TODO: Can't conditionally render a named slot, but ideally we only declare Card once here. -->
       {#if item?.heroImage?.imageSource?.url}

--- a/src/routes/(infoPages)/[topTierPage]/+page.svelte
+++ b/src/routes/(infoPages)/[topTierPage]/+page.svelte
@@ -8,8 +8,7 @@
   import VideoCard from "$lib/components/VideoCard";
 
   export let data;
-  $: ({ topTierPage, pageMetadata } = data);
-  $: ({ subheading, video, description, featuredServices } = topTierPage);
+  $: ({ subheading, video, description, featuredServices } = data?.topTierPage);
 
   const getButtonVariant = (index: number): Variant => {
     switch (index) {
@@ -23,11 +22,13 @@
   };
 </script>
 
-<h2>
-  {subheading}
-</h2>
-{#if description}
-  <ContentfulRichText document={description?.json} />
+{#if subheading}
+  <h2>
+    {subheading}
+  </h2>
+{/if}
+{#if description?.json}
+  <ContentfulRichText document={description.json} />
 {/if}
 {#if video?.videoUrl}
   <VideoCard url={video.videoUrl} title={video.videoTitle} description={video.videoSubhead} />
@@ -35,6 +36,7 @@
 {#if featuredServices}
   <ul class="ldaf-card-list">
     {#each featuredServices as item, index (item?.pageMetadata?.sys.id)}
+      <!-- TODO: Can't conditionally render a named slot, but ideally we only declare Card once here. -->
       {#if item?.heroImage?.imageSource?.url}
         <Card>
           <h3 class="usa-card__heading" slot="header">{item.title}</h3>
@@ -48,14 +50,7 @@
               {item.subheading}
             {/if}
           </svelte:fragment>
-          <!-- TODO: Use <Link /> pending LDAF-301 (link styled as button support) -->
-          <Button
-            slot="footer"
-            isLink={true}
-            variant={getButtonVariant(index)}
-            href={item.url}
-            class="usa-button ldaf-card-button"
-          >
+          <Button slot="footer" isLink={true} variant={getButtonVariant(index)} href={item.url}>
             <Icon src={arrowIcon} size={3} />
           </Button>
         </Card>
@@ -67,14 +62,7 @@
               {item.subheading}
             {/if}
           </svelte:fragment>
-          <!-- TODO: Use <Link /> pending LDAF-301 (link styled as button support) -->
-          <Button
-            slot="footer"
-            isLink={true}
-            variant={getButtonVariant(index)}
-            href={item.url}
-            class="usa-button ldaf-card-button"
-          >
+          <Button slot="footer" isLink={true} variant={getButtonVariant(index)} href={item.url}>
             <Icon src={arrowIcon} size={3} />
           </Button>
         </Card>

--- a/src/routes/(infoPages)/[topTierPage]/[...serviceGroupPage]/+page.svelte
+++ b/src/routes/(infoPages)/[topTierPage]/[...serviceGroupPage]/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import "../page.scss";
   import Accordion, { AccordionItem } from "$lib/components/Accordion";
+  import Button from "$lib/components/Button";
   import Card from "$lib/components/Card/Card.svelte";
   import ContactCard from "$lib/components/ContactCard";
   import ContentfulRichText from "$lib/components/ContentfulRichText";
@@ -57,10 +58,9 @@
             {item.subheading}
           {/if}
         </svelte:fragment>
-        <!-- TODO: Use <Link /> pending LDAF-301 (link styled as button support) -->
-        <a slot="footer" href={item.url} class="usa-button">
+        <Button slot="footer" isLink={true} href={item.url}>
           <Icon src={arrowIcon} size={3} />
-        </a>
+        </Button>
       </Card>
     {/each}
   </ul>

--- a/src/routes/(infoPages)/[topTierPage]/[...serviceGroupPage]/+page.svelte
+++ b/src/routes/(infoPages)/[topTierPage]/[...serviceGroupPage]/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import "./page.scss";
+  import "../page.scss";
   import Accordion, { AccordionItem } from "$lib/components/Accordion";
   import Card from "$lib/components/Card/Card.svelte";
   import ContactCard from "$lib/components/ContactCard";

--- a/src/routes/(infoPages)/[topTierPage]/page.scss
+++ b/src/routes/(infoPages)/[topTierPage]/page.scss
@@ -1,7 +1,3 @@
-.service-group-card .usa-icon {
-  filter: invert(1);
-}
-
 // TODO: Create a <CardGroup /> Wrapper to
 // avoid dealing with  the <ul> and styling overrides here.
 .service-group-list {


### PR DESCRIPTION
Jira ticket: [LDAF-341](https://ldaf.atlassian.net/browse/LDAF-341)

## Proposed changes

Adds a rough implementation of the Top Tier pages, e.g. `/animals`, `/plants`, etc. Highlights are:

- Render the Top Tier pages with a hero image, title, subheading, description, video embed, and featured service cards.
- Update the base `(infoPages)` layout so that it supports `TopTier` pages as well (hero image, photo credit, and title appear above the two-column layout).
  - The buttons on the Cards should vary depending on where they are in the order (first is `primary`, second is `secondary`, rest are `outline`).
- Some updates to the `Button` component:
  - Render a `Link` instead of a `button` if `isLink` is set to `true`.
  - Add a `secondary` variant (yellow).
  - Add some messy support for coloring our SVG icons that appear in `Button` components by setting the `filter` on these images so that they roughly match the `color`.
- Stub out a `VideoCard` component that just embeds a YouTube video in an `iframe` for now.

## Acceptance criteria validation

Following content should appear on the page:
- [x] Hero Image
- [x] Title
- [x] Subheading
- [x] Description
- [x] Featured service list (displayed as cards in a grid)

## Requested feedback

See self-review.


[LDAF-341]: https://ldaf.atlassian.net/browse/LDAF-341?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ