### PR TITLE
Set meta tag with theme color

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <link rel="icon" href="%sveltekit.assets%/favicon.ico" />
     <meta name="viewport" content="width=device-width" />
+    <meta name="theme-color" content="#00284d" />
     %sveltekit.head%
   </head>
   <body data-sveltekit-preload-data="hover">

--- a/src/app.html
+++ b/src/app.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <link rel="icon" href="%sveltekit.assets%/favicon.ico" />
     <meta name="viewport" content="width=device-width" />
+    <!-- the following color is $primary-darkest from USWDS -->
     <meta name="theme-color" content="#00284d" />
     %sveltekit.head%
   </head>


### PR DESCRIPTION
## Proposed changes

Sets a meta tag with the theme color. This is the color used by browsers (primarily mobile browsers) to theme the address bar area. Matching it with the background color of the header should make it a smooth transition.

## Screenshots

![image](https://github.com/la-ldaf/ldaf-site/assets/1425133/066d081c-2b73-44eb-afa8-b16e9c513c6b)