### PR TITLE
Implement news aggregation page and individual news article and press release pages

### DIFF
--- a/src/app.scss
+++ b/src/app.scss
@@ -28,3 +28,8 @@ body {
     }
   }
 }
+
+/* Override the max-width on paragraphs set by the USWDS */
+.usa-prose > p {
+  max-width: none;
+}

--- a/src/lib/components/ContentfulRichText/context.ts
+++ b/src/lib/components/ContentfulRichText/context.ts
@@ -5,11 +5,10 @@ import type { PageMetadataMap } from "$lib/loadPageMetadataMap";
 export const linksKey = Symbol("contentfulRichTextLinks");
 
 const getAssetLinksMap = (links: Links, key: "block" | "hyperlink") =>
-  new Map(links.assets[key]?.flatMap((link) => (link ? [[link?.sys?.id, link]] : [])));
+  new Map(links.assets?.[key]?.flatMap((link) => (link ? [[link?.sys?.id, link]] : [])));
 
-const getAssetEntriesMap = (links: Links, key: "block" | "hyperlink") => {
-  return new Map(links.entries?.[key]?.flatMap((link) => (link ? [[link?.sys?.id, link]] : [])));
-};
+const getAssetEntriesMap = (links: Links, key: "block" | "hyperlink") =>
+  new Map(links.entries?.[key]?.flatMap((link) => (link ? [[link?.sys?.id, link]] : [])));
 
 export const createLinksContext = (
   links: Links,

--- a/src/lib/components/ContentfulRichText/types.ts
+++ b/src/lib/components/ContentfulRichText/types.ts
@@ -60,11 +60,11 @@ export type RenderableAssetHyperlink = RenderableAssetBlock;
 export type RenderableEntryHyperlink = RenderableEntryBlock;
 
 export type Links = {
-  assets: {
+  assets?: {
     block?: (RenderableAssetBlock | null)[];
     hyperlink?: (RenderableAssetHyperlink | null)[];
   };
-  entries: {
+  entries?: {
     block?: (RenderableEntryBlock | null)[];
     hyperlink?: (RenderableEntryHyperlink | null)[];
   };

--- a/src/lib/components/Tag/Tag.svelte
+++ b/src/lib/components/Tag/Tag.svelte
@@ -1,0 +1,6 @@
+<!-- TODO: Add story and a test. -->
+<script lang="ts">
+  export let big: boolean = false;
+</script>
+
+<span class={`text-no-uppercase usa-tag ${big ? "usa-tag--big" : ""}`}><slot /></span>

--- a/src/lib/components/Tag/Tag.svelte
+++ b/src/lib/components/Tag/Tag.svelte
@@ -1,6 +1,7 @@
-<!-- TODO: Add story and a test. -->
 <script lang="ts">
   export let big: boolean = false;
 </script>
 
-<span class={`text-no-uppercase usa-tag ${big ? "usa-tag--big" : ""}`}><slot /></span>
+<span class={`text-no-uppercase usa-tag ${big ? "usa-tag--big" : ""}`}>
+  <slot>example tag</slot>
+</span>

--- a/src/lib/components/Tag/Tag.test.ts
+++ b/src/lib/components/Tag/Tag.test.ts
@@ -1,0 +1,20 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/svelte";
+import { describe, it, expect } from "vitest";
+
+import Tag from ".";
+
+describe("Tag", () => {
+  it("renders", async () => {
+    render(Tag);
+    const tag = screen.getByText("example tag");
+    expect(tag).toBeInTheDocument();
+    expect(tag).toHaveClass("usa-tag");
+    expect(tag).not.toHaveClass("usa-tag--big");
+  });
+  it("renders with larger variation", async () => {
+    render(Tag, { big: true });
+    const tag = screen.getByText("example tag");
+    expect(tag).toHaveClass("usa-tag--big");
+  });
+});

--- a/src/lib/components/Tag/index.ts
+++ b/src/lib/components/Tag/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./Tag.svelte";

--- a/src/lib/util/dates.ts
+++ b/src/lib/util/dates.ts
@@ -2,6 +2,8 @@ import utcToZonedTime from "date-fns-tz/utcToZonedTime";
 import zonedTimeToUtc from "date-fns-tz/zonedTimeToUtc";
 import { parseISO, startOfDay, endOfDay, formatISO } from "date-fns";
 
+import { months } from "$lib/constants/date";
+
 export const getCurrentDateInTZ = (tz: string): string => {
   const date = new Date();
   const zoned = utcToZonedTime(date, tz);
@@ -16,4 +18,11 @@ export const getStartOfDayForDateInTZ = (dateString: string, tz: string): Date =
 export const getEndOfDayForDateInTZ = (dateString: string, tz: string): Date => {
   const date = endOfDay(parseISO(dateString));
   return zonedTimeToUtc(date, tz);
+};
+
+// date-only fields in Contentful (fields without timestamps) still include UTC
+//  timezone, so we need to use getUTC* methods to generate a date string
+export const getDateStringFromUTCDate = (dateString: string): string => {
+  const date = new Date(dateString);
+  return `${months[date.getUTCMonth()]} ${date.getUTCDate()}, ${date.getUTCFullYear()}`;
 };

--- a/src/routes/(infoPages)/about/events/+page.svelte
+++ b/src/routes/(infoPages)/about/events/+page.svelte
@@ -8,7 +8,8 @@
 
 <h1>All events</h1>
 
-<div class="events">
+<!-- See src/routes/(infoPages)/layout.scss for styling. -->
+<div class="ldaf-events-list-container">
   {#each events as event}
     <Event {event} />
   {/each}
@@ -19,13 +20,3 @@
   {totalPages}
   getPageLink={(page) => `/about/events/page/${page}`}
 />
-
-<style>
-  .events {
-    margin-top: 32px;
-    display: flex;
-    flex-direction: column;
-    gap: 18px;
-    margin-bottom: 18px;
-  }
-</style>

--- a/src/routes/(infoPages)/about/events/page/[page]/+page.server.ts
+++ b/src/routes/(infoPages)/about/events/page/[page]/+page.server.ts
@@ -1,4 +1,5 @@
 import { loadEventsPage } from "../../shared.server";
 import type { PageServerLoad } from "./$types";
 
+// [page] is passed to `loadEventsPage` as `params.page`
 export const load = loadEventsPage satisfies PageServerLoad;

--- a/src/routes/(infoPages)/about/events/shared.server.ts
+++ b/src/routes/(infoPages)/about/events/shared.server.ts
@@ -90,7 +90,6 @@ export const loadEventsPage = async ({
         currentPageNumber: pageNumber,
         totalPages: Math.ceil(testEvents.length / limit),
         events: testEventPages[pageNumber - 1].items,
-        totalEvents: testEvents.length,
         breadcrumbs: breadcrumbsPromise,
       };
     }
@@ -119,7 +118,6 @@ export const loadEventsPage = async ({
       currentPageNumber: pageNumber,
       totalPages: Math.ceil(eventsData.eventEntryCollection.total / limit),
       events: eventsData.eventEntryCollection.items,
-      totalEvents: eventsData.eventEntryCollection.total,
     };
   }
   throw error(404);

--- a/src/routes/(infoPages)/about/news/+page.server.ts
+++ b/src/routes/(infoPages)/about/news/+page.server.ts
@@ -1,0 +1,5 @@
+import { loadNewsPage } from "./shared.server";
+import type { PageServerLoad } from "./$types";
+
+export const load = (async ({ params, ...arg }) =>
+  loadNewsPage({ ...arg, params: { ...params, page: "1" } })) satisfies PageServerLoad;

--- a/src/routes/(infoPages)/about/news/+page.svelte
+++ b/src/routes/(infoPages)/about/news/+page.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+  import Pagination from "$lib/components/Pagination";
+  //import Event from "./Event.svelte";
+
+  export let data;
+  $: ({ newsArticles, currentPageNumber, totalPages } = data);
+</script>
+
+<h1>Latest news articles</h1>
+
+<div class="news-articles">
+  {#each newsArticles as article}
+    <p>{article.newsArticleTitle}</p>
+    <p>{article.newsArticleSubhead}</p>
+  {/each}
+</div>
+
+<Pagination
+  currentPage={currentPageNumber}
+  {totalPages}
+  getPageLink={(page) => `/about/news/page/${page}`}
+/>
+
+<style>
+  .news-articles {
+    margin-top: 32px;
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+    margin-bottom: 18px;
+  }
+</style>

--- a/src/routes/(infoPages)/about/news/+page.svelte
+++ b/src/routes/(infoPages)/about/news/+page.svelte
@@ -1,17 +1,16 @@
 <script lang="ts">
+  import News from "./News.svelte";
   import Pagination from "$lib/components/Pagination";
-  //import Event from "./Event.svelte";
 
   export let data;
-  $: ({ newsArticles, currentPageNumber, totalPages } = data);
+  $: ({ newsEntries, currentPageNumber, totalPages } = data);
 </script>
 
-<h1>Latest news articles</h1>
+<h1>News</h1>
 
-<div class="news-articles">
-  {#each newsArticles as article}
-    <p>{article.newsArticleTitle}</p>
-    <p>{article.newsArticleSubhead}</p>
+<div>
+  {#each newsEntries as entry}
+    <News {entry} />
   {/each}
 </div>
 
@@ -20,13 +19,3 @@
   {totalPages}
   getPageLink={(page) => `/about/news/page/${page}`}
 />
-
-<style>
-  .news-articles {
-    margin-top: 32px;
-    display: flex;
-    flex-direction: column;
-    gap: 18px;
-    margin-bottom: 18px;
-  }
-</style>

--- a/src/routes/(infoPages)/about/news/+page.svelte
+++ b/src/routes/(infoPages)/about/news/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import "./page.scss";
 
-  import News from "./NewsEntrySnippet.svelte";
+  import NewsEntrySnippet from "./NewsEntrySnippet.svelte";
   import Pagination from "$lib/components/Pagination";
 
   export let data;
@@ -13,7 +13,7 @@
 <div>
   {#each newsEntries as entry}
     {#if entry}
-      <News {entry} />
+      <NewsEntrySnippet {entry} />
     {/if}
   {/each}
 </div>

--- a/src/routes/(infoPages)/about/news/+page.svelte
+++ b/src/routes/(infoPages)/about/news/+page.svelte
@@ -1,12 +1,14 @@
 <script lang="ts">
-  import News from "./News.svelte";
+  import "./page.scss";
+
+  import News from "./NewsEntrySnippet.svelte";
   import Pagination from "$lib/components/Pagination";
 
   export let data;
   $: ({ newsEntries, currentPageNumber, totalPages } = data);
 </script>
 
-<h1>News</h1>
+<h1 class="ldaf-news-page--heading">News</h1>
 
 <div>
   {#each newsEntries as entry}

--- a/src/routes/(infoPages)/about/news/+page.svelte
+++ b/src/routes/(infoPages)/about/news/+page.svelte
@@ -12,7 +12,9 @@
 
 <div>
   {#each newsEntries as entry}
-    <News {entry} />
+    {#if entry}
+      <News {entry} />
+    {/if}
   {/each}
 </div>
 

--- a/src/routes/(infoPages)/about/news/News.svelte
+++ b/src/routes/(infoPages)/about/news/News.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+  import { months } from "$lib/constants/date";
+  import ContentfulRichText from "$lib/components/ContentfulRichText";
+  import Link from "$lib/components/Link";
+  import type { PageServerData } from "./$types";
+  export let entry: PageServerData["newsEntries"][number];
+
+  $: if (entry?.body?.json?.content?.length) {
+    entry.body.json.content.length = 1;
+  }
+  // We only care about the date, not the timestamp.
+  // TODO: Update using work completed in #378
+  $: [date] = entry?.publicationDate ? entry.publicationDate.split("T") : "";
+  $: [year, month, day] = date.split("-");
+  $: dateString = `${months[month - 1]} ${day.replace(/^0+/, "")}, ${year}`;
+</script>
+
+{#if entry}
+  {@const { slug, title, body, byline, type } = entry}
+  {#if title && slug}
+    <div class="news-entry">
+      <Link href={`/about/news/article/${slug}`}>
+        <h2>{title}</h2></Link
+      >
+      {#if body?.json}
+        <ContentfulRichText document={body.json} />
+      {/if}
+      {#if byline}
+        <p>{byline}</p>
+      {/if}
+      <p>
+        {dateString}
+      </p>
+      <p>
+        {type}
+      </p>
+    </div>
+  {/if}
+{/if}

--- a/src/routes/(infoPages)/about/news/NewsEntrySnippet.svelte
+++ b/src/routes/(infoPages)/about/news/NewsEntrySnippet.svelte
@@ -4,39 +4,40 @@
   import Link from "$lib/components/Link";
   import Tag from "$lib/components/Tag";
   import type { PageServerData } from "./$types";
-  export let entry: PageServerData["newsEntries"][number];
 
-  $: if (entry?.body?.json?.content?.length) {
-    entry.body.json.content.length = 1;
+  export let entry: NonNullable<PageServerData["newsEntries"][number]>;
+
+  $: ({ slug, title, body, byline, type, publicationDate } = entry);
+
+  $: if (body?.json?.content?.length) {
+    body.json.content.length = 1;
   }
   // We only care about the date, not the timestamp.
   // TODO: Update using work completed in #378
-  $: [date] = entry?.publicationDate ? entry.publicationDate.split("T") : "";
+  $: [date] = publicationDate ? publicationDate.split("T") : "";
   $: [year, month, day] = date.split("-");
   $: dateString = `${months[month - 1]} ${day.replace(/^0+/, "")}, ${year}`;
+  $: isArticle = type === "News article";
 </script>
 
-{#if entry}
-  {@const { slug, title, body, byline, type } = entry}
-  {#if title && slug}
-    <div class="ldaf-news-entry">
-      <Link href={`/about/news/article/${slug}`}>
-        <h2 class="font-body-lg">{title}</h2></Link
-      >
-      {#if body?.json}
-        <ContentfulRichText document={body.json} />
+{#if title && slug}
+  <div class="ldaf-news-entry">
+    <Link href={`/about/news/article/${slug}`}>
+      <h2 class="font-body-lg">{title}</h2></Link
+    >
+    {#if body?.json}
+      <ContentfulRichText document={body.json} links={body?.links} imageSizeType="col-9" />
+    {/if}
+    <div class="font-body-2xs">
+      {#if isArticle && byline}
+        By {byline}<br />
       {/if}
-      <div class="font-body-2xs">
-        {#if byline}
-          {byline}<br />
-        {/if}
-        {dateString}
-      </div>
-      <div class="margin-top-1">
-        <!-- TODO: LDAF-402 support additional tags -->
-        <Tag>{type}</Tag>
-      </div>
+      {dateString}
     </div>
-    <hr />
-  {/if}
+    <div class="margin-top-1 margin-bottom-2">
+      <!-- TODO: LDAF-402 support additional tags -->
+      <Tag>{type}</Tag>
+    </div>
+  </div>
+  <hr />
 {/if}

--- a/src/routes/(infoPages)/about/news/NewsEntrySnippet.svelte
+++ b/src/routes/(infoPages)/about/news/NewsEntrySnippet.svelte
@@ -2,6 +2,7 @@
   import { months } from "$lib/constants/date";
   import ContentfulRichText from "$lib/components/ContentfulRichText";
   import Link from "$lib/components/Link";
+  import Tag from "$lib/components/Tag";
   import type { PageServerData } from "./$types";
   export let entry: PageServerData["newsEntries"][number];
 
@@ -18,22 +19,24 @@
 {#if entry}
   {@const { slug, title, body, byline, type } = entry}
   {#if title && slug}
-    <div class="news-entry">
+    <div class="ldaf-news-entry">
       <Link href={`/about/news/article/${slug}`}>
-        <h2>{title}</h2></Link
+        <h2 class="font-body-lg">{title}</h2></Link
       >
       {#if body?.json}
         <ContentfulRichText document={body.json} />
       {/if}
-      {#if byline}
-        <p>{byline}</p>
-      {/if}
-      <p>
+      <div class="font-body-2xs">
+        {#if byline}
+          {byline}<br />
+        {/if}
         {dateString}
-      </p>
-      <p>
-        {type}
-      </p>
+      </div>
+      <div class="margin-top-1">
+        <!-- TODO: LDAF-402 support additional tags -->
+        <Tag>{type}</Tag>
+      </div>
     </div>
+    <hr />
   {/if}
 {/if}

--- a/src/routes/(infoPages)/about/news/NewsEntrySnippet.svelte
+++ b/src/routes/(infoPages)/about/news/NewsEntrySnippet.svelte
@@ -4,14 +4,19 @@
   import Tag from "$lib/components/Tag";
   import { getDateStringFromUTCDate } from "$lib/util/dates";
 
+  import type { Node } from "@contentful/rich-text-types";
   import type { PageServerData } from "./$types";
 
   export let entry: NonNullable<PageServerData["newsEntries"][number]>;
 
   $: ({ slug, title, body, byline, type, publicationDate } = entry);
 
-  $: if (body?.json?.content?.length) {
-    body.json.content.length = 1;
+  // Only display the first paragraph.
+  $: if (body?.json?.content) {
+    const firstParagraph = body.json.content.find(
+      (content: Node) => content.nodeType === "paragraph",
+    );
+    body.json.content = [firstParagraph];
   }
 
   $: dateString = getDateStringFromUTCDate(publicationDate);

--- a/src/routes/(infoPages)/about/news/NewsEntrySnippet.svelte
+++ b/src/routes/(infoPages)/about/news/NewsEntrySnippet.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
-  import { months } from "$lib/constants/date";
   import ContentfulRichText from "$lib/components/ContentfulRichText";
   import Link from "$lib/components/Link";
   import Tag from "$lib/components/Tag";
+  import { getDateStringFromUTCDate } from "$lib/util/dates";
+
   import type { PageServerData } from "./$types";
 
   export let entry: NonNullable<PageServerData["newsEntries"][number]>;
@@ -12,11 +13,9 @@
   $: if (body?.json?.content?.length) {
     body.json.content.length = 1;
   }
-  // We only care about the date, not the timestamp.
-  // TODO: Update using work completed in #378
-  $: [date] = publicationDate ? publicationDate.split("T") : "";
-  $: [year, month, day] = date.split("-");
-  $: dateString = `${months[month - 1]} ${day.replace(/^0+/, "")}, ${year}`;
+
+  $: dateString = getDateStringFromUTCDate(publicationDate);
+
   $: isArticle = type === "News article";
 </script>
 

--- a/src/routes/(infoPages)/about/news/__tests__/newsTestContent.ts
+++ b/src/routes/(infoPages)/about/news/__tests__/newsTestContent.ts
@@ -43,6 +43,7 @@ const getArticle = (i: number) => ({
         },
       ],
     },
+    links: undefined,
   },
 });
 

--- a/src/routes/(infoPages)/about/news/__tests__/newsTestContent.ts
+++ b/src/routes/(infoPages)/about/news/__tests__/newsTestContent.ts
@@ -19,16 +19,35 @@ const getArticleID = (i: number) => `${1000 + i}`;
 const lipsum =
   "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";
 
-const getArticle = (_, i: number) => ({
+const getArticle = (i: number) => ({
   sys: {
     id: getArticleID(i),
   },
-  newsArticleTitle: "Test title",
-  newsArticleSubhead: "Test subhead",
+  title: "Test title",
+  subhead: "Test subhead",
+  slug: "test-slug",
+  byline: "Test Author",
+  publicationDate: new Date(),
+  type: "article",
+  body: {
+    json: {
+      content: [
+        {
+          nodeType: "paragraph",
+          content: [
+            {
+              nodeType: "text",
+              value: lipsum,
+            },
+          ],
+        },
+      ],
+    },
+  },
 });
 
-export const newsArticles = new Array(200).fill(undefined).map((_, i) => getArticle({}, i));
-export const pages = chunk(newsArticles, 20).map((items) => ({
-  total: newsArticles.length,
+export const newsEntries = new Array(200).fill(undefined).map((_, i) => getArticle(i));
+export const pages = chunk(newsEntries, 20).map((items) => ({
+  total: newsEntries.length,
   items,
 }));

--- a/src/routes/(infoPages)/about/news/__tests__/newsTestContent.ts
+++ b/src/routes/(infoPages)/about/news/__tests__/newsTestContent.ts
@@ -1,0 +1,34 @@
+// import type { ExtractQueryType } from "$lib/util/types";
+import chunk from "lodash/chunk";
+// import type { NewsArticlesQuery } from "../$queries.generated";
+
+// type EventCollection = ExtractQueryType<EventsQuery, ["eventEntryCollection"]>;
+// type Event = ExtractQueryType<EventCollection, ["items", number]>;
+
+// type EventOptionsKeys = never;
+// type EventOptionsNullable = Required<Pick<Event, EventOptionsKeys>>;
+// type EventOptions = {
+//   [K in keyof EventOptionsNullable]: NonNullable<EventOptionsNullable[K]>;
+// };
+
+//const baseTimestamp = Date.now() + 1 * day;
+//const getEventDateAndTime = (i: number) => new Date(baseTimestamp + i * day).toISOString();
+
+const getArticleID = (i: number) => `${1000 + i}`;
+
+const lipsum =
+  "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";
+
+const getArticle = (_, i: number) => ({
+  sys: {
+    id: getArticleID(i),
+  },
+  newsArticleTitle: "Test title",
+  newsArticleSubhead: "Test subhead",
+});
+
+export const newsArticles = new Array(200).fill(undefined).map((_, i) => getArticle({}, i));
+export const pages = chunk(newsArticles, 20).map((items) => ({
+  total: newsArticles.length,
+  items,
+}));

--- a/src/routes/(infoPages)/about/news/__tests__/newsTestContent.ts
+++ b/src/routes/(infoPages)/about/news/__tests__/newsTestContent.ts
@@ -1,18 +1,4 @@
-// import type { ExtractQueryType } from "$lib/util/types";
 import chunk from "lodash/chunk";
-// import type { NewsArticlesQuery } from "../$queries.generated";
-
-// type EventCollection = ExtractQueryType<EventsQuery, ["eventEntryCollection"]>;
-// type Event = ExtractQueryType<EventCollection, ["items", number]>;
-
-// type EventOptionsKeys = never;
-// type EventOptionsNullable = Required<Pick<Event, EventOptionsKeys>>;
-// type EventOptions = {
-//   [K in keyof EventOptionsNullable]: NonNullable<EventOptionsNullable[K]>;
-// };
-
-//const baseTimestamp = Date.now() + 1 * day;
-//const getEventDateAndTime = (i: number) => new Date(baseTimestamp + i * day).toISOString();
 
 const getArticleID = (i: number) => `${1000 + i}`;
 

--- a/src/routes/(infoPages)/about/news/article/[slug]/+page.server.ts
+++ b/src/routes/(infoPages)/about/news/article/[slug]/+page.server.ts
@@ -2,12 +2,18 @@ import { error } from "@sveltejs/kit";
 import gql from "graphql-tag";
 import { print as printQuery } from "graphql";
 import { CONTENTFUL_DELIVERY_API_TOKEN, CONTENTFUL_SPACE_ID } from "$env/static/private";
+import { getBlurhash } from "$lib/services/blurhashes";
 import getContentfulClient from "$lib/services/contentful";
 import type { PageServerLoad } from "./$types";
-import type { NewsQuery } from "./$queries.generated";
+import type { DefaultPressReleaseContactInfoQuery, NewsQuery } from "./$queries.generated";
 import { loadBaseBreadcrumbs } from "../../shared.server";
+import imagePropsFragment from "$lib/fragments/imageProps";
+import entryPropsFragment from "$lib/fragments/entryProps";
 
-const query = gql`
+const newsQuery = gql`
+  # eslint-disable @graphql-eslint/selection-set-depth
+  ${imagePropsFragment}
+  ${entryPropsFragment}
   query News($slug: String!) {
     newsCollection(limit: 1, where: { slug: $slug }) {
       items {
@@ -18,18 +24,130 @@ const query = gql`
         title
         subhead
         publicationDate
+        heroImage {
+          ... on HeroImage {
+            imageSource {
+              ... on Asset {
+                title
+                description
+                contentType
+                fileName
+                size
+                url
+                width
+                height
+              }
+            }
+            imageTitle
+            altField
+            fotogCredit
+          }
+        }
         body {
           json
+          links {
+            assets {
+              block {
+                ...ImageProps
+              }
+              hyperlink {
+                ...ImageProps
+              }
+            }
+            entries {
+              block {
+                ...EntryProps
+              }
+              hyperlink {
+                ...EntryProps
+              }
+            }
+          }
         }
         slug
         metaTitle
+        metaDescription
         byline
+        contactInformationCollection {
+          items {
+            ... on Contact {
+              sys {
+                id
+              }
+              entityName
+              phone
+              email
+            }
+          }
+        }
+        relatedLinks {
+          json
+          links {
+            assets {
+              block {
+                ...ImageProps
+              }
+              hyperlink {
+                ...ImageProps
+              }
+            }
+            entries {
+              block {
+                ...EntryProps
+              }
+              hyperlink {
+                ...EntryProps
+              }
+            }
+          }
+        }
+        relatedEventsCollection {
+          items {
+            ... on EventEntry {
+              sys {
+                id
+              }
+              eventDateAndTime
+              shortTitle
+              slug
+              eventDescription
+            }
+          }
+        }
+        relatedNewsCollection {
+          items {
+            ... on News {
+              sys {
+                id
+              }
+              slug
+              title
+              byline
+              type
+              publicationDate
+            }
+          }
+        }
       }
     }
   }
 `;
 
-export const load = (async ({ params: { slug }, parent }) => {
+// TODO: Find a better way to grab the default press release contact
+const defaultPressReleaseContactInfoQuery = gql`
+  query DefaultPressReleaseContactInfo {
+    contact(id: "6lhNJaZ05vgqkoRSF2wNM8") {
+      sys {
+        id
+      }
+      entityName
+      phone
+      email
+    }
+  }
+`;
+
+export const load = (async ({ params: { slug }, parent, fetch }) => {
   if (!slug) throw error(404);
   // TODO: example contents
   if (!CONTENTFUL_SPACE_ID || !CONTENTFUL_DELIVERY_API_TOKEN) throw error(404);
@@ -41,7 +159,7 @@ export const load = (async ({ params: { slug }, parent }) => {
   const variables = {
     slug,
   };
-  const newsArticleDataPromise = client.fetch<NewsQuery>(printQuery(query), {
+  const newsArticleDataPromise = client.fetch<NewsQuery>(printQuery(newsQuery), {
     variables,
   });
   const [baseBreadcrumbs, newsArticleData] = await Promise.all([
@@ -50,14 +168,55 @@ export const load = (async ({ params: { slug }, parent }) => {
   ]);
   const [newsArticle] = newsArticleData?.newsCollection?.items ?? [];
   if (!newsArticle) throw error(404);
+
+  let defaultPressReleaseContactInfoPromise: Promise<
+    DefaultPressReleaseContactInfoQuery | undefined
+  > = Promise.resolve(undefined);
+  // Fetch the default press release contact info for press releases if other contacts aren't provided
+  if (
+    newsArticle.type === "Press release" &&
+    !newsArticle.contactInformationCollection?.items?.length
+  ) {
+    defaultPressReleaseContactInfoPromise = client.fetch<DefaultPressReleaseContactInfoQuery>(
+      printQuery(defaultPressReleaseContactInfoQuery),
+    );
+  }
+
+  const heroImageURL = newsArticle.heroImage?.imageSource?.url;
+  const heroImageBlurhashPromise = heroImageURL
+    ? getBlurhash(heroImageURL, { fetch })
+    : Promise.resolve(undefined);
+
+  const [defaultPressReleaseContactInfo, heroImageBlurhash] = await Promise.all([
+    defaultPressReleaseContactInfoPromise,
+    heroImageBlurhashPromise,
+  ]);
+
+  const url = `/about/news/article/${slug}`;
+
   return {
-    newsArticle,
+    newsArticle: {
+      ...newsArticle,
+      contactInformationCollection: defaultPressReleaseContactInfo?.contact
+        ? { items: [defaultPressReleaseContactInfo.contact] }
+        : newsArticle.contactInformationCollection,
+      heroImage: newsArticle.heroImage
+        ? {
+            ...newsArticle.heroImage,
+            imageSource: newsArticle.heroImage.imageSource
+              ? {
+                  ...newsArticle.heroImage.imageSource,
+                  blurhash: heroImageBlurhash,
+                }
+              : undefined,
+          }
+        : undefined,
+    },
     pageMetadata: {
-      metaTitle: `News - ${newsArticle.metaTitle || newsArticle.title}`,
-      breadcrumbs: [
-        ...baseBreadcrumbs,
-        { title: newsArticle.title, link: `/about/news/article/${slug}` },
-      ],
+      metaTitle: `${newsArticle.type} - ${newsArticle.metaTitle || newsArticle.title}`,
+      metaDescription: newsArticle.metaDescription,
+      url,
+      breadcrumbs: [...baseBreadcrumbs, { title: newsArticle.title, link: url }],
     },
   };
 }) satisfies PageServerLoad;

--- a/src/routes/(infoPages)/about/news/article/[slug]/+page.server.ts
+++ b/src/routes/(infoPages)/about/news/article/[slug]/+page.server.ts
@@ -1,0 +1,56 @@
+import { error } from "@sveltejs/kit";
+import gql from "graphql-tag";
+import { print as printQuery } from "graphql";
+import { CONTENTFUL_DELIVERY_API_TOKEN, CONTENTFUL_SPACE_ID } from "$env/static/private";
+import getContentfulClient from "$lib/services/contentful";
+import type { PageServerLoad } from "./$types";
+import type { NewsArticleQuery } from "./$queries.generated";
+import { loadBaseBreadcrumbs } from "../../shared.server";
+
+const query = gql`
+  query NewsArticle($slug: String!) {
+    newsArticleCollection(limit: 1, where: { slug: $slug }) {
+      items {
+        sys {
+          id
+        }
+        slug
+        newsArticleTitle
+        newsArticleSubhead
+      }
+    }
+  }
+`;
+
+export const load = (async ({ params: { slug }, parent }) => {
+  if (!slug) throw error(404);
+  // TODO: example contents
+  if (!CONTENTFUL_SPACE_ID || !CONTENTFUL_DELIVERY_API_TOKEN) throw error(404);
+  const baseBreadcrumbsPromise = loadBaseBreadcrumbs({ parent });
+  const client = getContentfulClient({
+    spaceID: CONTENTFUL_SPACE_ID,
+    token: CONTENTFUL_DELIVERY_API_TOKEN,
+  });
+  const variables = {
+    slug,
+  };
+  const newsArticleDataPromise = client.fetch<NewsArticleQuery>(printQuery(query), {
+    variables,
+  });
+  const [baseBreadcrumbs, newsArticleData] = await Promise.all([
+    baseBreadcrumbsPromise,
+    newsArticleDataPromise,
+  ]);
+  const [newsArticle] = newsArticleData?.newsArticleCollection?.items ?? [];
+  if (!newsArticle) throw error(404);
+  return {
+    newsArticle,
+    pageMetadata: {
+      metaTitle: `News - ${newsArticle.newsArticleTitle}`,
+      breadcrumbs: [
+        ...baseBreadcrumbs,
+        { title: newsArticle.newsArticleTitle, link: `/about/news/article/${slug}` },
+      ],
+    },
+  };
+}) satisfies PageServerLoad;

--- a/src/routes/(infoPages)/about/news/article/[slug]/+page.server.ts
+++ b/src/routes/(infoPages)/about/news/article/[slug]/+page.server.ts
@@ -4,19 +4,20 @@ import { print as printQuery } from "graphql";
 import { CONTENTFUL_DELIVERY_API_TOKEN, CONTENTFUL_SPACE_ID } from "$env/static/private";
 import getContentfulClient from "$lib/services/contentful";
 import type { PageServerLoad } from "./$types";
-import type { NewsArticleQuery } from "./$queries.generated";
+import type { NewsQuery } from "./$queries.generated";
 import { loadBaseBreadcrumbs } from "../../shared.server";
 
 const query = gql`
-  query NewsArticle($slug: String!) {
-    newsArticleCollection(limit: 1, where: { slug: $slug }) {
+  query News($slug: String!) {
+    newsCollection(limit: 1, where: { slug: $slug }) {
       items {
         sys {
           id
         }
         slug
-        newsArticleTitle
-        newsArticleSubhead
+        title
+        subhead
+        metaTitle
       }
     }
   }
@@ -34,7 +35,7 @@ export const load = (async ({ params: { slug }, parent }) => {
   const variables = {
     slug,
   };
-  const newsArticleDataPromise = client.fetch<NewsArticleQuery>(printQuery(query), {
+  const newsArticleDataPromise = client.fetch<NewsQuery>(printQuery(query), {
     variables,
   });
   const [baseBreadcrumbs, newsArticleData] = await Promise.all([
@@ -46,10 +47,10 @@ export const load = (async ({ params: { slug }, parent }) => {
   return {
     newsArticle,
     pageMetadata: {
-      metaTitle: `News - ${newsArticle.newsArticleTitle}`,
+      metaTitle: `News - ${newsArticle.metaTitle || newsArticle.title}`,
       breadcrumbs: [
         ...baseBreadcrumbs,
-        { title: newsArticle.newsArticleTitle, link: `/about/news/article/${slug}` },
+        { title: newsArticle.title, link: `/about/news/article/${slug}` },
       ],
     },
   };

--- a/src/routes/(infoPages)/about/news/article/[slug]/+page.server.ts
+++ b/src/routes/(infoPages)/about/news/article/[slug]/+page.server.ts
@@ -14,10 +14,15 @@ const query = gql`
         sys {
           id
         }
-        slug
+        type
         title
-        subhead
+        publicationDate
+        body {
+          json
+        }
+        slug
         metaTitle
+        byline
       }
     }
   }
@@ -42,7 +47,7 @@ export const load = (async ({ params: { slug }, parent }) => {
     baseBreadcrumbsPromise,
     newsArticleDataPromise,
   ]);
-  const [newsArticle] = newsArticleData?.newsArticleCollection?.items ?? [];
+  const [newsArticle] = newsArticleData?.newsCollection?.items ?? [];
   if (!newsArticle) throw error(404);
   return {
     newsArticle,

--- a/src/routes/(infoPages)/about/news/article/[slug]/+page.server.ts
+++ b/src/routes/(infoPages)/about/news/article/[slug]/+page.server.ts
@@ -16,6 +16,7 @@ const query = gql`
         }
         type
         title
+        subhead
         publicationDate
         body {
           json

--- a/src/routes/(infoPages)/about/news/article/[slug]/+page.svelte
+++ b/src/routes/(infoPages)/about/news/article/[slug]/+page.svelte
@@ -1,8 +1,44 @@
 <script lang="ts">
+  import "./page.scss";
+
+  import { months } from "$lib/constants/date";
   import ContentfulRichText from "$lib/components/ContentfulRichText";
+  import Tag from "$lib/components/Tag";
 
   export let data;
+  $: ({
+    newsArticle: { title, byline, publicationDate, type, subhead, body },
+  } = data);
+  // We only care about the date, not the timestamp.
+  // TODO: Update using work completed in #378
+  $: [date] = publicationDate ? publicationDate.split("T") : "";
+  $: [year, month, day] = date.split("-");
+  $: dateString = `${months[month - 1]} ${day.replace(/^0+/, "")}, ${year}`;
+
+  $: isPressRelease = type === "Press release";
+  $: isArticle = type === "News article";
 </script>
 
-<h1>{data.newsArticle.title}</h1>
-<ContentfulRichText document={data.newsArticle?.body?.json} />
+<div><strong>News</strong></div>
+<h1 class="ldaf-news-entry--heading">{title}</h1>
+{#if isArticle}
+  <div class="font-body-2xs">
+    {#if byline}
+      {byline}<br />
+    {/if}
+    {dateString}
+  </div>
+{/if}
+<div class="margin-top-1 margin-bottom-2">
+  <!-- TODO: LDAF-402 support additional tags -->
+  <Tag>{type}</Tag>
+</div>
+{#if subhead}
+  <p class="usa-intro">
+    {subhead}
+  </p>
+{/if}
+{#if isPressRelease}
+  <strong>For immediate release: {dateString}</strong>
+{/if}
+<ContentfulRichText document={body?.json} />

--- a/src/routes/(infoPages)/about/news/article/[slug]/+page.svelte
+++ b/src/routes/(infoPages)/about/news/article/[slug]/+page.svelte
@@ -2,5 +2,5 @@
   export let data;
 </script>
 
-<h1>{data.newsArticle.newsArticleTitle}</h1>
-<p>{data.newsArticle.newsArticleSubhead}</p>
+<h1>{data.newsArticle.title}</h1>
+<p>{data.newsArticle.subhead}</p>

--- a/src/routes/(infoPages)/about/news/article/[slug]/+page.svelte
+++ b/src/routes/(infoPages)/about/news/article/[slug]/+page.svelte
@@ -99,7 +99,8 @@
 
 {#if relatedEventsCollection?.items && relatedEventsCollection?.items.length > 0}
   <h2>Related events</h2>
-  <div class="events">
+  <!-- See src/routes/(infoPages)/layout.scss for styling. -->
+  <div class="ldaf-events-list-container">
     {#each relatedEventsCollection?.items as event (event?.sys.id)}
       <Event {event} />
     {/each}
@@ -114,14 +115,3 @@
     {/if}
   {/each}
 {/if}
-
-<!-- TODO: This is copied from the events page, should be reusable instead. -->
-<style>
-  .events {
-    margin-top: 32px;
-    display: flex;
-    flex-direction: column;
-    gap: 18px;
-    margin-bottom: 18px;
-  }
-</style>

--- a/src/routes/(infoPages)/about/news/article/[slug]/+page.svelte
+++ b/src/routes/(infoPages)/about/news/article/[slug]/+page.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+  export let data;
+</script>
+
+<h1>{data.newsArticle.newsArticleTitle}</h1>
+<p>{data.newsArticle.newsArticleSubhead}</p>

--- a/src/routes/(infoPages)/about/news/article/[slug]/+page.svelte
+++ b/src/routes/(infoPages)/about/news/article/[slug]/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
+  import ContentfulRichText from "$lib/components/ContentfulRichText";
+
   export let data;
 </script>
 
 <h1>{data.newsArticle.title}</h1>
-<p>{data.newsArticle.subhead}</p>
+<ContentfulRichText document={data.newsArticle?.body?.json} />

--- a/src/routes/(infoPages)/about/news/article/[slug]/+page.svelte
+++ b/src/routes/(infoPages)/about/news/article/[slug]/+page.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import "./page.scss";
 
-  import { months } from "$lib/constants/date";
   import ContactCard from "$lib/components/ContactCard";
   import ContentfulRichText from "$lib/components/ContentfulRichText";
   import Event from "../../../events/Event.svelte";
@@ -9,6 +8,7 @@
   import NewsEntrySnippet from "../../NewsEntrySnippet.svelte";
   import Tag from "$lib/components/Tag";
   import { getSources } from "$lib/imageServices/contentful";
+  import { getDateStringFromUTCDate } from "$lib/util/dates";
 
   export let data;
   $: ({
@@ -26,11 +26,8 @@
       relatedNewsCollection,
     },
   } = data);
-  // We only care about the date, not the timestamp.
-  // TODO: Update using work completed in #378
-  $: [date] = publicationDate ? publicationDate.split("T") : "";
-  $: [year, month, day] = date.split("-");
-  $: dateString = `${months[month - 1]} ${day.replace(/^0+/, "")}, ${year}`;
+
+  $: dateString = getDateStringFromUTCDate(publicationDate);
 
   $: isPressRelease = type === "Press release";
   $: isArticle = type === "News article";

--- a/src/routes/(infoPages)/about/news/article/[slug]/+page.svelte
+++ b/src/routes/(infoPages)/about/news/article/[slug]/+page.svelte
@@ -49,16 +49,13 @@
 </div>
 {#if heroImage?.imageSource?.url}
   <Image
-    class="top-tier-page-hero-image"
     src={heroImage.imageSource.url}
-    alt={heroImage.imageSource.description ?? "Hero image"}
     sources={getSources}
+    blurhash={heroImage.imageSource.blurhash}
+    alt={heroImage.imageSource.description ?? "Hero image"}
     width={heroImage.imageSource.width}
     height={heroImage.imageSource.height}
     sizeType="col-9"
-    blurhash={heroImage.imageSource.blurhash}
-    fit={true}
-    preserveAspectRatio={false}
     loading="eager"
   />
   {#if heroImage.fotogCredit}

--- a/src/routes/(infoPages)/about/news/article/[slug]/+page.svelte
+++ b/src/routes/(infoPages)/about/news/article/[slug]/+page.svelte
@@ -105,9 +105,11 @@
 
 {#if relatedEventsCollection?.items && relatedEventsCollection?.items.length > 0}
   <h2>Related events</h2>
-  {#each relatedEventsCollection?.items as event (event?.sys.id)}
-    <Event {event} />
-  {/each}
+  <div class="events">
+    {#each relatedEventsCollection?.items as event (event?.sys.id)}
+      <Event {event} />
+    {/each}
+  </div>
 {/if}
 
 {#if relatedNewsCollection?.items && relatedNewsCollection?.items.length > 0}
@@ -118,3 +120,14 @@
     {/if}
   {/each}
 {/if}
+
+<!-- TODO: This is copied from the events page, should be reusable instead. -->
+<style>
+  .events {
+    margin-top: 32px;
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+    margin-bottom: 18px;
+  }
+</style>

--- a/src/routes/(infoPages)/about/news/article/[slug]/+page.svelte
+++ b/src/routes/(infoPages)/about/news/article/[slug]/+page.svelte
@@ -2,12 +2,29 @@
   import "./page.scss";
 
   import { months } from "$lib/constants/date";
+  import ContactCard from "$lib/components/ContactCard";
   import ContentfulRichText from "$lib/components/ContentfulRichText";
+  import Event from "../../../events/Event.svelte";
+  import Image from "$lib/components/Image";
+  import NewsEntrySnippet from "../../NewsEntrySnippet.svelte";
   import Tag from "$lib/components/Tag";
+  import { getSources } from "$lib/imageServices/contentful";
 
   export let data;
   $: ({
-    newsArticle: { title, byline, publicationDate, type, subhead, body },
+    newsArticle: {
+      title,
+      byline,
+      publicationDate,
+      type,
+      heroImage,
+      subhead,
+      body,
+      contactInformationCollection,
+      relatedLinks,
+      relatedEventsCollection,
+      relatedNewsCollection,
+    },
   } = data);
   // We only care about the date, not the timestamp.
   // TODO: Update using work completed in #378
@@ -24,7 +41,7 @@
 {#if isArticle}
   <div class="font-body-2xs">
     {#if byline}
-      {byline}<br />
+      By {byline}<br />
     {/if}
     {dateString}
   </div>
@@ -33,12 +50,71 @@
   <!-- TODO: LDAF-402 support additional tags -->
   <Tag>{type}</Tag>
 </div>
+{#if heroImage?.imageSource?.url}
+  <Image
+    class="top-tier-page-hero-image"
+    src={heroImage.imageSource.url}
+    alt={heroImage.imageSource.description ?? "Hero image"}
+    sources={getSources}
+    width={heroImage.imageSource.width}
+    height={heroImage.imageSource.height}
+    sizeType="col-9"
+    blurhash={heroImage.imageSource.blurhash}
+    fit={true}
+    preserveAspectRatio={false}
+    loading="eager"
+  />
+  {#if heroImage.fotogCredit}
+    <p class="font-sans-3xs text-base-dark">
+      Photo credit: {heroImage.fotogCredit}
+    </p>
+  {/if}
+{/if}
 {#if subhead}
   <p class="usa-intro">
     {subhead}
   </p>
 {/if}
 {#if isPressRelease}
-  <strong>For immediate release: {dateString}</strong>
+  <p>
+    <strong>For immediate release: {dateString}</strong>
+  </p>
 {/if}
-<ContentfulRichText document={body?.json} />
+
+{#if body?.json}
+  <ContentfulRichText document={body.json} links={body?.links} imageSizeType="col-9" />
+{/if}
+
+<div />
+{#if contactInformationCollection?.items && contactInformationCollection.items.length > 0}
+  <ContactCard
+    address={undefined}
+    contacts={contactInformationCollection.items}
+    class="margin-top-6"
+  />
+{/if}
+
+{#if relatedLinks}
+  <h2>Related links</h2>
+  <ContentfulRichText
+    document={relatedLinks.json}
+    links={relatedLinks.links}
+    imageSizeType="col-9"
+  />
+{/if}
+
+{#if relatedEventsCollection?.items && relatedEventsCollection?.items.length > 0}
+  <h2>Related events</h2>
+  {#each relatedEventsCollection?.items as event (event?.sys.id)}
+    <Event {event} />
+  {/each}
+{/if}
+
+{#if relatedNewsCollection?.items && relatedNewsCollection?.items.length > 0}
+  <h2>Related news</h2>
+  {#each relatedNewsCollection?.items as entry (entry?.sys.id)}
+    {#if entry}
+      <NewsEntrySnippet {entry} />
+    {/if}
+  {/each}
+{/if}

--- a/src/routes/(infoPages)/about/news/article/[slug]/page.scss
+++ b/src/routes/(infoPages)/about/news/article/[slug]/page.scss
@@ -2,6 +2,7 @@
   $theme-show-notifications: false
 );
 
+// TODO: We need to fix fonts across the site, at which point this should go in app.scss
 .usa-prose > .ldaf-news-entry--heading {
   /* Override font family on `.usa-prose > h1` */
   @include u-font-family("sans");

--- a/src/routes/(infoPages)/about/news/article/[slug]/page.scss
+++ b/src/routes/(infoPages)/about/news/article/[slug]/page.scss
@@ -2,9 +2,9 @@
   $theme-show-notifications: false
 );
 
-// TODO: We need to fix fonts across the site, at which point this should go in app.scss
 .usa-prose > .ldaf-news-entry--heading {
   /* Override font family on `.usa-prose > h1` */
+  // TODO: We need to fix fonts across the site, at which point this should go in app.scss
   @include u-font-family("sans");
   /* Override margin-top on `.usa-prose > * + h1` */
   margin-top: 1rem;

--- a/src/routes/(infoPages)/about/news/article/[slug]/page.scss
+++ b/src/routes/(infoPages)/about/news/article/[slug]/page.scss
@@ -1,0 +1,10 @@
+@use "uswds-core" as * with (
+  $theme-show-notifications: false
+);
+
+.usa-prose > .ldaf-news-entry--heading {
+  /* Override font family on `.usa-prose > h1` */
+  @include u-font-family("sans");
+  /* Override margin-top on `.usa-prose > * + h1` */
+  margin-top: 1rem;
+}

--- a/src/routes/(infoPages)/about/news/page.scss
+++ b/src/routes/(infoPages)/about/news/page.scss
@@ -1,0 +1,8 @@
+@use "uswds-core" as * with (
+  $theme-show-notifications: false
+);
+
+/* Override font family on `.usa-prose > h1` */
+.usa-prose > .ldaf-news-page--heading {
+  @include u-font-family("sans");
+}

--- a/src/routes/(infoPages)/about/news/page.scss
+++ b/src/routes/(infoPages)/about/news/page.scss
@@ -3,6 +3,7 @@
 );
 
 /* Override font family on `.usa-prose > h1` */
+// TODO: We need to fix fonts across the site, at which point this should go in app.scss
 .usa-prose > .ldaf-news-page--heading {
   @include u-font-family("sans");
 }

--- a/src/routes/(infoPages)/about/news/page/[page]/+page.server.ts
+++ b/src/routes/(infoPages)/about/news/page/[page]/+page.server.ts
@@ -1,4 +1,5 @@
 import { loadNewsPage } from "../../shared.server";
 import type { PageServerLoad } from "./$types";
 
+// [page] is passed to `loadNewsPage` as `params.page`
 export const load = loadNewsPage satisfies PageServerLoad;

--- a/src/routes/(infoPages)/about/news/page/[page]/+page.server.ts
+++ b/src/routes/(infoPages)/about/news/page/[page]/+page.server.ts
@@ -1,0 +1,4 @@
+import { loadNewsPage } from "../../shared.server";
+import type { PageServerLoad } from "./$types";
+
+export const load = loadNewsPage satisfies PageServerLoad;

--- a/src/routes/(infoPages)/about/news/page/[page]/+page.svelte
+++ b/src/routes/(infoPages)/about/news/page/[page]/+page.svelte
@@ -1,0 +1,6 @@
+<script>
+  import Page from "../../+page.svelte";
+  export let data;
+</script>
+
+<Page {data} />

--- a/src/routes/(infoPages)/about/news/shared.server.ts
+++ b/src/routes/(infoPages)/about/news/shared.server.ts
@@ -1,0 +1,92 @@
+import { CONTENTFUL_SPACE_ID, CONTENTFUL_DELIVERY_API_TOKEN } from "$env/static/private";
+import getContentfulClient from "$lib/services/contentful";
+import gql from "graphql-tag";
+import { print as printQuery } from "graphql";
+import type { NewsArticlesQuery } from "./$queries.generated";
+import { error } from "@sveltejs/kit";
+import type { PageServerLoad } from "./page/[page]/$types";
+import type { Breadcrumbs } from "$lib/components/Breadcrumbs";
+import {
+  newsArticles as testNewsArticles,
+  pages as testNewsArticlePages,
+} from "./__tests__/newsTestContent";
+
+const limit = 20;
+
+// TODO: filter to only future events. this will require thinking about timezones
+export const query = gql`
+  query NewsArticles($limit: Int = 20, $skip: Int = 0) {
+    newsArticleCollection(limit: $limit, skip: $skip) {
+      total
+      items {
+        sys {
+          id
+        }
+        newsArticleTitle
+        newsArticleSubhead
+      }
+    }
+  }
+`;
+
+export const loadBaseBreadcrumbs = async ({
+  parent,
+}: Pick<Parameters<PageServerLoad>[0], "parent">): Promise<Breadcrumbs> => {
+  const { pageMetadataMap, pathsToIDs } = await parent();
+  const aboutPageMetadataID = pathsToIDs.get("/about");
+  if (!aboutPageMetadataID) return [];
+  const { breadcrumbs } = pageMetadataMap.get(aboutPageMetadataID) ?? {};
+  return [...(breadcrumbs ?? []), { title: "News", link: "/about/news" }];
+};
+
+export const loadNewsPage = async ({
+  parent,
+  params: { page },
+}: Pick<Parameters<PageServerLoad>[0], "params" | "parent">) => {
+  fetchData: {
+    const pageNumber = parseInt(page);
+    if (isNaN(pageNumber)) break fetchData;
+    const breadcrumbsPromise = loadBaseBreadcrumbs({ parent }).then((baseBreadcrumbs) => [
+      ...baseBreadcrumbs,
+      ...(pageNumber > 1
+        ? [{ title: `Page ${pageNumber}`, link: `/about/news/page/${pageNumber}` }]
+        : []),
+    ]);
+    if (!CONTENTFUL_SPACE_ID || !CONTENTFUL_DELIVERY_API_TOKEN) {
+      return {
+        currentPageNumber: pageNumber,
+        totalPages: Math.ceil(testNewsArticles.length / limit),
+        newsArticles: testNewsArticlePages[pageNumber - 1].items,
+        totalNewsArticles: testNewsArticles.length,
+        breadcrumbs: breadcrumbsPromise,
+      };
+    }
+    const client = getContentfulClient({
+      spaceID: CONTENTFUL_SPACE_ID,
+      token: CONTENTFUL_DELIVERY_API_TOKEN,
+    });
+    const newsData = await client.fetch<NewsArticlesQuery>(printQuery(query), {
+      variables: {
+        limit,
+        skip: limit * Math.max(pageNumber - 1, 0),
+      },
+    });
+    if (
+      !newsData?.newsArticleCollection?.items ||
+      newsData?.newsArticleCollection?.items?.length === 0
+    ) {
+      break fetchData;
+    }
+    return {
+      pageMetadata: {
+        metaTitle: pageNumber <= 1 ? "News" : `News - page ${pageNumber}`,
+        breadcrumbs: await breadcrumbsPromise,
+      },
+      currentPageNumber: pageNumber,
+      totalPages: Math.ceil(newsData.newsArticleCollection.total / limit),
+      newsArticles: newsData.newsArticleCollection.items,
+      totalNewsArticles: newsData.newsArticleCollection.total,
+    };
+  }
+  throw error(404);
+};

--- a/src/routes/(infoPages)/about/news/shared.server.ts
+++ b/src/routes/(infoPages)/about/news/shared.server.ts
@@ -10,11 +10,16 @@ import {
   newsEntries as testNewsEntries,
   pages as testNewsEntryPages,
 } from "./__tests__/newsTestContent";
+import imagePropsFragment from "$lib/fragments/imageProps";
+import entryPropsFragment from "$lib/fragments/entryProps";
 
-const limit = 20;
+const limit = 10;
 
 export const query = gql`
-  query NewsEntries($limit: Int = 20, $skip: Int = 0) {
+  # eslint-disable @graphql-eslint/selection-set-depth
+  ${imagePropsFragment}
+  ${entryPropsFragment}
+  query NewsEntries($limit: Int = 10, $skip: Int = 0) {
     newsCollection(limit: $limit, skip: $skip, order: [publicationDate_DESC]) {
       total
       items {
@@ -26,6 +31,24 @@ export const query = gql`
         publicationDate
         body {
           json
+          links {
+            assets {
+              block {
+                ...ImageProps
+              }
+              hyperlink {
+                ...ImageProps
+              }
+            }
+            entries {
+              block {
+                ...EntryProps
+              }
+              hyperlink {
+                ...EntryProps
+              }
+            }
+          }
         }
         slug
         byline

--- a/src/routes/(infoPages)/about/news/shared.server.ts
+++ b/src/routes/(infoPages)/about/news/shared.server.ts
@@ -10,12 +10,14 @@ import {
   newsEntries as testNewsEntries,
   pages as testNewsEntryPages,
 } from "./__tests__/newsTestContent";
+import imagePropsFragment from "$lib/fragments/imageProps";
 import entryPropsFragment from "$lib/fragments/entryProps";
 
 const limit = 10;
 
 export const query = gql`
   # eslint-disable @graphql-eslint/selection-set-depth
+  ${imagePropsFragment}
   ${entryPropsFragment}
   query NewsEntries($limit: Int = 10, $skip: Int = 0) {
     newsCollection(limit: $limit, skip: $skip, order: [publicationDate_DESC]) {
@@ -31,7 +33,13 @@ export const query = gql`
           json
           links {
             # Only including hyperlinks since we should only be displaying the
-            #   first paragraph node in the rich text field.
+            #   first paragraph node in the rich text field, i.e. no other
+            #   blocks will be embedded.
+            assets {
+              hyperlink {
+                ...ImageProps
+              }
+            }
             entries {
               hyperlink {
                 ...EntryProps

--- a/src/routes/(infoPages)/about/news/shared.server.ts
+++ b/src/routes/(infoPages)/about/news/shared.server.ts
@@ -10,14 +10,12 @@ import {
   newsEntries as testNewsEntries,
   pages as testNewsEntryPages,
 } from "./__tests__/newsTestContent";
-import imagePropsFragment from "$lib/fragments/imageProps";
 import entryPropsFragment from "$lib/fragments/entryProps";
 
 const limit = 10;
 
 export const query = gql`
   # eslint-disable @graphql-eslint/selection-set-depth
-  ${imagePropsFragment}
   ${entryPropsFragment}
   query NewsEntries($limit: Int = 10, $skip: Int = 0) {
     newsCollection(limit: $limit, skip: $skip, order: [publicationDate_DESC]) {
@@ -32,18 +30,9 @@ export const query = gql`
         body {
           json
           links {
-            assets {
-              block {
-                ...ImageProps
-              }
-              hyperlink {
-                ...ImageProps
-              }
-            }
+            # Only including hyperlinks since we should only be displaying the
+            #   first paragraph node in the rich text field.
             entries {
-              block {
-                ...EntryProps
-              }
               hyperlink {
                 ...EntryProps
               }
@@ -85,7 +74,6 @@ export const loadNewsPage = async ({
         currentPageNumber: pageNumber,
         totalPages: Math.ceil(testNewsEntries.length / limit),
         newsEntries: testNewsEntryPages[pageNumber - 1].items,
-        totalNewsEntries: testNewsEntries.length,
         breadcrumbs: breadcrumbsPromise,
       };
     }
@@ -110,7 +98,6 @@ export const loadNewsPage = async ({
       currentPageNumber: pageNumber,
       totalPages: Math.ceil(newsData.newsCollection.total / limit),
       newsEntries: newsData.newsCollection.items,
-      totalNewsEntries: newsData.newsCollection.total,
     };
   }
   throw error(404);

--- a/src/routes/(infoPages)/layout.scss
+++ b/src/routes/(infoPages)/layout.scss
@@ -1,3 +1,14 @@
 .top-tier-page-hero-image {
   height: 33vh;
 }
+
+// TODO: If we create an EventList component, this should go there instead.
+// Not included on the homepage since (if we were to use it there) we would
+//   likely want to style it to be more compact.
+.ldaf-events-list-container {
+  margin-top: 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  margin-bottom: 18px;
+}

--- a/src/stories/Tag.stories.ts
+++ b/src/stories/Tag.stories.ts
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from "@storybook/svelte";
+
+import Tag from "$lib/components/Tag";
+
+const meta = {
+  title: "Components/Tag",
+  component: Tag,
+  tags: ["autodocs"],
+  parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/file/oGKbyCnCRRdNzLYbiags93/LDAF-Component-Library-USWDS-3.0.2?type=design&node-id=2196-28748&mode=design&t=VJZqauXMe61U0NvQ-4",
+    },
+  },
+} satisfies Meta<Tag>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Big: Story = {
+  args: { big: true },
+};


### PR DESCRIPTION
Jira ticket: [LDAF-362](https://ldaf.atlassian.net/browse/LDAF-362)

## Proposed changes

- Adds pages for news, heavily copied from work done in #364 (we have a follow-up ticket to cut down on the repetition).
- Adds a `NewEntrySnippet` component for showing only some data for a news entry, for use on the aggregation pages or as a related news entry. 
- Adds another `date` utility for converting a Contentful UTC date without a timestamp to a date string, e.g. `2023-08-31T00:00:00.000Z` converts to `August 31, 2023` when using `getUTC*` methods (if we don't use the `getUTC*` methods we would get `August 30, 2023` because of the timezone difference).
- Adds a simple `Tag` component with a test and story.
- Fixes default paragraph width within container elements with the `usa-prose` class.

There are two different `type`s of News entries:
* `Press release` - for these we never show a byline, we default to the Press Secretary `ContactInfo` entry if one is not provided, and we put the publication date right before the main content on a `For immediate release:` line.
* `News article` - show the byline, contact info is optional, and we put the publication date at the top

## TODO
- [x] Move all of the press releases and news articles using the old CTs into the new one. Remove test entries.
  * Megan and Jill will handle moving any entries before June to the new CT.
- [ ] After merging, create a `PageMetadata` entry in Contentful for `News` so that it shows up in the main menu and side nav. Add a link to News to the Footer Menu as well.

## Requested feedback

See self-review. Only other note is that I think I'd like to save any major clean-up work that could also impact Events for the follow-up ticket.


[LDAF-362]: https://ldaf.atlassian.net/browse/LDAF-362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ