### PR TITLE
Fix service group page by splitting query

### DIFF
--- a/src/lib/fragments/imageProps.ts
+++ b/src/lib/fragments/imageProps.ts
@@ -1,0 +1,14 @@
+import gql from "graphql-tag";
+export default gql`
+  fragment ImageProps on Asset {
+    sys {
+      id
+    }
+    contentType
+    title
+    description
+    url
+    width
+    height
+  }
+`;

--- a/src/lib/util/chunks.ts
+++ b/src/lib/util/chunks.ts
@@ -1,0 +1,8 @@
+export default <T>(arr: T[], chunkSize: number): T[][] => {
+  if (chunkSize === 0) return [];
+  const chunks: T[][] = [];
+  for (let i = 0; i < arr.length; i += chunkSize) {
+    chunks.push(arr.slice(i, i + chunkSize));
+  }
+  return chunks;
+};

--- a/src/routes/(infoPages)/[topTierPage]/[...serviceGroupPage]/+page.server.ts
+++ b/src/routes/(infoPages)/[topTierPage]/[...serviceGroupPage]/+page.server.ts
@@ -138,6 +138,9 @@ const childServiceGroupsQuery = gql`
   query ServiceGroupChildGroups($ids: [String]!) {
     serviceGroupCollection(limit: 10, where: { sys: { id_in: $ids } }) {
       items {
+        sys {
+          id
+        }
         pageMetadata {
           sys {
             id
@@ -195,6 +198,18 @@ export type ServiceGroupPage = {
   pageMetadata?: ServiceGroupMetadata;
 };
 
+const inOrder = <T>(items: T[], fn: (item: T) => string, order: string[]) => {
+  if (order.length !== items.length) {
+    throw new Error("ID order array does not match the provided items");
+  }
+  const ids = items.map(fn);
+  const record = Object.fromEntries(ids.map((id, i) => [id, items[i]]));
+  if (!order.every((id) => record[id])) {
+    throw new Error("ID order array does not match the provided items");
+  }
+  return order.map((id) => record[id]);
+};
+
 export const load = async ({
   parent,
   params: { topTierPage, serviceGroupPage },
@@ -220,11 +235,14 @@ export const load = async ({
     if (!baseData) break fetchData;
     const [serviceGroup] = baseData?.serviceGroupCollection?.items ?? [];
     if (!serviceGroup) break fetchData;
+
     const heroImageURL = serviceGroup?.heroImage?.imageSource?.url;
     const heroImageBlurhashPromise = heroImageURL && getBlurhash(heroImageURL, { fetch });
-    const descriptionBlurhashesPromise = getBlurhashMapFromRichText(serviceGroup?.description, {
-      fetch,
-    });
+    const descriptionBlurhashesPromise =
+      serviceGroup.description &&
+      getBlurhashMapFromRichText(serviceGroup.description, {
+        fetch,
+      });
 
     const childServiceEntryIDs =
       serviceGroup.serviceEntriesCollection?.items
@@ -257,9 +275,13 @@ export const load = async ({
         : { serviceGroupCollection: { items: [] } },
     ]);
 
-    const childServiceEntriesItems = childEntriesDataChunks
-      .map((dataChunk) => dataChunk?.serviceEntryCollection?.items ?? [])
-      .flat();
+    const childServiceEntriesItems = inOrder(
+      childEntriesDataChunks
+        .map((dataChunk) => dataChunk?.serviceEntryCollection?.items ?? [])
+        .flat(),
+      (item) => item?.sys?.id,
+      childServiceEntryIDs
+    );
 
     const childServiceEntriesPromise = Promise.all(
       childServiceEntriesItems?.map(async (entry) =>
@@ -279,14 +301,17 @@ export const load = async ({
       ) ?? []
     ).then((arr) => arr.flat());
 
-    const childServiceGroups =
+    const childServiceGroups = inOrder(
       childGroupsData?.serviceGroupCollection?.items?.flatMap((group) => {
         if (!group) return [];
         const { id } = group.pageMetadata?.sys ?? {};
         if (!id) return [group];
         const { url } = pageMetadataMap.get(id) ?? {};
         return [{ ...group, url }];
-      }) ?? [];
+      }) ?? [],
+      (item) => item?.sys?.id,
+      childServiceGroupIDs
+    );
 
     // additionalResources is not yet used on the page, so we don't fetch its blurhashes
 

--- a/src/routes/(infoPages)/[topTierPage]/[...serviceGroupPage]/+page.server.ts
+++ b/src/routes/(infoPages)/[topTierPage]/[...serviceGroupPage]/+page.server.ts
@@ -240,15 +240,21 @@ export const load = async ({
 
     const [childEntriesDataChunks, childGroupsData] = await Promise.all([
       Promise.all(
-        childServiceEntryIDChunks.map((chunk) =>
-          client.fetch<ServiceGroupChildEntriesQuery>(printQuery(childServiceEntriesQuery), {
-            variables: { ids: chunk },
-          })
+        childServiceEntryIDChunks.flatMap((chunk) =>
+          chunk.length > 0
+            ? [
+                client.fetch<ServiceGroupChildEntriesQuery>(printQuery(childServiceEntriesQuery), {
+                  variables: { ids: chunk },
+                }),
+              ]
+            : []
         )
       ),
-      client.fetch<ServiceGroupChildGroupsQuery>(printQuery(childServiceGroupsQuery), {
-        variables: { ids: childServiceGroupIDs },
-      }),
+      childServiceGroupIDs.length > 0
+        ? client.fetch<ServiceGroupChildGroupsQuery>(printQuery(childServiceGroupsQuery), {
+            variables: { ids: childServiceGroupIDs },
+          })
+        : { serviceGroupCollection: { items: [] } },
     ]);
 
     const childServiceEntriesItems = childEntriesDataChunks

--- a/src/routes/(infoPages)/[topTierPage]/[...serviceGroupPage]/+page.server.ts
+++ b/src/routes/(infoPages)/[topTierPage]/[...serviceGroupPage]/+page.server.ts
@@ -276,9 +276,12 @@ export const load = async ({
     ]);
 
     const childServiceEntriesItems = inOrder(
-      childEntriesDataChunks
-        .map((dataChunk) => dataChunk?.serviceEntryCollection?.items ?? [])
-        .flat(),
+      childEntriesDataChunks.flatMap(
+        (dataChunk) =>
+          dataChunk?.serviceEntryCollection?.items.filter(
+            (item): item is NonNullable<typeof item> => !!item
+          ) ?? []
+      ),
       (item) => item?.sys?.id,
       childServiceEntryIDs
     );

--- a/src/routes/(infoPages)/[topTierPage]/[...serviceGroupPage]/+page.server.ts
+++ b/src/routes/(infoPages)/[topTierPage]/[...serviceGroupPage]/+page.server.ts
@@ -285,7 +285,7 @@ export const load = async ({
         const { id } = group.pageMetadata?.sys ?? {};
         if (!id) return [group];
         const { url } = pageMetadataMap.get(id) ?? {};
-        return { ...group, url };
+        return [{ ...group, url }];
       }) ?? [];
 
     // additionalResources is not yet used on the page, so we don't fetch its blurhashes

--- a/src/routes/(infoPages)/[topTierPage]/[...serviceGroupPage]/+page.server.ts
+++ b/src/routes/(infoPages)/[topTierPage]/[...serviceGroupPage]/+page.server.ts
@@ -235,7 +235,7 @@ export const load = async ({
 
     const childServiceGroupIDs =
       serviceGroup.serviceEntriesCollection?.items
-        ?.filter((item): item is ChildServiceGroupStub => item?.__typename === "ServiceEntry")
+        ?.filter((item): item is ChildServiceGroupStub => item?.__typename === "ServiceGroup")
         ?.map(({ sys: { id } }) => id) ?? [];
 
     const [childEntriesDataChunks, childGroupsData] = await Promise.all([

--- a/src/routes/test-contentful-content/+page.server.ts
+++ b/src/routes/test-contentful-content/+page.server.ts
@@ -5,20 +5,11 @@ import getContentfulClient from "$lib/services/contentful";
 import { getBlurhashMapFromRichText } from "$lib/services/blurhashes";
 import { markdownDocument } from "$lib/components/ContentfulRichText/__tests__/documents";
 import type { Document } from "@contentful/rich-text-types";
+import imagePropsFragment from "$lib/fragments/imageProps";
 import type { EntryQuery } from "./$queries.generated";
 
 const query = gql`
-  fragment ImageProps on Asset {
-    sys {
-      id
-    }
-    contentType
-    title
-    description
-    url
-    width
-    height
-  }
+  ${imagePropsFragment}
 
   query Entry {
     testRichText(id: "V7ibT9I8Vg99iKsDgLhsK") {


### PR DESCRIPTION
## Proposed changes

- Splits up the service group page GraphQL query into separate queries for the base data and its children (service entries and groups).
- If more than 10 child service entries are present, chunks the queries into batches of 10 IDs at a time to avoid query complexity limits

- [x] Manually tested
- [x] All tests pass