### PR TITLE
Only send speed insights in production; load `web-vitals` on demand

### DIFF
--- a/src/lib/vitals.ts
+++ b/src/lib/vitals.ts
@@ -1,3 +1,5 @@
+import type { Metric } from "web-vitals";
+
 const vitalsURL = "https://vitals.vercel-analytics.com/v1/vitals";
 
 const getConnectionSpeed = (): string =>
@@ -48,7 +50,7 @@ const sendToAnalytics = (metric: Metric, options: Options) => {
 
 export const webVitals = (options: Options) => {
   try {
-    const { onCLS, onFCP, onFID, onLCP, onTTFB, type Metric } = await import("web-vitals");
+    const { onCLS, onFCP, onFID, onLCP, onTTFB } = await import("web-vitals");
     onFID((metric) => sendToAnalytics(metric, options));
     onTTFB((metric) => sendToAnalytics(metric, options));
     onLCP((metric) => sendToAnalytics(metric, options));

--- a/src/lib/vitals.ts
+++ b/src/lib/vitals.ts
@@ -1,5 +1,3 @@
-import { onCLS, onFCP, onFID, onLCP, onTTFB, type Metric } from "web-vitals";
-
 const vitalsURL = "https://vitals.vercel-analytics.com/v1/vitals";
 
 const getConnectionSpeed = (): string =>
@@ -50,6 +48,7 @@ const sendToAnalytics = (metric: Metric, options: Options) => {
 
 export const webVitals = (options: Options) => {
   try {
+    const { onCLS, onFCP, onFID, onLCP, onTTFB, type Metric } = await import("web-vitals");
     onFID((metric) => sendToAnalytics(metric, options));
     onTTFB((metric) => sendToAnalytics(metric, options));
     onLCP((metric) => sendToAnalytics(metric, options));

--- a/src/lib/vitals.ts
+++ b/src/lib/vitals.ts
@@ -48,7 +48,7 @@ const sendToAnalytics = (metric: Metric, options: Options) => {
   }
 };
 
-export const webVitals = (options: Options) => {
+export const webVitals = async (options: Options) => {
   try {
     const { onCLS, onFCP, onFID, onLCP, onTTFB } = await import("web-vitals");
     onFID((metric) => sendToAnalytics(metric, options));

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -1,4 +1,4 @@
-import { VERCEL_ANALYTICS_ID } from "$env/static/private";
+import { VERCEL_ENV, VERCEL_ANALYTICS_ID } from "$env/static/private";
 import { loadPageMetadataMap } from "$lib/loadPageMetadataMap";
 import { loadSiteTitle } from "$lib/components/Header/Title/Title.server";
 import { loadMainNav, loadSecondaryNav } from "$lib/components/Header/Nav/Nav.server";
@@ -18,7 +18,8 @@ export const load = async () => {
     headerPrimaryNavItemsPromise,
   ]).then(([{ pageMetadataMap }, navItems]) => loadSideNavMap(pageMetadataMap, navItems));
   return {
-    analyticsID: VERCEL_ANALYTICS_ID, // this env variable can't be renamed, so we send it with the page data
+    // this env variable can't be renamed, so we send it with the page data
+    analyticsID: VERCEL_ENV === "production" ? VERCEL_ANALYTICS_ID : undefined,
     pageMetadataMap: pageMetadataMapPromise.then(({ pageMetadataMap }) => pageMetadataMap),
     pathsToIDs: pageMetadataMapPromise.then(({ pathsToIDs }) => pathsToIDs),
     siteTitle: loadSiteTitle(),


### PR DESCRIPTION
We're currently sending data to Speed Insights even in development and preview settings.