### PR TITLE
Disable the news route as its not implemented yet.

### DIFF
--- a/e2e-tests/header.spec.ts
+++ b/e2e-tests/header.spec.ts
@@ -44,6 +44,7 @@ test("nav items can be expanded and collapsed", async ({ page }) => {
 });
 
 // Following test cannot be run as a component unit test since it relies on navigation.
+// TODO: This actually goes to a 404 currently, but still works since the header menu still loads.
 test("mobile menu is closed on route change", async ({ page }) => {
   await page.setViewportSize({ width: 400, height: 850 });
   await page.goto("/news");

--- a/src/routes/(infoPages)/about/news/+page.server.ts
+++ b/src/routes/(infoPages)/about/news/+page.server.ts
@@ -1,9 +1,0 @@
-export const load = async ({ parent }) => {
-  const { pageMetadataMap } = await parent();
-  const matchedPageMetadata = [...pageMetadataMap].find(([_, page]) => {
-    return page.url === "/about/news";
-  });
-  if (matchedPageMetadata && matchedPageMetadata.length === 2) {
-    return { pageMetadata: matchedPageMetadata[1] };
-  }
-};

--- a/src/routes/(infoPages)/about/news/+page.svelte
+++ b/src/routes/(infoPages)/about/news/+page.svelte
@@ -1,7 +1,0 @@
-<script lang="ts">
-  export let data;
-  $: ({ pageMetadata } = data);
-</script>
-
-<h1>{pageMetadata?.title}</h1>
-<p>This is a stub for the News Aggregation page!</p>


### PR DESCRIPTION
Quick fix, as part of this I also unpublished the appropriate entries in Contentful:
* Page Details for News - https://app.contentful.com/spaces/pc5e1rlgfrov/entries/7uRzUfPjJoNjTXlVCcjOIi
* Page Details for an article with News as the parent - https://app.contentful.com/spaces/pc5e1rlgfrov/environments/master/entries/4I50gHKAiy0QkxMUEJmcmT
* Menu Item in Footer for News - https://app.contentful.com/spaces/pc5e1rlgfrov/environments/master/entries/3MouxaFvLV8EKtbQmU18la