### PR TITLE
Update URLs for generating Lighthouse reports.

### DIFF
--- a/.lighthouse/urls.txt
+++ b/.lighthouse/urls.txt
@@ -1,2 +1,3 @@
-http://localhost:4173/
-http://localhost:4173/documentation
+http://localhost:4173
+http://localhost:4173/land
+http://localhost:4173/land/indian-creek


### PR DESCRIPTION
Noticed that our Lighthouse report index page was running into an error due to the removal of the `/documentation` page, and I figured this would be a good time to throw a Top Tier page and Core Content page into the mix.