### PR TITLE
Fix stale accordion-expanded state when navigating between pages

### DIFF
--- a/src/lib/components/Accordion/Accordion.svelte
+++ b/src/lib/components/Accordion/Accordion.svelte
@@ -1,16 +1,16 @@
 <script lang="ts">
-  import { setContext } from "svelte";
   import { writable } from "svelte/store";
+  import { setAccordionContext } from "./context";
 
   export let multiselectable = false;
   export let bordered = false;
 
-  const selectedItems = writable<Record<string, boolean>>({});
+  const expandedItems = writable<Record<string, boolean>>({});
 
-  setContext("Accordion", {
-    subscribe: selectedItems.subscribe,
+  setAccordionContext({
+    expandedItems,
     toggle: (itemID: string) =>
-      selectedItems.update((items) => ({
+      expandedItems.update((items) => ({
         ...(multiselectable ? items : {}),
         [itemID]: !items[itemID],
       })),

--- a/src/lib/components/Accordion/AccordionItem.svelte
+++ b/src/lib/components/Accordion/AccordionItem.svelte
@@ -1,21 +1,15 @@
 <script lang="ts">
-  import { getContext } from "svelte";
+  import { getAccordionContext } from "./context";
 
   export let id: string;
   export let title: string | null | undefined = "Title";
-  export let expanded = false;
+
   let ref: HTMLElement | null = null;
 
-  interface ItemApi {
-    subscribe: (run: (items: Record<string, boolean>) => void) => () => void;
-    toggle: (id: string) => void;
-  }
+  $: ({ expandedItems, toggle } = getAccordionContext());
 
-  const { subscribe, toggle } = getContext<ItemApi>("Accordion");
-
-  subscribe((items) => {
-    expanded = items[id] || false;
-  });
+  let expanded: boolean;
+  $: expanded = $expandedItems[id] ?? false;
 </script>
 
 <h3 {...$$restProps} class="usa-accordion__heading">

--- a/src/lib/components/Accordion/context.ts
+++ b/src/lib/components/Accordion/context.ts
@@ -1,0 +1,13 @@
+import type { Writable } from "svelte/store";
+import { getContext, setContext } from "svelte";
+
+const key = Symbol("AccordionContext");
+
+type AccordionContext = {
+  expandedItems: Writable<Record<string, boolean>>;
+  toggle: (id: string) => void;
+};
+
+export const setAccordionContext = (context: AccordionContext) =>
+  setContext<AccordionContext>(key, context);
+export const getAccordionContext = () => getContext<AccordionContext>(key);

--- a/src/routes/(infoPages)/[topTierPage]/[...serviceGroupPage]/+page.svelte
+++ b/src/routes/(infoPages)/[topTierPage]/[...serviceGroupPage]/+page.svelte
@@ -68,7 +68,7 @@
 
 {#if childServiceEntries.length > 0}
   <Accordion multiselectable bordered>
-    {#each childServiceEntries as item}
+    {#each childServiceEntries as item (item.sys.id)}
       <AccordionItem title={item?.entryTitle} id={item.sys.id}>
         <ContentfulRichText
           document={item?.description?.json}


### PR DESCRIPTION
Jira ticket: [LDAF-371](https://ldaf.atlassian.net/browse/LDAF-371)

## Proposed changes

- Adds an `each` key that is the accordion item ID when rendering child accordion components. This fixes a bug where the state and event handlers were being inappropriately preserved after page navigation, leading to an accordion item that is open by default (instead of closed) and takes two clicks to close (because the event handler is stale).

- Slightly refactors `Accordion`.

Right now it's still not perfect because the expandedItems record is still sticking around after navigation, it's just not causing problems because we never use accordion items with the same ID on separate pages.

## Acceptance criteria validation

- [x] Tests and checks pass
- [x] Manually verified that bug is no longer present

[LDAF-371]: https://ldaf.atlassian.net/browse/LDAF-371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ