### PR TITLE
Stop leaking a redis client connection descriptor every request

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,9 +1,7 @@
 import type { Handle } from "@sveltejs/kit";
 import { KV_URL } from "$env/static/private";
 import { sequence } from "@sveltejs/kit/hooks";
-import { createClient } from "$lib/services/server/kv";
-
-const kvClients = Map<string>;
+import { getClient } from "$lib/services/server/kv";
 
 const handleSetupKVClient = (async ({ event, resolve }) => {
   // we intentionally don't await this promise here, so that other things can happen while redis is
@@ -11,7 +9,7 @@ const handleSetupKVClient = (async ({ event, resolve }) => {
   // event.locals.getKVClient and awaiting the result. If nothing awaits the promise
   // then we never wait on redis connecting first.
   const kvClientPromise = KV_URL
-    ? createClient({ url: KV_URL })
+    ? getClient({ url: KV_URL })
     : Promise.reject(new Error("could not get KV client; no KV_URL was specified"));
   event.locals.getKVClient = () => kvClientPromise;
   return resolve(event);

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -3,7 +3,9 @@ import { KV_URL } from "$env/static/private";
 import { sequence } from "@sveltejs/kit/hooks";
 import { createClient } from "$lib/services/server/kv";
 
-const handleSetupRedisClient = (async ({ event, resolve }) => {
+const kvClients = Map<string>;
+
+const handleSetupKVClient = (async ({ event, resolve }) => {
   // we intentionally don't await this promise here, so that other things can happen while redis is
   // initializing. Anything that needs redis can await the promise by calling
   // event.locals.getKVClient and awaiting the result. If nothing awaits the promise
@@ -25,4 +27,4 @@ const handlePreload = (async ({ event, resolve }) => {
   return response;
 }) satisfies Handle;
 
-export const handle = sequence(handleSetupRedisClient, handlePreload);
+export const handle = sequence(handleSetupKVClient, handlePreload);

--- a/src/lib/services/server/kv/index.ts
+++ b/src/lib/services/server/kv/index.ts
@@ -1,4 +1,4 @@
-import { createClient as createRedisClient, type RedisClientType } from "redis";
+import { createClient as createRedisClient } from "redis";
 
 export type Client = {
   getBlurhashByURL: (url: string) => Promise<string | null>;


### PR DESCRIPTION
## Proposed changes

- Cache the KV client to avoid creating and connecting a new Redis client every request, which leaks file descriptors.

## Acceptance criteria validation

It's rather difficult to test if this is actually working or not, either manually or automatically. Existing tests pass, and I'm working on verifying that we're not leaking FDs.

Update: I was able to reproduce the problem locally and verify the fix by checking the open file descriptor list in Activity Monitor.

- [x] Tests continue to pass
- [x] Manually verified that site works
- [x] Manually verified that open file descriptors do not increase on every request