### PR TITLE
Make all event dates relative to Louisiana timezone; filter events aggregation page to present+future events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "@contentful/rich-text-types": "^16.0.3",
         "@uswds/uswds": "^3.4.1",
+        "date-fns": "^2.30.0",
+        "date-fns-tz": "^2.0.0",
         "devalue": "^4.3.2",
         "fast-blurhash": "^1.1.2",
         "graphql": "^16.7.1",
@@ -2426,7 +2428,6 @@
       "version": "7.21.0",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.0.tgz",
       "integrity": "sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==",
-      "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.13.11"
       },
@@ -14161,7 +14162,6 @@
       "version": "2.30.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
       "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
-      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.21.0"
       },
@@ -14171,6 +14171,14 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/date-fns"
+      }
+    },
+    "node_modules/date-fns-tz": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-2.0.0.tgz",
+      "integrity": "sha512-OAtcLdB9vxSXTWHdT8b398ARImVwQMyjfYGkKD2zaGpHseG2UPHbHjXELReErZFxWdSLph3c2zOaaTyHfOhERQ==",
+      "peerDependencies": {
+        "date-fns": ">=2.0.0"
       }
     },
     "node_modules/debounce": {
@@ -20890,8 +20898,7 @@
     "node_modules/regenerator-runtime": {
       "version": "0.13.11",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
-      "dev": true
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "node_modules/regenerator-transform": {
       "version": "0.15.1",
@@ -26374,7 +26381,6 @@
       "version": "7.21.0",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.0.tgz",
       "integrity": "sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==",
-      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.11"
       }
@@ -34905,10 +34911,15 @@
       "version": "2.30.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
       "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
-      "dev": true,
       "requires": {
         "@babel/runtime": "^7.21.0"
       }
+    },
+    "date-fns-tz": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-2.0.0.tgz",
+      "integrity": "sha512-OAtcLdB9vxSXTWHdT8b398ARImVwQMyjfYGkKD2zaGpHseG2UPHbHjXELReErZFxWdSLph3c2zOaaTyHfOhERQ==",
+      "requires": {}
     },
     "debounce": {
       "version": "1.2.1",
@@ -39973,8 +39984,7 @@
     "regenerator-runtime": {
       "version": "0.13.11",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
-      "dev": true
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "regenerator-transform": {
       "version": "0.15.1",

--- a/package.json
+++ b/package.json
@@ -96,6 +96,8 @@
   "dependencies": {
     "@contentful/rich-text-types": "^16.0.3",
     "@uswds/uswds": "^3.4.1",
+    "date-fns": "^2.30.0",
+    "date-fns-tz": "^2.0.0",
     "devalue": "^4.3.2",
     "fast-blurhash": "^1.1.2",
     "graphql": "^16.7.1",

--- a/src/lib/constants/date.ts
+++ b/src/lib/constants/date.ts
@@ -32,3 +32,5 @@ export const shortMonths = [
   "Nov",
   "Dec",
 ];
+
+export const eventIANATimezone = "America/Chicago";

--- a/src/lib/util/dates.test.ts
+++ b/src/lib/util/dates.test.ts
@@ -1,0 +1,49 @@
+import { vi, describe, it, expect } from "vitest";
+
+import { getCurrentDateInTZ, getStartOfDayForDateInTZ, getEndOfDayForDateInTZ } from "./dates";
+
+vi.useFakeTimers();
+
+describe("getCurrentDateInTZ", () => {
+  type TestCase = [Date, string, string];
+  const testCases: TestCase[] = [
+    [new Date("2023-08-24T22:43:24.298Z"), "America/Los_Angeles", "2023-08-24"],
+    [new Date("2023-08-24T00:00:00.000Z"), "America/Los_Angeles", "2023-08-23"],
+    [new Date("2023-08-24T05:00:00.000Z"), "America/Los_Angeles", "2023-08-23"],
+    [new Date("2023-08-24T05:00:00.000Z"), "America/Chicago", "2023-08-24"],
+  ];
+  testCases.forEach(([atDate, tz, expectedDateString]) => {
+    it(`returns ${expectedDateString} for the datetime ${atDate.toISOString()} in ${tz}`, () => {
+      vi.setSystemTime(atDate);
+      expect(getCurrentDateInTZ(tz)).toEqual(expectedDateString);
+    });
+  });
+});
+
+describe("getStartOfDayForDateInTZ", () => {
+  type TestCase = [string, string, Date];
+  const testCases: TestCase[] = [
+    ["2023-08-24", "GMT", new Date("2023-08-24T00:00:00.000Z")],
+    ["2023-08-24", "America/Chicago", new Date("2023-08-24T05:00:00.000Z")],
+    ["2023-08-24", "America/Los_Angeles", new Date("2023-08-24T07:00:00.000Z")],
+  ];
+  testCases.forEach(([dateString, tz, expectedDate]) => {
+    it(`returns ${expectedDate.toISOString()} for the date ${dateString} in ${tz}`, () => {
+      expect(getStartOfDayForDateInTZ(dateString, tz)).toEqual(expectedDate);
+    })
+  })
+})
+
+describe("getEndOfDayForDateInTZ", () => {
+  type TestCase = [string, string, Date];
+  const testCases: TestCase[] = [
+    ["2023-08-24", "GMT", new Date("2023-08-24T23:59:59.999Z")],
+    ["2023-08-24", "America/Chicago", new Date("2023-08-25T04:59:59.999Z")],
+    ["2023-08-24", "America/Los_Angeles", new Date("2023-08-25T06:59:59.999Z")],
+  ];
+  testCases.forEach(([dateString, tz, expectedDate]) => {
+    it(`returns ${expectedDate.toISOString()} for the date ${dateString} in ${tz}`, () => {
+      expect(getEndOfDayForDateInTZ(dateString, tz)).toEqual(expectedDate);
+    })
+  })
+})

--- a/src/lib/util/dates.test.ts
+++ b/src/lib/util/dates.test.ts
@@ -30,9 +30,9 @@ describe("getStartOfDayForDateInTZ", () => {
   testCases.forEach(([dateString, tz, expectedDate]) => {
     it(`returns ${expectedDate.toISOString()} for the date ${dateString} in ${tz}`, () => {
       expect(getStartOfDayForDateInTZ(dateString, tz)).toEqual(expectedDate);
-    })
-  })
-})
+    });
+  });
+});
 
 describe("getEndOfDayForDateInTZ", () => {
   type TestCase = [string, string, Date];
@@ -44,6 +44,6 @@ describe("getEndOfDayForDateInTZ", () => {
   testCases.forEach(([dateString, tz, expectedDate]) => {
     it(`returns ${expectedDate.toISOString()} for the date ${dateString} in ${tz}`, () => {
       expect(getEndOfDayForDateInTZ(dateString, tz)).toEqual(expectedDate);
-    })
-  })
-})
+    });
+  });
+});

--- a/src/lib/util/dates.ts
+++ b/src/lib/util/dates.ts
@@ -1,7 +1,5 @@
-import utcToZonedTime from "date-fns-tz/utcToZonedTime/index";
-import zonedTimeToUtc from "date-fns-tz/zonedTimeToUtc/index";
-import startOfDay from "date-fns/startOfDay/index";
-import endOfDay from "date-fns/endOfDay/index";
+import { utcToZonedTime, zonedTimeToUtc } from "date-fns-tz";
+import { startOfDay, endOfDay } from "date-fns";
 
 type Dateable = Date | string | number;
 

--- a/src/lib/util/dates.ts
+++ b/src/lib/util/dates.ts
@@ -1,7 +1,7 @@
-import utcToZonedTime from "date-fns-tz/utcToZonedTime";
-import zonedTimeToUtc from "date-fns-tz/zonedTimeToUtc";
-import startOfDay from "date-fns/startOfDay";
-import endOfDay from "date-fns/endOfDay";
+import utcToZonedTime from "date-fns-tz/utcToZonedTime/index";
+import zonedTimeToUtc from "date-fns-tz/zonedTimeToUtc/index";
+import startOfDay from "date-fns/startOfDay/index";
+import endOfDay from "date-fns/endOfDay/index";
 
 type Dateable = Date | string | number;
 

--- a/src/lib/util/dates.ts
+++ b/src/lib/util/dates.ts
@@ -11,9 +11,9 @@ export const getCurrentDateInTZ = (tz: string): string => {
 export const getStartOfDayForDateInTZ = (dateString: string, tz: string): Date => {
   const date = startOfDay(parseISO(dateString));
   return zonedTimeToUtc(date, tz);
-}
+};
 
 export const getEndOfDayForDateInTZ = (dateString: string, tz: string): Date => {
   const date = endOfDay(parseISO(dateString));
   return zonedTimeToUtc(date, tz);
-}
+};

--- a/src/lib/util/dates.ts
+++ b/src/lib/util/dates.ts
@@ -1,20 +1,19 @@
 import utcToZonedTime from "date-fns-tz/utcToZonedTime";
 import zonedTimeToUtc from "date-fns-tz/zonedTimeToUtc";
-import { startOfDay, endOfDay } from "date-fns";
+import { parseISO, startOfDay, endOfDay, formatISO } from "date-fns";
 
-type Dateable = Date | string | number;
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const calcZonedDate = <F extends (...args: any[]) => Date>(
-  date: Dateable,
-  tz: string,
-  fn: F,
-  options?: Parameters<F>[1]
-) => {
-  const inputZoned = utcToZonedTime(date, tz);
-  const fnZoned = options ? fn(inputZoned, options) : fn(inputZoned);
-  return zonedTimeToUtc(fnZoned, tz);
+export const getCurrentDateInTZ = (tz: string): string => {
+  const date = new Date();
+  const zoned = utcToZonedTime(date, tz);
+  return formatISO(zoned, { format: "extended", representation: "date" });
 };
 
-export const zonedStartOfDay = (date: Dateable, tz: string) => calcZonedDate(date, tz, startOfDay);
-export const zonedEndOfDay = (date: Dateable, tz: string) => calcZonedDate(date, tz, endOfDay);
+export const getStartOfDayForDateInTZ = (dateString: string, tz: string): Date => {
+  const date = startOfDay(parseISO(dateString));
+  return zonedTimeToUtc(date, tz);
+}
+
+export const getEndOfDayForDateInTZ = (dateString: string, tz: string): Date => {
+  const date = endOfDay(parseISO(dateString));
+  return zonedTimeToUtc(date, tz);
+}

--- a/src/lib/util/dates.ts
+++ b/src/lib/util/dates.ts
@@ -1,0 +1,20 @@
+import utcToZonedTime from "date-fns-tz/utcToZonedTime";
+import zonedTimeToUtc from "date-fns-tz/zonedTimeToUtc";
+import startOfDay from "date-fns/startOfDay";
+import endOfDay from "date-fns/endOfDay";
+
+type Dateable = Date | string | number;
+
+const calcZonedDate = <F extends (...args: any[]) => Date>(
+  date: Dateable,
+  tz: string,
+  fn: F,
+  options?: Parameters<F>[1]
+) => {
+  const inputZoned = utcToZonedTime(date, tz);
+  const fnZoned = options ? fn(inputZoned, options) : fn(inputZoned);
+  return zonedTimeToUtc(fnZoned, tz);
+};
+
+export const zonedStartOfDay = (date: Dateable, tz: string) => calcZonedDate(date, tz, startOfDay);
+export const zonedEndOfDay = (date: Dateable, tz: string) => calcZonedDate(date, tz, endOfDay);

--- a/src/lib/util/dates.ts
+++ b/src/lib/util/dates.ts
@@ -3,6 +3,7 @@ import { startOfDay, endOfDay } from "date-fns";
 
 type Dateable = Date | string | number;
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const calcZonedDate = <F extends (...args: any[]) => Date>(
   date: Dateable,
   tz: string,

--- a/src/lib/util/dates.ts
+++ b/src/lib/util/dates.ts
@@ -1,4 +1,5 @@
-import { utcToZonedTime, zonedTimeToUtc } from "date-fns-tz";
+import utcToZonedTime from "date-fns-tz/utcToZonedTime";
+import zonedTimeToUtc from "date-fns-tz/zonedTimeToUtc";
 import { startOfDay, endOfDay } from "date-fns";
 
 type Dateable = Date | string | number;

--- a/src/routes/(infoPages)/about/events/event/[dateAndSlug]/+page.server.ts
+++ b/src/routes/(infoPages)/about/events/event/[dateAndSlug]/+page.server.ts
@@ -8,6 +8,7 @@ import type { EventQuery } from "./$queries.generated";
 import { loadBaseBreadcrumbs } from "../../shared.server";
 import { eventIANATimezone } from "$lib/constants/date";
 import { zonedEndOfDay, zonedStartOfDay } from "$lib/util/dates";
+import zonedTimeToUtc from "date-fns-tz/zonedTimeToUtc";
 
 const query = gql`
   query Event($dateStart: DateTime!, $dateEnd: DateTime!, $slug: String!) {

--- a/src/routes/(infoPages)/about/events/event/[dateAndSlug]/+page.server.ts
+++ b/src/routes/(infoPages)/about/events/event/[dateAndSlug]/+page.server.ts
@@ -7,7 +7,7 @@ import type { PageServerLoad } from "./$types";
 import type { EventQuery } from "./$queries.generated";
 import { loadBaseBreadcrumbs } from "../../shared.server";
 import { eventIANATimezone } from "$lib/constants/date";
-import { zonedEndOfDay, zonedStartOfDay } from "$lib/util/dates";
+import { getEndOfDayForDateInTZ, getStartOfDayForDateInTZ } from "$lib/util/dates";
 import zonedTimeToUtc from "date-fns-tz/zonedTimeToUtc";
 
 const query = gql`
@@ -65,11 +65,10 @@ const query = gql`
 export const load = (async ({ params: { dateAndSlug }, parent }) => {
   // dateAndSlug should be constructed like 2023-08-10-some-slug
   // TODO: write route matcher that enforces this
-  const [_, dateString, slug] = dateAndSlug.match(/(\d{4}-\d{2}-\d{2})-([a-z1-9-]+)/) ?? [];
+  const [_, dateString, slug] = dateAndSlug.match(/^(\d{4}-\d{2}-\d{2})-([a-z1-9-]+)$/) ?? [];
   if (!dateString || !slug) throw error(404);
-  const date = zonedTimeToUtc(dateString, eventIANATimezone);
-  const dateStart = zonedStartOfDay(date, eventIANATimezone).toISOString();
-  const dateEnd = zonedEndOfDay(date, eventIANATimezone).toISOString();
+  const dateStart = getStartOfDayForDateInTZ(dateString, eventIANATimezone);
+  const dateEnd = getEndOfDayForDateInTZ(dateString, eventIANATimezone);
   // TODO: example contents
   if (!CONTENTFUL_SPACE_ID || !CONTENTFUL_DELIVERY_API_TOKEN) throw error(404);
   const baseBreadcrumbsPromise = loadBaseBreadcrumbs({ parent });

--- a/src/routes/(infoPages)/about/events/event/[dateAndSlug]/+page.server.ts
+++ b/src/routes/(infoPages)/about/events/event/[dateAndSlug]/+page.server.ts
@@ -2,14 +2,12 @@ import { error } from "@sveltejs/kit";
 import gql from "graphql-tag";
 import { print as printQuery } from "graphql";
 import { CONTENTFUL_DELIVERY_API_TOKEN, CONTENTFUL_SPACE_ID } from "$env/static/private";
-import { day } from "$lib/constants/date";
 import getContentfulClient from "$lib/services/contentful";
 import type { PageServerLoad } from "./$types";
 import type { EventQuery } from "./$queries.generated";
 import { loadBaseBreadcrumbs } from "../../shared.server";
 import { eventIANATimezone } from "$lib/constants/date";
 import { zonedEndOfDay, zonedStartOfDay } from "$lib/util/dates";
-import zonedTimeToUtc from "date-fns-tz/zonedTimeToUtc";
 
 const query = gql`
   query Event($dateStart: DateTime!, $dateEnd: DateTime!, $slug: String!) {

--- a/src/routes/(infoPages)/about/events/shared.server.ts
+++ b/src/routes/(infoPages)/about/events/shared.server.ts
@@ -8,7 +8,7 @@ import type { PageServerLoad } from "./page/[page]/$types";
 import type { Breadcrumbs } from "$lib/components/Breadcrumbs";
 import { events as testEvents, pages as testEventPages } from "./__tests__/eventsTestContent";
 import { eventIANATimezone } from "$lib/constants/date";
-import { zonedStartOfDay } from "$lib/util/dates";
+import { getCurrentDateInTZ, getStartOfDayForDateInTZ } from "$lib/util/dates";
 
 const limit = 20;
 
@@ -72,7 +72,7 @@ export const loadEventsPage = async ({
   parent,
   params: { page },
 }: Pick<Parameters<PageServerLoad>[0], "params" | "parent">) => {
-  const startDate = zonedStartOfDay(new Date(), eventIANATimezone).toISOString();
+  const startDate = getStartOfDayForDateInTZ(getCurrentDateInTZ(eventIANATimezone), eventIANATimezone);
   fetchData: {
     const pageNumber = parseInt(page);
     if (isNaN(pageNumber)) break fetchData;

--- a/src/routes/(infoPages)/about/events/shared.server.ts
+++ b/src/routes/(infoPages)/about/events/shared.server.ts
@@ -72,7 +72,10 @@ export const loadEventsPage = async ({
   parent,
   params: { page },
 }: Pick<Parameters<PageServerLoad>[0], "params" | "parent">) => {
-  const startDate = getStartOfDayForDateInTZ(getCurrentDateInTZ(eventIANATimezone), eventIANATimezone);
+  const startDate = getStartOfDayForDateInTZ(
+    getCurrentDateInTZ(eventIANATimezone),
+    eventIANATimezone
+  );
   fetchData: {
     const pageNumber = parseInt(page);
     if (isNaN(pageNumber)) break fetchData;

--- a/src/routes/(infoPages)/about/events/shared.server.ts
+++ b/src/routes/(infoPages)/about/events/shared.server.ts
@@ -7,7 +7,6 @@ import { error } from "@sveltejs/kit";
 import type { PageServerLoad } from "./page/[page]/$types";
 import type { Breadcrumbs } from "$lib/components/Breadcrumbs";
 import { events as testEvents, pages as testEventPages } from "./__tests__/eventsTestContent";
-import { zonedTimeToUtc } from "date-fns-tz";
 import { eventIANATimezone } from "$lib/constants/date";
 import { zonedStartOfDay } from "$lib/util/dates";
 


### PR DESCRIPTION
Jira ticket: [TICKET_NUMBER](URL)

## Proposed changes

- Does all event calculations using the start and end of day _in Louisiana_, not the current timezone wherever the server is running.
- Filters out past events from event aggregation page

## Acceptance criteria validation

- [x] Things continue to work in manual testing
- [x] Tests added to cover the change