### PR TITLE
Don't use random component ID outside of tests/storybook

### DIFF
--- a/src/lib/components/ContentfulRichText/ContentfulRichText.svelte
+++ b/src/lib/components/ContentfulRichText/ContentfulRichText.svelte
@@ -39,6 +39,6 @@
   }
 </script>
 
-{#each document.content as subNode (crypto.randomUUID())}
+{#each document.content as subNode}
   <Node node={subNode} />
 {/each}


### PR DESCRIPTION
## Proposed changes

- Remove random IDs from `each` block in `ContentfulRichText` - we shouldn't be using random IDs in real code
 
## Acceptance criteria validation

- [x] Tested manually
- [x] Tests continue to pass