### PR TITLE
Don't upscale content images

### DIFF
--- a/src/lib/components/Header/Header.svelte
+++ b/src/lib/components/Header/Header.svelte
@@ -46,6 +46,7 @@
     alt=""
     width={headerBgWidth}
     height={headerBgHeight}
+    neverUpscaleImage={false}
     fit
   />
   <div class="ldaf-nav usa-navbar">

--- a/src/lib/components/Header/Header.svelte
+++ b/src/lib/components/Header/Header.svelte
@@ -46,7 +46,7 @@
     alt=""
     width={headerBgWidth}
     height={headerBgHeight}
-    neverUpscaleImage={false}
+    canUpscaleImage={true}
     fit
   />
   <div class="ldaf-nav usa-navbar">

--- a/src/lib/components/Header/Header.svelte
+++ b/src/lib/components/Header/Header.svelte
@@ -46,7 +46,7 @@
     alt=""
     width={headerBgWidth}
     height={headerBgHeight}
-    canUpscaleImage={true}
+    canUpscaleImage
     fit
   />
   <div class="ldaf-nav usa-navbar">

--- a/src/lib/components/Image/Image.svelte
+++ b/src/lib/components/Image/Image.svelte
@@ -16,7 +16,7 @@
   export let preserveAspectRatio = true;
 
   // The size type of the image
-  export let sizeType;
+  export let sizeType: SizeType;
   export let neverUpscaleImage = sizeType !== "full-bleed";
 
   export let src: string;

--- a/src/lib/components/Image/Image.svelte
+++ b/src/lib/components/Image/Image.svelte
@@ -58,7 +58,10 @@
   $: resolvedSources = getResolvedSources(src, sources, sizeType);
 
   const getSizesAttr = (sizeType: SizeType | "static") => {
-    if (sizeType === "static") return `${width}px`;
+    // 100vw in the following line is technically a lie but the worst it will do is load a slightly
+    // larger version of an image explicitly marked "static", all of which should have sources
+    // explicitly specified in the code.
+    if (sizeType === "static") return `(max-width: ${width}px) 100vw, ${width}px`;
     const sizesByScreenSize = sizesByScreenSizeByType[sizeType];
     let lastSize: number = 0;
     const screenSizesAndSizes: [number, number][] = [];

--- a/src/lib/components/Image/Image.svelte
+++ b/src/lib/components/Image/Image.svelte
@@ -16,7 +16,7 @@
   export let preserveAspectRatio = true;
 
   // The size type of the image
-  export let sizeType: SizeType | "static";
+  export let sizeType: SizeType | "static" = "static";
   export let neverUpscaleImage = sizeType !== "full-bleed";
 
   export let src: string;

--- a/src/lib/components/Image/Image.svelte
+++ b/src/lib/components/Image/Image.svelte
@@ -154,15 +154,22 @@
 
   $: imgProps = { class: imageClass, width, height, border: 0, ...$$restProps };
 
-  const getContainerStyleProps = (width: number, height: number, fit: boolean, preserveAspectRatio: boolean, neverUpscaleImage: boolean) => {
+  const getContainerStyleProps = (
+    width: number | undefined,
+    height: number | undefined,
+    fit: boolean,
+    preserveAspectRatio: boolean,
+    neverUpscaleImage: boolean
+  ) =>
     [
       ...(width && neverUpscaleImage ? [`max-width: ${width}px`] : []),
       ...(height && neverUpscaleImage ? [`max-height: ${height}px`] : []),
-      ...(fit && preserveAspectRatio && width && height ? [`aspect-ratio: ${width} / ${height}`] : []),
-    ].join("; ")
-  }
+      ...(fit && preserveAspectRatio && width && height
+        ? [`aspect-ratio: ${width} / ${height}`]
+        : []),
+    ].join("; ");
 
-  $: styleProp =
+  $: styleProp = getContainerStyleProps(width, height, fit, preserveAspectRatio, neverUpscaleImage);
 </script>
 
 {#key src}
@@ -182,9 +189,7 @@
         className
       )}
       bind:this={thisContainer}
-      {...fit && preserveAspectRatio && width && height
-        ? { style: `aspect-ratio: ${width} / ${height}` }
-        : {}}
+      style={styleProp}
     >
       {#if loading === "lazy"}
         <noscript>

--- a/src/lib/components/Image/Image.svelte
+++ b/src/lib/components/Image/Image.svelte
@@ -16,7 +16,8 @@
   export let preserveAspectRatio = true;
 
   // The size type of the image
-  export let sizeType: SizeType = "full-bleed";
+  export let sizeType;
+  export let neverUpscaleImage = sizeType !== "full-bleed";
 
   export let src: string;
 
@@ -151,7 +152,17 @@
     window.drawBlurhash(thisBg, blurhash);
   }
 
-  const imgProps = { class: imageClass, width, height, border: 0, ...$$restProps };
+  $: imgProps = { class: imageClass, width, height, border: 0, ...$$restProps };
+
+  const getContainerStyleProps = (width: number, height: number, fit: boolean, preserveAspectRatio: boolean, neverUpscaleImage: boolean) => {
+    [
+      ...(width && neverUpscaleImage ? [`max-width: ${width}px`] : []),
+      ...(height && neverUpscaleImage ? [`max-height: ${height}px`] : []),
+      ...(fit && preserveAspectRatio && width && height ? [`aspect-ratio: ${width} / ${height}`] : []),
+    ].join("; ")
+  }
+
+  $: styleProp =
 </script>
 
 {#key src}

--- a/src/lib/components/Image/Image.svelte
+++ b/src/lib/components/Image/Image.svelte
@@ -17,7 +17,7 @@
 
   // The size type of the image
   export let sizeType: SizeType | "static" = "static";
-  export let neverUpscaleImage = sizeType !== "full-bleed";
+  export let canUpscaleImage = sizeType === "full-bleed";
 
   export let src: string;
 
@@ -171,17 +171,17 @@
     height: number | undefined,
     fit: boolean,
     preserveAspectRatio: boolean,
-    neverUpscaleImage: boolean
+    canUpscaleImage: boolean
   ) =>
     [
-      ...(width && neverUpscaleImage ? [`max-width: ${width}px`] : []),
-      ...(height && neverUpscaleImage ? [`max-height: ${height}px`] : []),
+      ...(width && !canUpscaleImage ? [`max-width: ${width}px`] : []),
+      ...(height && !canUpscaleImage ? [`max-height: ${height}px`] : []),
       ...(fit && preserveAspectRatio && width && height
         ? [`aspect-ratio: ${width} / ${height}`]
         : []),
     ].join("; ");
 
-  $: styleProp = getContainerStyleProps(width, height, fit, preserveAspectRatio, neverUpscaleImage);
+  $: styleProp = getContainerStyleProps(width, height, fit, preserveAspectRatio, canUpscaleImage);
 </script>
 
 {#key src}

--- a/src/stories/CardView.svelte
+++ b/src/stories/CardView.svelte
@@ -64,6 +64,7 @@
               alt="Primary view placeholder"
               width={imageWidth}
               height={imageHeight}
+              sizeType="card"
               mean={imageMean}
               blurhash={imageBlurhash}
             />


### PR DESCRIPTION
## Proposed changes

- Adds `max-width` and `max-height` to the image container if the image size type is not full bleed.
- Makes "static" on option for the "sizeType" of an image, which sets its `sizes` attribute to its static size (but _not_ its srcset attribute, so multiple DPI options

## Screenshots

![image](https://github.com/la-ldaf/ldaf-site/assets/1425133/bced9e9a-c120-4e0c-b44e-e2200f99f443)

## Acceptance criteria validation

- [x] Manually tested with QR code
