### PR TITLE
Reimplement youtube subscribe button, avoiding loading google js

### DIFF
--- a/src/lib/components/VideoCard/VideoCard.svelte
+++ b/src/lib/components/VideoCard/VideoCard.svelte
@@ -3,8 +3,8 @@
 
   import { afterUpdate } from "svelte";
 
-  import { PUBLIC_YOUTUBE_CHANNEL_ID } from "$env/static/public";
   import getYoutubeVideoData from "$lib/services/youtube";
+  import YoutubeSubscribeLink from "$lib/components/YoutubeSubscribeLink";
 
   type VideoCardVariation = "hero" | "primary" | "secondary" | "tertiary";
   interface $$Props {
@@ -37,7 +37,6 @@
 
   $: title = customTitle;
   $: description = customDescription;
-  $: loadSubscribeButton = false;
 
   afterUpdate(async () => {
     if (youtubeVideoId && (!customTitle || !customDescription)) {
@@ -52,7 +51,6 @@
         description = snippet.description.split("\n")[0];
       }
     }
-    loadSubscribeButton = true;
   });
 </script>
 
@@ -76,16 +74,7 @@
       {#if description}
         <p class="ldaf-video-description">{description}</p>
       {/if}
-      <!-- https://developers.google.com/youtube/youtube_subscribe_button -->
-      {#if loadSubscribeButton}
-        <script src="https://apis.google.com/js/platform.js"></script>
-        <div
-          class="g-ytsubscribe"
-          data-channelid={PUBLIC_YOUTUBE_CHANNEL_ID}
-          data-layout="default"
-          data-count="hidden"
-        />
-      {/if}
+      <YoutubeSubscribeLink />
     </div>
   </div>
 {/if}

--- a/src/lib/components/YoutubeSubscribeLink/YoutubeSubscribeLink.svelte
+++ b/src/lib/components/YoutubeSubscribeLink/YoutubeSubscribeLink.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+  import { url as youtubeIcon } from "$icons/youtube";
+  import Link from "$lib/components/Link";
+  import Icon from "$lib/components/Icon";
+  import { PUBLIC_YOUTUBE_CHANNEL_ID } from "$env/static/public";
+</script>
+
+<Link
+  href={`https://www.youtube.com/channel/${PUBLIC_YOUTUBE_CHANNEL_ID}`}
+  class="youtube-subscribe-link"
+>
+  <Icon src={youtubeIcon} class="youtube-subscribe-icon" />
+  YouTube
+</Link>
+
+<style>
+  :global(.youtube-subscribe-link),
+  :global(.youtube-subscribe-link:visited),
+  :global(.usa-link.youtube-subscribe-link),
+  :global(.usa-link.youtube-subscribe-link:visited) {
+    background: #e62117;
+    border: 1px solid #d7211a;
+    border-radius: 3px;
+    color: white;
+    text-decoration: none;
+    height: 24px;
+    padding: 0 8px 0 5.5px;
+    font-size: 12px;
+    display: inline-flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 4px;
+  }
+
+  :global(.usa-icon.youtube-subscribe-icon) {
+    width: 16px;
+    height: 16px;
+    filter: brightness(0) invert(1);
+  }
+</style>

--- a/src/lib/components/YoutubeSubscribeLink/YoutubeSubscribeLink.svelte
+++ b/src/lib/components/YoutubeSubscribeLink/YoutubeSubscribeLink.svelte
@@ -10,7 +10,7 @@
   class="youtube-subscribe-link"
 >
   <Icon src={youtubeIcon} class="youtube-subscribe-icon" />
-  YouTube
+  Subscribe on YouTube
 </Link>
 
 <style>

--- a/src/lib/components/YoutubeSubscribeLink/YoutubeSubscribeLink.svelte
+++ b/src/lib/components/YoutubeSubscribeLink/YoutubeSubscribeLink.svelte
@@ -6,7 +6,7 @@
 </script>
 
 <Link
-  href={`https://www.youtube.com/channel/${PUBLIC_YOUTUBE_CHANNEL_ID}`}
+  href={`https://www.youtube.com/channel/${PUBLIC_YOUTUBE_CHANNEL_ID}?sub_confirmation=1&feature=subscribe-embed-click`}
   class="youtube-subscribe-link"
 >
   <Icon src={youtubeIcon} class="youtube-subscribe-icon" />

--- a/src/lib/components/YoutubeSubscribeLink/index.ts
+++ b/src/lib/components/YoutubeSubscribeLink/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./YoutubeSubscribeLink.svelte";


### PR DESCRIPTION
## Proposed changes

Uses a styled link resembling the YouTube subscribe button to replace the embedded subscribe button and avoid all the extra JS it was loading. This also fixes the errors that were happening when navigating around the site if a `VideoCard` had _ever_ been loaded.

## Screenshots

![image](https://github.com/la-ldaf/ldaf-site/assets/1425133/fb86bd33-3b46-496a-a732-58df7e438b5e)

## Acceptance criteria validation

- [x] Tested manually
- [x] Tests continue to pass