### PR TITLE
Resize top tier header images to avoid loading unshown parts

### DIFF
--- a/src/lib/components/Image/Image.svelte
+++ b/src/lib/components/Image/Image.svelte
@@ -11,9 +11,11 @@
   export let height: number | null | undefined = undefined;
   export let width: number | null | undefined = undefined;
 
+  export let maxHeight: number | null | undefined = undefined;
+
   // Whether the image should fit its container
   export let fit = true;
-  export let preserveAspectRatio = true;
+  export let preserveAspectRatio = maxHeight === null || maxHeight === undefined;
 
   // The size type of the image
   export let sizeType: SizeType | "static" = "static";
@@ -52,7 +54,7 @@
     if (Array.isArray(sources)) return sources;
     if (sizeType === "static" && !width) return [{ srcset: [src] }];
     const widths = sizeType == "static" ? (width ? [width, width * 2] : []) : getWidths(sizeType);
-    return sources(src, { widths, srcWidth: width, srcHeight: height });
+    return sources(src, { widths, srcWidth: width, srcHeight: height, maxHeight });
   };
 
   $: resolvedSources = getResolvedSources(src, sources, sizeType);

--- a/src/lib/components/Image/types.ts
+++ b/src/lib/components/Image/types.ts
@@ -20,6 +20,7 @@ export type GetSources = (
     widths: number[];
     srcWidth?: number | null | undefined;
     srcHeight?: number | null | undefined;
+    maxHeight?: number | null | undefined;
   }
 ) => Sources;
 

--- a/src/routes/(infoPages)/+layout.svelte
+++ b/src/routes/(infoPages)/+layout.svelte
@@ -30,8 +30,9 @@
       width={topTierPage.heroImage.imageSource.width}
       height={topTierPage.heroImage.imageSource.height}
       sizeType="full-bleed"
+      maxHeight={16 * 14}
       blurhash={topTierPage.heroImage.imageSource.blurhash}
-      fit={true}
+      fit
       preserveAspectRatio={false}
       loading="eager"
     />

--- a/src/routes/(infoPages)/layout.scss
+++ b/src/routes/(infoPages)/layout.scss
@@ -1,3 +1,4 @@
 .top-tier-page-hero-image {
-  height: 33vh;
+  height: 14rem;
+  max-height: 33vh;
 }


### PR DESCRIPTION
## Proposed changes

<!-- Add detailed description of changes here. -->

- Makes top tier header images have a static maximum height
- Resizes top tier header images in `getSources` such that we never require more of an image than can possibly be shown

## Screenshots

Desktop:

![image](https://github.com/la-ldaf/ldaf-site/assets/1425133/f03c27f2-fde9-4901-b7d9-9234700e52d7)

Mobile:

![image](https://github.com/la-ldaf/ldaf-site/assets/1425133/6253895a-fe5a-4350-a40a-5667e1aa5f9f)
