### PR TITLE
[LDAF-402] Render latest news and upcoming events on the Home Page

### DIFF
--- a/src/lib/components/Date/Date.scss
+++ b/src/lib/components/Date/Date.scss
@@ -2,11 +2,17 @@
   display: flex;
   flex-direction: column;
   text-align: center;
-  width: 78px;
-  height: calc(39px * 2 + 2px);
   font-size: 18px;
   border: 1px solid $primary-light;
   flex-shrink: 0;
+  &--big {
+    width: 78px;
+    height: 78px;
+  }
+  &--small {
+    width: 64px;
+    height: 64px;
+  }
 }
 
 .event-date-month,
@@ -23,6 +29,7 @@
 .event-date-month {
   background-color: $primary-light;
   color: $white;
+  text-transform: uppercase;
 }
 
 .event-date-day {

--- a/src/lib/components/Date/Date.svelte
+++ b/src/lib/components/Date/Date.svelte
@@ -4,6 +4,7 @@
   import { shortMonths } from "$lib/constants/date";
 
   export let dateString: string;
+  export let variation: "big" | "small" = "big";
 
   $: date = new Date(dateString);
   $: month = date.getMonth();
@@ -11,7 +12,7 @@
   $: day = date.getDate();
 </script>
 
-<div class="event-date">
+<div class="event-date event-date--{variation}">
   <div class="event-date-month">{monthName}</div>
   <div class="event-date-day">{day}</div>
 </div>

--- a/src/routes/(infoPages)/about/events/Event.svelte
+++ b/src/routes/(infoPages)/about/events/Event.svelte
@@ -9,13 +9,14 @@
 
   export let event: PageServerData["events"][number];
   export let headingLevel: HeadingLevel = 2;
+  export let variation: "big" | "small" = "big";
 
   $: date = event?.eventDateAndTime ? new Date(event?.eventDateAndTime) : undefined;
 </script>
 
 <div class="event">
   {#if event?.eventDateAndTime}
-    <DateComponent dateString={event.eventDateAndTime} />
+    <DateComponent dateString={event.eventDateAndTime} {variation} />
   {/if}
   <div class="event-details">
     {#if event?.shortTitle}
@@ -43,7 +44,7 @@
     flex-direction: row;
     gap: 14px;
     padding-bottom: 18px;
-    border-bottom: 1px solid #757473;
+    border-bottom: 1px solid #757473; /* replace with $grayscale-90 */
   }
 
   .event-title {

--- a/src/routes/(infoPages)/about/events/Event.svelte
+++ b/src/routes/(infoPages)/about/events/Event.svelte
@@ -21,6 +21,7 @@
   <div class="event-details">
     {#if event?.shortTitle}
       <Link
+        class="display-block"
         href={date && event?.slug
           ? `/about/events/event/${date.toISOString().split("T")[0]}-${event.slug}`
           : undefined}

--- a/src/routes/(infoPages)/about/news/NewsEntrySnippet.svelte
+++ b/src/routes/(infoPages)/about/news/NewsEntrySnippet.svelte
@@ -9,8 +9,11 @@
 
   import type { PageServerData } from "./$types";
 
+  type NewsSnippetVariation = "default" | "homepage-featured" | "homepage-listed";
+
   export let entry: NonNullable<PageServerData["newsEntries"][number]>;
   export let headingLevel: HeadingLevel = 2;
+  export let variation: NewsSnippetVariation = "default";
 
   $: ({ slug, title, subhead, byline, type, publicationDate } = entry);
 
@@ -20,14 +23,17 @@
 </script>
 
 {#if title && slug}
-  <div class="ldaf-news-entry">
+  <div class={`ldaf-news-entry ldaf-news-entry--${variation}`}>
     <Link href={`/about/news/article/${slug}`}>
       <svelte:element this={headingTagByLevel[headingLevel]} class="news-title">
         {title}
       </svelte:element>
     </Link>
-    {#if subhead}
-      <p>{subhead}</p>
+    {#if variation === "homepage-listed"}
+      <div class="margin-bottom-1"><Tag>{type}</Tag></div>
+    {/if}
+    {#if subhead && variation !== "homepage-listed"}
+      <p class="margin-y-1">{subhead}</p>
     {/if}
     <div class="font-body-2xs">
       {#if isArticle && byline}
@@ -35,11 +41,13 @@
       {/if}
       {dateString}
     </div>
-    <div class="margin-top-1 margin-bottom-2">
-      <Tag>{type}</Tag>
-    </div>
+    {#if variation !== "homepage-listed"}
+      <div class="margin-y-1">
+        <Tag>{type}</Tag>
+      </div>
+    {/if}
   </div>
-  <hr />
+  <hr class="margin-bottom-2" />
 {/if}
 
 <style>

--- a/src/routes/(infoPages)/about/news/NewsEntrySnippet.svelte
+++ b/src/routes/(infoPages)/about/news/NewsEntrySnippet.svelte
@@ -24,7 +24,7 @@
 
 {#if title && slug}
   <div class={`ldaf-news-entry ldaf-news-entry--${variation}`}>
-    <Link href={`/about/news/article/${slug}`}>
+    <Link class="display-block" href={`/about/news/article/${slug}`}>
       <svelte:element this={headingTagByLevel[headingLevel]} class="news-title">
         {title}
       </svelte:element>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,6 +2,8 @@
   import "./(infoPages)/[topTierPage]/page.scss";
   import "./page.scss";
 
+  import chunk from "lodash/chunk";
+
   import { url as arrowIcon } from "$icons/arrow_forward";
 
   import { getSources } from "$lib/imageServices/contentful";
@@ -46,11 +48,12 @@
   };
 </script>
 
-<main id="main-content" class="grid-container usa-prose margin-top-2">
+<main id="main-content" class="grid-container usa-prose margin-top-3">
   {#if heroVideo && heroVideo.videoUrl}
     {@const { videoUrl, videoTitle, videoSubhead, youtubeVideoData } = heroVideo}
     {@const { title, description, thumbnails, blurhash } = youtubeVideoData ?? {}}
     <VideoCard
+      class="margin-bottom-4"
       url={videoUrl}
       title={videoTitle ?? title}
       description={videoSubhead ?? description}
@@ -110,16 +113,16 @@
     </ul>
   {/if}
   {#if popularResources && popularResources.length > 0}
-    <div class="ldaf-homepage__popular-resources">
+    <div class="margin-top-6 margin-bottom-10">
       <h2>Popular resources</h2>
       <ResourceLinks links={popularResources} />
     </div>
   {/if}
   {#if news && news.length > 0}
     {@const [featuredEntry, ...listedEntries] = news}
-    <div class="ldaf-homepage__news">
+    <div class="margin-bottom-4">
       <h2 class="margin-bottom-0">Recent news</h2>
-      <hr class="margin-top-0 margin-bottom-2" />
+      <hr class="margin-top-0 margin-bottom-3" />
       <div class="grid-row grid-gap-lg">
         <div class="tablet:grid-col-6">
           {#if featuredEntry}
@@ -143,15 +146,25 @@
     </div>
   {/if}
   {#if events && events.length > 0}
-    <div class="ldaf-homepage__events">
+    {@const eventColumns = chunk(events, 2)}
+    <div class="margin-bottom-3">
       <h2 class="margin-bottom-0">Upcoming events</h2>
-      {#each events as event (event?.sys?.id)}
-        <Event {event} headingLevel={3} />
-      {/each}
+      <hr class="margin-top-0 margin-bottom-3" />
+      <div class="grid-row grid-gap-lg">
+        {#each eventColumns as column, i (i)}
+          <div class="tablet:grid-col-6">
+            {#each column as event (event?.sys.id)}
+              <div class="margin-bottom-7">
+                <Event {event} headingLevel={3} variation="small" />
+              </div>
+            {/each}
+          </div>
+        {/each}
+      </div>
     </div>
   {/if}
   {#if commissionerGreeting?.json && commissionerByline && commissionerHeadshot?.linkedImage?.url}
-    <section class="greeting-wrapper" aria-label="Introduction">
+    <section class="greeting-wrapper margin-bottom-6" aria-label="Introduction">
       <!-- This section can render without the background image, so this is optional. -->
       {#if commissionerBackground?.linkedImage?.url}
         {@const {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -13,6 +13,8 @@
   import ContentfulRichText from "$lib/components/ContentfulRichText";
   import VideoCard from "$lib/components/VideoCard";
   import ResourceLinks from "$lib/components/ResourceLinks";
+  import NewsEntrySnippet from "./(infoPages)/about/news/NewsEntrySnippet.svelte";
+  import Event from "./(infoPages)/about/events/Event.svelte";
 
   export let data;
   $: ({
@@ -24,6 +26,8 @@
       commissionerByline,
       commissionerHeadshot,
       commissionerBackground,
+      news,
+      events,
     },
   } = data);
 
@@ -107,8 +111,43 @@
   {/if}
   {#if popularResources && popularResources.length > 0}
     <div class="ldaf-homepage__popular-resources">
-      <h2 class="ldaf-homepage__popular-resources-heading">Popular resources</h2>
+      <h2>Popular resources</h2>
       <ResourceLinks links={popularResources} />
+    </div>
+  {/if}
+  {#if news && news.length > 0}
+    {@const [featuredEntry, ...listedEntries] = news}
+    <div class="ldaf-homepage__news">
+      <h2 class="margin-bottom-0">Recent news</h2>
+      <hr class="margin-top-0 margin-bottom-2" />
+      <div class="grid-row grid-gap-lg">
+        <div class="tablet:grid-col-6">
+          {#if featuredEntry}
+            <NewsEntrySnippet
+              entry={featuredEntry}
+              headingLevel={3}
+              variation="homepage-featured"
+            />
+          {/if}
+        </div>
+        <div class="tablet:grid-col-6">
+          {#if listedEntries.length > 0}
+            {#each listedEntries as entry (entry?.sys.id)}
+              {#if entry}
+                <NewsEntrySnippet {entry} headingLevel={3} variation="homepage-listed" />
+              {/if}
+            {/each}
+          {/if}
+        </div>
+      </div>
+    </div>
+  {/if}
+  {#if events && events.length > 0}
+    <div class="ldaf-homepage__events">
+      <h2 class="margin-bottom-0">Upcoming events</h2>
+      {#each events as event (event?.sys?.id)}
+        <Event {event} headingLevel={3} />
+      {/each}
     </div>
   {/if}
   {#if commissionerGreeting?.json && commissionerByline && commissionerHeadshot?.linkedImage?.url}

--- a/src/routes/__tests__/homePageTestContent.ts
+++ b/src/routes/__tests__/homePageTestContent.ts
@@ -90,6 +90,8 @@ export default {
         blurhash: null,
       },
     },
+    news: [],
+    events: [],
   },
   pageMetadata: {
     sys: { id: "0" },

--- a/src/routes/page.scss
+++ b/src/routes/page.scss
@@ -3,10 +3,6 @@
   $theme-font-type-sans: "public-sans"
 );
 
-.ldaf-homepage__popular-resources {
-  margin-bottom: 1.5rem;
-}
-
 // https://stackoverflow.com/a/24895631/5469511
 .greeting-wrapper {
   position: relative;

--- a/src/routes/page.scss
+++ b/src/routes/page.scss
@@ -3,11 +3,6 @@
   $theme-font-type-sans: "public-sans"
 );
 
-.usa-prose > .ldaf-homepage__popular-resources-heading {
-  margin-bottom: 1rem;
-  @include u-font("sans", $theme-h2-font-size);
-}
-
 .ldaf-homepage__popular-resources {
   margin-bottom: 1.5rem;
 }


### PR DESCRIPTION
Jira ticket: [LDAF-402](https://ldaf.atlassian.net/browse/LDAF-402)

This is pretty similar to #462; we want to display news and events on the homepage but in a slightly more compact style.

## Proposed changes
- As part of the homepage query, also request the 4 most recent news entries and the next 4 upcoming events, and render them on the homepage between "Popular resources" and "From the commissioner" sections.
- Adjust lots of spacing on the homepage to more closely match mocks.
- Allow variations on News and Events components to render them slightly differently on the homepage.
- Make some minor adjustments to the styling of the Event component (color, size, month capitalization)

## Requested feedback

See self-review.

[LDAF-402]: https://ldaf.atlassian.net/browse/LDAF-402?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ