### PR TITLE
Filter out the home page and null URLs from search.

### DIFF
--- a/src/routes/api/v1/algolia/+server.ts
+++ b/src/routes/api/v1/algolia/+server.ts
@@ -4,5 +4,6 @@ import { loadPageMetadataMap } from "$lib/loadPageMetadataMap";
 
 export const GET = (async () => {
   const { pageMetadataMap } = await loadPageMetadataMap({ includeBreadcrumbs: false });
-  return json(Array.from(pageMetadataMap.values()));
+  // exclude the home page and pages where we can't determine the URL
+  return json(Array.from(pageMetadataMap.values()).filter((page) => page.url && !page.isRoot));
 }) satisfies RequestHandler;


### PR DESCRIPTION
Discussed during our "think tank" meeting, we need to make sure we're not linking to pages that don't exist, and there's not much use in linking to the home page.