### PR TITLE
Don't preserve aspect ratio of card images

### DIFF
--- a/src/lib/components/Image/Image.svelte
+++ b/src/lib/components/Image/Image.svelte
@@ -17,13 +17,15 @@
   // The size type of the image
   export let sizeType: SizeType | "static" = "static";
   export let canUpscaleImage = sizeType === "full-bleed";
-  export let preserveAspectRatio = ({
-    "static": true,
-    card: false,
-    "full-bleed": true,
-    "col-9": true,
-    "col-12": true,
-  } satisfies Record<SizeType | "static", boolean>)[sizeType];
+  export let preserveAspectRatio = (
+    {
+      static: true,
+      card: false,
+      "full-bleed": true,
+      "col-9": true,
+      "col-12": true,
+    } satisfies Record<SizeType | "static", boolean>
+  )[sizeType];
 
   export let src: string;
 

--- a/src/lib/components/Image/Image.svelte
+++ b/src/lib/components/Image/Image.svelte
@@ -13,11 +13,17 @@
 
   // Whether the image should fit its container
   export let fit = true;
-  export let preserveAspectRatio = true;
 
   // The size type of the image
   export let sizeType: SizeType | "static" = "static";
   export let canUpscaleImage = sizeType === "full-bleed";
+  export let preserveAspectRatio = ({
+    "static": true,
+    card: false,
+    "full-bleed": true,
+    "col-9": true,
+    "col-12": true,
+  } satisfies Record<SizeType | "static", boolean>)[sizeType];
 
   export let src: string;
 


### PR DESCRIPTION
## Proposed changes

- Changes `preserveAspectRatio` default to depend on the given `sizeType`.
- Makes `"card"` sized images not preserve aspect ratio.