### PR TITLE
Increase timeout for Lighthouse to wait for Vercel preview deployment.

### DIFF
--- a/.github/workflows/tests_and_reports.yml
+++ b/.github/workflows/tests_and_reports.yml
@@ -142,8 +142,8 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           # Check once a minute
           check_interval: 60
-          # Timeout after 30 minutes
-          max_timeout: 1800
+          # Timeout after 45 minutes
+          max_timeout: 2700
 
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
This is only really necessary in situations like we have today where we have many changes being merged and a lot of open PRs that are all redeploying previews to Vercel at the same time.