### PR TITLE
Disable the Vercel toolbar when running Lighthouse reports.

### DIFF
--- a/.github/workflows/tests_and_reports.yml
+++ b/.github/workflows/tests_and_reports.yml
@@ -174,8 +174,8 @@ jobs:
         #   reports that the GitHub Actions runner couldn't keep up. Increasing this to 8 from the
         #   base of 4 seems to fix the issue.
         run: |
-          lighthouse-batch --use-global --html --out lighthouse-reports/mobile --file .lighthouse/urls.txt --params "--only-categories=\"performance,accessibility,best-practices,seo\" --throttling.cpuSlowdownMultiplier=8"
-          lighthouse-batch --use-global --html --out lighthouse-reports/desktop --file .lighthouse/urls.txt --params "--only-categories=\"performance,accessibility,best-practices,seo\" --throttling.cpuSlowdownMultiplier=8 --preset=desktop"
+          lighthouse-batch --use-global --html --out lighthouse-reports/mobile --file .lighthouse/urls.txt --params "--only-categories=\"performance,accessibility,best-practices,seo\" --extra-headers \"{\\\"x-vercel-skip-toolbar\\\":\\\"1\\\"}\" --throttling.cpuSlowdownMultiplier=8"
+          lighthouse-batch --use-global --html --out lighthouse-reports/desktop --file .lighthouse/urls.txt --params "--only-categories=\"performance,accessibility,best-practices,seo\" --extra-headers \"{\\\"x-vercel-skip-toolbar\\\":\\\"1\\\"}\" --throttling.cpuSlowdownMultiplier=8 --preset=desktop"
 
       - name: Copy landing page for reports summary
         run: cp .lighthouse/index.html lighthouse-reports/index.html

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ build-storybook.log
 /e2e-tests/report
 /e2e-tests/results
 /bundle-visualizer
+.lighthouse/urls.txt
 /lighthouse-reports
 
 # generated test files


### PR DESCRIPTION
When running Lighthouse reports, send an extra header to let Vercel know to disable preview comments.  Without that extra cruft, the reports on preview URLs should more closely reflect how the reports will perform on production.

Docs: https://vercel.com/docs/workflow-collaboration/comments/specialized-usage#disable-comments-temporarily

To test, open up the Lighthouse reports and view an HTML report (e.g. [homepage on mobile](https://meta-site-402-ldaf.vercel.app/lighthouse/mobile/ldaf-lunz59dzh-ldaf_vercel_app_.report.html)). You should no longer see the Vercel toolbar at the bottom of the page in the report's screenshot.