### PR TITLE
Slight refactor to Office Page query. Add support for links and images in Office Page rich text.

### DIFF
--- a/src/routes/(infoPages)/about/organization/[officePage]/+page.svelte
+++ b/src/routes/(infoPages)/about/organization/[officePage]/+page.svelte
@@ -17,12 +17,20 @@
 <p class="usa-intro">
   {subheading}
 </p>
-{#if description}
-  <ContentfulRichText document={description?.json} />
+{#if description?.json}
+  <ContentfulRichText
+    document={description.json}
+    links={description?.links}
+    imageSizeType="col-9"
+  />
 {/if}
-{#if servicesAndPrograms}
+{#if servicesAndPrograms?.json}
   <h2>Services</h2>
-  <ContentfulRichText document={servicesAndPrograms?.json} />
+  <ContentfulRichText
+    document={servicesAndPrograms.json}
+    links={servicesAndPrograms?.links}
+    imageSizeType="col-9"
+  />
 {/if}
 <div />
 {#if mailingAddress || contactsCollection}


### PR DESCRIPTION
This issue came up from @uxrebecca's [post in Slack](https://adhoc.slack.com/archives/C03QPK0E2UU/p1693338707360349); when we made the updates to support links and images in rich text fields we missed the Office Pages. This PR refactors the query for the data to be more inline with our other queries (mostly stolen from the Core Content page query) and adds the support for links and images.