### PR TITLE
Hard code some content on the licensing and permits page for user testing.

### DIFF
--- a/src/routes/licensing-permits/+page.svelte
+++ b/src/routes/licensing-permits/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import Link from "$lib/components/Link";
   export let data;
   $: ({ pageMetadata } = data);
 </script>
@@ -6,6 +7,34 @@
 <div class="grid-container">
   <main class="margin-top-2 usa-prose" id="main-content">
     <h1>{pageMetadata?.title}</h1>
-    <p>This is a stub for the Licensing and Permits Aggregation page!</p>
+    <ul>
+      <li><Link href="/land/arborists">Arborist licensing</Link></li>
+      <li>
+        <Link href="/business/warehousing-distribution">Commodity warehousing and distribution</Link
+        >
+      </li>
+      <li>
+        <Link href="/plants/florists">Florist and flower dealer licensing</Link>
+      </li>
+      <li>
+        <Link href="/plants/industrial-hemp/hemp-licensing">Industrial hemp licensing</Link>
+      </li>
+      <li>
+        <Link href="/plants/nurseries-landscaping">Nursery and landscape licensing</Link>
+      </li>
+      <li>
+        <Link href="/plants/pesticides">Pesticide licensing and registration</Link>
+      </li>
+      <li>
+        <Link href="/business/pest-control/pest-control-licensing"
+          >Structural pest control licensing and registration</Link
+        >
+      </li>
+      <li>
+        <Link href="/business/weights-measures/weighmaster-technician-licensing"
+          >Weighmaster and technician licensing</Link
+        >
+      </li>
+    </ul>
   </main>
 </div>


### PR DESCRIPTION
@uxrebecca sent over some temporary content for us to put on the "Licensing and permits" page as a stop-gap until we can properly implement the aggregator page.