### PR TITLE
Use Image component instead of img tags, reset image state on src change

### DIFF
--- a/src/lib/components/Card/Card.scss
+++ b/src/lib/components/Card/Card.scss
@@ -1,3 +1,8 @@
+.usa-card__img {
+  width: 100%;
+  height: 100%;
+}
+
 .usa-card__img .ldaf-img {
   height: 100%;
 }

--- a/src/lib/components/DotGovBanner/DotGovBanner.svelte
+++ b/src/lib/components/DotGovBanner/DotGovBanner.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import "./DotGovBanner.scss";
-  import ldafLogo from "$lib/assets/ldaf-flat-logo-transparent.png";
+  import ldafLogo from "$lib/assets/ldaf-flat-logo-transparent.png?w=16&imagetools";
+  import ldafLogo2x from "$lib/assets/ldaf-flat-logo-transparent.png?w=32&imagetools";
   import { url as dotGovIcon } from "$icons/icon-dot-gov";
   import { url as httpsIcon } from "$icons/icon-https";
   import Icon from "$lib/components/Icon";
@@ -21,9 +22,11 @@
             aria-hidden={!bannerExpanded}
             class="usa-banner__header-flag ldaf-logo"
             src={ldafLogo}
+            srcset={`${ldafLogo2x} 32w, ${ldafLogo} 16w`}
+            sizes="16px"
             alt="Louisiana Department of Agriculture and Forestry Logo"
             width={16}
-            height={11}
+            height={16}
           />
         </div>
         <div class="grid-col-fill tablet:grid-col-auto" aria-hidden={!bannerExpanded}>

--- a/src/lib/components/Header/Logo/Logo.svelte
+++ b/src/lib/components/Header/Logo/Logo.svelte
@@ -15,7 +15,6 @@
   alt="Louisiana Department of Agriculture and Forestry Home"
   {width}
   {height}
-  fit={false}
   loading="eager"
   sources={[
     { type: "image/avif", srcset: [ldafLogoAvif, [ldafLogoAvif2x, width * 2]] },

--- a/src/lib/components/Image/Image.scss
+++ b/src/lib/components/Image/Image.scss
@@ -1,6 +1,7 @@
 .ldaf-img__container {
   position: relative;
   overflow: hidden;
+  isolation: isolate;
 }
 
 .ldaf-img__img {
@@ -12,6 +13,7 @@
   width: 100%;
   height: 100%;
   object-fit: cover;
+  object-position: center;
 }
 
 @keyframes fadeIn {

--- a/src/lib/components/Image/Image.svelte
+++ b/src/lib/components/Image/Image.svelte
@@ -20,13 +20,15 @@
 
   export let src: string;
 
-  const getSrcsetAttr = ([defaultSrc, ...widthsOrDPIStrings]: Srcset) =>
-    [
-      ...widthsOrDPIStrings.map(
-        ([source, sourceWidthOrDPIString]) => `${source} ${sourceWidthOrDPIString}w`
-      ),
-      width ? `${defaultSrc} ${width}w` : defaultSrc,
+  const getSrcsetAttr = (srcset: Srcset): string | undefined => {
+    if (srcset.length === 0) return;
+    const hasFallback = typeof srcset[0] === "string";
+    const sourcesAndWidths = hasFallback ? srcset.slice(1) : srcset;
+    return [
+      ...sourcesAndWidths.map(([source, width]) => `${source} ${width}w`),
+      ...(hasFallback ? [`${srcset[0]} ${width}w`] : []),
     ].join(", ");
+  };
 
   export let sources: Sources | GetSources | undefined = undefined;
 

--- a/src/lib/components/Image/Image.svelte
+++ b/src/lib/components/Image/Image.svelte
@@ -7,6 +7,7 @@
   import IntersectionObserver from "$lib/components/IntersectionObserver";
   import warn from "$lib/util/warn";
   import type { Loading, LazyLoading, Color, Sources, GetSources, Srcset } from "./types";
+  import { afterUpdate } from "svelte";
 
   export let height: number | undefined = undefined;
   export let width: number | undefined = undefined;

--- a/src/lib/components/Image/types.ts
+++ b/src/lib/components/Image/types.ts
@@ -3,7 +3,7 @@ export type Loading = "eager" | "lazy";
 export type LazyLoading = "none" | "native" | "intersectionObserver";
 
 type SrcsetSrc = [string, number];
-export type Srcset = [string, ...SrcsetSrc[]];
+export type Srcset = [string, ...SrcsetSrc[]] | SrcsetSrc[];
 
 export type Format = `image/${string}`;
 export type Source = {

--- a/src/lib/constants/images.ts
+++ b/src/lib/constants/images.ts
@@ -1,11 +1,11 @@
 import partition from "lodash/partition";
 
-export const sizeTypes = ["full-bleed", "col-12", "col-9"] as const;
+export const sizeTypes = ["full-bleed", "col-12", "col-9", "card"] as const;
 export type SizeType = (typeof sizeTypes)[number];
 
 type ScreenSize = number;
 
-const screenSizesInit = [360, 412, 720, 960, 1024, 1280, 1366, 1440, 1920, 2560, 3840];
+const screenSizesInit = [360, 412, 640, 720, 960, 1024, 1280, 1366, 1440, 1920, 2560, 3840];
 export const screenSizes = [
   ...new Set([...screenSizesInit, ...screenSizesInit.map((n) => n * 2)]),
 ].sort((a, b) => a - b);
@@ -21,6 +21,11 @@ export const defaultWidths = [...screenSizes, ...screenSizes.map((n) => n * 2)].
   (a, b) => a - b
 );
 
+const [cardMobileScreenSizes, cardDesktopScreenSizes] = partition(screenSizes, (n) => n <= 640);
+const cardMobileSizes = Object.fromEntries(
+  cardMobileScreenSizes.map((size) => [size, size - mobilePadding - 2])
+) as Record<ScreenSize, number>;
+
 export const sizesByScreenSizeByType: Record<SizeType, Record<ScreenSize, number>> = {
   // typescript doesn't type the return value of Object.fromEntries as cleanly as it could, so the
   // "as" is necessary. we know it's safe because it's based solely on "as const" values above
@@ -32,6 +37,10 @@ export const sizesByScreenSizeByType: Record<SizeType, Record<ScreenSize, number
   "col-9": {
     ...mobileSizesInGrid,
     ...Object.fromEntries(desktopScreenSizes.map((size) => [size, 712])),
+  },
+  card: {
+    ...cardMobileSizes,
+    ...Object.fromEntries(cardDesktopScreenSizes.map((size) => [size, 240])),
   },
 };
 

--- a/src/routes/(infoPages)/+layout.svelte
+++ b/src/routes/(infoPages)/+layout.svelte
@@ -31,6 +31,7 @@
       blurhash={topTierPage.heroImage.imageSource.blurhash}
       fit={true}
       preserveAspectRatio={false}
+      loading="eager"
     />
     {#if topTierPage.heroImage.fotogCredit}
       <div class="grid-container">

--- a/src/routes/(infoPages)/+layout.svelte
+++ b/src/routes/(infoPages)/+layout.svelte
@@ -1,8 +1,11 @@
 <!-- Shared layout for all informative pages (Top Tiers, Service Groups, Offices, Boards/Commissions)-->
 <script lang="ts">
+  import "./layout.scss";
   import { page } from "$app/stores";
   import Breadcrumbs from "$lib/components/Breadcrumbs";
   import SideNav from "$lib/components/SideNav";
+  import Image from "$lib/components/Image";
+  import { getSources } from "$lib/imageServices/contentful";
 
   $: ({ pathname } = $page.url);
   $: ({ pageMetadata, sideNavMap, __typename, topTierPage } = $page.data);
@@ -16,20 +19,20 @@
 </div>
 <!-- Top Tier pages have a slightly different layout, with a hero image and title above the rest of the layout. -->
 {#if __typename === "TopTier"}
-  {#if topTierPage?.heroImage}
-    <!-- TODO: Update this to use a proper Hero/Image Component
-       (pending merge of https://github.com/la-ldaf/ldaf-site/pull/279) -->
-    <div
-      style={`
-        background-image:url(${topTierPage.heroImage?.imageSource?.url});
-        background-size: cover;
-        background-position: center;
-        background-repeat: no-repeat;
-        height: 33vh;
-        width: 100%;
-      `}
+  {#if topTierPage?.heroImage?.imageSource}
+    <Image
+      class="top-tier-page-hero-image"
+      src={topTierPage.heroImage.imageSource.url}
+      alt={topTierPage.heroImage.imageSource.description}
+      sources={getSources}
+      width={topTierPage.heroImage.imageSource.width}
+      height={topTierPage.heroImage.imageSource.height}
+      sizeType="full-bleed"
+      blurhash={topTierPage.heroImage.imageSource.blurhash}
+      fit={true}
+      preserveAspectRatio={false}
     />
-    {#if topTierPage.heroImage?.fotogCredit}
+    {#if topTierPage.heroImage.fotogCredit}
       <div class="grid-container">
         <p class="font-sans-3xs text-base-dark">
           Photo credit: {topTierPage.heroImage.fotogCredit}

--- a/src/routes/(infoPages)/[topTierPage]/+page.svelte
+++ b/src/routes/(infoPages)/[topTierPage]/+page.svelte
@@ -8,6 +8,8 @@
   import ContentfulRichText from "$lib/components/ContentfulRichText";
   import Icon from "$lib/components/Icon";
   import VideoCard from "$lib/components/VideoCard";
+  import Image from "$lib/components/Image/Image.svelte";
+  import { getSources } from "$lib/imageServices/contentful";
 
   export let data;
   $: ({ topTierPage } = data);
@@ -48,10 +50,13 @@
       {#if item?.heroImage?.imageSource?.url}
         <Card>
           <h3 class="usa-card__heading" slot="header">{item.title}</h3>
-          <img
+          <Image
             slot="image"
             src={item.heroImage.imageSource.url}
             alt={item.heroImage.imageSource.title}
+            blurhash={item.heroImage.imageSource.blurhash}
+            height={item.heroImage.imageSource.height}
+            width={item.heroImage.imageSource.width}
           />
           <svelte:fragment slot="body">
             {#if item.subheading}

--- a/src/routes/(infoPages)/[topTierPage]/+page.svelte
+++ b/src/routes/(infoPages)/[topTierPage]/+page.svelte
@@ -43,7 +43,7 @@
     variation="secondary"
   />
 {/if}
-{#if featuredServices}
+{#if featuredServices && featuredServices.length > 0}
   <ul class="service-group-list">
     {#each featuredServices as item, index (item?.pageMetadata?.sys.id)}
       <!-- TODO: Can't conditionally render a named slot, but ideally we only declare Card once here. -->
@@ -53,10 +53,12 @@
           <Image
             slot="image"
             src={item.heroImage.imageSource.url}
-            alt={item.heroImage.imageSource.title}
-            blurhash={item.heroImage.imageSource.blurhash}
-            height={item.heroImage.imageSource.height}
-            width={item.heroImage.imageSource.width}
+            sources={getSources}
+            alt={item.heroImage.imageSource.title ?? "Hero image"}
+            blurhash={item.heroImage.imageSource.blurhash ?? undefined}
+            height={item.heroImage.imageSource.height ?? undefined}
+            width={item.heroImage.imageSource.width ?? undefined}
+            sizeType="card"
           />
           <svelte:fragment slot="body">
             {#if item.subheading}

--- a/src/routes/(infoPages)/layout.scss
+++ b/src/routes/(infoPages)/layout.scss
@@ -1,0 +1,3 @@
+.top-tier-page-hero-image {
+  height: 33vh;
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -44,7 +44,6 @@
         {#if item?.heroImage?.imageSource?.url}
           <Card class={`usa-card--${cardSize}`}>
             <h2 class="usa-card__heading" slot="header">{item.title}</h2>
-            <!-- TODO: After merging #348, set Image sizeType="card" -->
             <Image
               slot="image"
               src={item.heroImage.imageSource.url}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -54,6 +54,7 @@
               width={item.heroImage.imageSource.width ?? undefined}
               height={item.heroImage.imageSource.height ?? undefined}
               fit
+              sizeType="card"
               loading={imageLoading}
             />
             <svelte:fragment slot="body">

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -53,7 +53,6 @@
               blurhash={item.heroImage.imageSource?.blurhash ?? undefined}
               width={item.heroImage.imageSource.width ?? undefined}
               height={item.heroImage.imageSource.height ?? undefined}
-              fit
               sizeType="card"
               loading={imageLoading}
             />


### PR DESCRIPTION
## Proposed changes

- Uses `Image` for the hero image and card images on top tier pages
- Uses a very small version of the logo to display in the banner
- Resets the state of the Image component on src change, fixing the stale-image-on-client-side-navigation issue
- Some small fixes

## Acceptance criteria validation

- [x] Tested manually
- [x] All tests continue to pass