### PR TITLE
Update secondary nav links and stub out 'Licensing and permits' page.

### DIFF
--- a/src/lib/components/Header/Nav/__tests__/SecondaryNavTestContent.ts
+++ b/src/lib/components/Header/Nav/__tests__/SecondaryNavTestContent.ts
@@ -1,6 +1,6 @@
 const secondaryNavTestContent = [
-  { id: "0", name: "Grants and funding", link: "/news" },
-  { id: "1", name: "Licensing and permits", link: "/documentation" },
+  { id: "0", name: "Grants and funding", link: "/business/grants-funding" },
+  { id: "1", name: "Licensing and permits", link: "/licensing-permits" },
 ];
 
 export default secondaryNavTestContent;

--- a/src/routes/licensing-permits/+page.server.ts
+++ b/src/routes/licensing-permits/+page.server.ts
@@ -1,0 +1,9 @@
+export const load = async ({ parent }) => {
+  const { pageMetadataMap } = await parent();
+  const matchedPageMetadata = [...pageMetadataMap].find(([_, page]) => {
+    return page.url === "/licensing-permits";
+  });
+  if (matchedPageMetadata && matchedPageMetadata.length === 2) {
+    return { pageMetadata: matchedPageMetadata[1] };
+  }
+};

--- a/src/routes/licensing-permits/+page.svelte
+++ b/src/routes/licensing-permits/+page.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+  export let data;
+  $: ({ pageMetadata } = data);
+</script>
+
+<div class="grid-container">
+  <main class="margin-top-2 usa-prose" id="main-content">
+    <h1>{pageMetadata?.title}</h1>
+    <p>This is a stub for the Licensing and Permits Aggregation page!</p>
+  </main>
+</div>


### PR DESCRIPTION
This is a very quick fix just to get the secondary nav updated. Should be straightforward but let me know if you have any questions!