### PR TITLE
Fix a bug in the main menu in Safari

### DIFF
--- a/src/lib/components/Button/Button.svelte
+++ b/src/lib/components/Button/Button.svelte
@@ -43,7 +43,16 @@
     <slot>Link</slot>
   </Link>
 {:else}
-  <button {type} {disabled} aria-disabled={disabled} class={classes} on:click>
+  <button
+    {...$$restProps}
+    {type}
+    {disabled}
+    aria-disabled={disabled}
+    class={classes}
+    on:click
+    on:keydown
+    on:mousedown
+  >
     <slot>Button</slot>
   </button>
 {/if}

--- a/src/lib/components/Header/Nav/NavMenu.svelte
+++ b/src/lib/components/Header/Nav/NavMenu.svelte
@@ -56,7 +56,7 @@
   // These additional checks should be redundant on other browsers but will ensure we close the menu
   //   in Safari when the user clicks out or navigates to a new page.
   let menuElement: HTMLDivElement;
-  const handleClickOnBody = ({ target }: MouseEvent) => {
+  const handleMouseDownOnBody = ({ target }: MouseEvent) => {
     if (expanded) {
       if (menuElement && target instanceof HTMLElement && menuElement.contains(target)) return;
       dispatch("close");
@@ -65,7 +65,7 @@
   afterNavigate(() => expanded && dispatch("close"));
 </script>
 
-<svelte:body on:click={handleClickOnBody} />
+<svelte:body on:mousedown={handleMouseDownOnBody} />
 
 <!-- TODO: This div is necessary for handling focus loss, but it breaks the styling for a menu
            being marked with an underline as the active / current nav item. -->

--- a/src/lib/components/Header/Nav/NavMenu.svelte
+++ b/src/lib/components/Header/Nav/NavMenu.svelte
@@ -1,8 +1,11 @@
 <script lang="ts">
-  import Link from "$lib/components/Link/Link.svelte";
+  import Button from "$lib/components/Button";
+  import Link from "$lib/components/Link";
   import chunk from "lodash/chunk";
   import classNames from "$lib/util/classNames";
   import { createEventDispatcher } from "svelte";
+  import { afterNavigate } from "$app/navigation";
+
   import type { NavMenuProps, NavLinkType } from "./types";
   type $$Props = NavMenuProps;
 
@@ -47,13 +50,25 @@
     if (relatedTarget instanceof HTMLElement && currentTarget?.contains(relatedTarget)) return;
     dispatch("close");
   };
+
+  // Safari doesn't assign focus to <button> and <a> elements, so the focusout event doesn't close
+  //   menus unless the user is keyboard navigating.
+  // These additional checks should be redundant on other browsers but will ensure we close the menu
+  //   in Safari.
+  let menuElement: HTMLDivElement;
+  const handleClickOnBody = ({ target }: MouseEvent) => {
+    if (menuElement && target instanceof HTMLElement && menuElement.contains(target)) return;
+    dispatch("close");
+  };
+  afterNavigate(() => dispatch("close"));
 </script>
+
+<svelte:body on:click={handleClickOnBody} />
 
 <!-- TODO: This div is necessary for handling focus loss, but it breaks the styling for a menu
            being marked with an underline as the active / current nav item. -->
-<div on:focusout={handleDropdownFocusLoss}>
-  <button
-    type="button"
+<div bind:this={menuElement} on:focusout={handleDropdownFocusLoss}>
+  <Button
     class={buttonClassNames}
     aria-expanded={expanded}
     aria-controls="extended-mega-nav-section-{id}"
@@ -62,7 +77,7 @@
   >
     <!-- Extra <span/> element is necessary for expand icons to load. -->
     <span><slot /></span>
-  </button>
+  </Button>
   {#if columns <= 1}
     <!-- Basic Menu Layout-->
     <ul id="extended-mega-nav-section-{id}" class="usa-nav__submenu" hidden={!expanded}>

--- a/src/lib/components/Header/Nav/NavMenu.svelte
+++ b/src/lib/components/Header/Nav/NavMenu.svelte
@@ -54,13 +54,15 @@
   // Safari doesn't assign focus to <button> and <a> elements, so the focusout event doesn't close
   //   menus unless the user is keyboard navigating.
   // These additional checks should be redundant on other browsers but will ensure we close the menu
-  //   in Safari.
+  //   in Safari when the user clicks out or navigates to a new page.
   let menuElement: HTMLDivElement;
   const handleClickOnBody = ({ target }: MouseEvent) => {
-    if (menuElement && target instanceof HTMLElement && menuElement.contains(target)) return;
-    dispatch("close");
+    if (expanded) {
+      if (menuElement && target instanceof HTMLElement && menuElement.contains(target)) return;
+      dispatch("close");
+    }
   };
-  afterNavigate(() => dispatch("close"));
+  afterNavigate(() => expanded && dispatch("close"));
 </script>
 
 <svelte:body on:click={handleClickOnBody} />


### PR DESCRIPTION
## Description

On Safari, menus in the header do not close when the user clicks away or navigates to a new page. This is due to Safari not automatically applying `focus` to `<button>` and `<a>` elements on click (and thus our `focusout` event is not triggered when the user clicks away from a menu or when the user navigates).

## Steps to reproduce

1. Open up [new.ldaf.la.gov]() in Safari.
2. Open one of the menus.
3. Confirm that clicking outside the menu does not close it.
4. Confirm that navigating to a different page does not close it.

## Proposed changes

Add two additional checks for Safari that should be redundant for other browsers:
1. Create an event listener on the `<body>` element that will check where a user clicked (technically `mousedown`), and close an opened menu if the target was outside the menu.
2. Always close an opened menu when the user navigates.

## Alternate solutions

At first I tried to just add `focus` to `<button>` and `<a>` elements on click, but this was giving me other issues. Ultimately it seemed like adding some logic that would be redundant in other browsers was the easiest fix.

## Known issues

Our `Header` story in Storybook is currently not rendering after the addition of the `ConditionalWrapper` component on `Title`. Decided to not fiddle with a fix on that for now.