### PR TITLE
[LDAF-427] Update link and button colors across site by using USWDS theming settings

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -5,7 +5,7 @@
     <link rel="icon" href="%sveltekit.assets%/favicon.ico" />
     <meta name="viewport" content="width=device-width" />
     <meta name="google-site-verification" content="z_ztslPeuodgQEEjtgJQhmBJ4TEW37PK504oo1VFt-w" />
-    <!-- the following color is $primary-darkest from USWDS -->
+    <!-- The following color is LDAF's $primary-darker -->
     <meta name="theme-color" content="#00284d" />
     %sveltekit.head%
   </head>

--- a/src/app.scss
+++ b/src/app.scss
@@ -2,12 +2,103 @@
 @use "uswds" as * with (
   $theme-font-path: $theme-font-path,
   $theme-image-path: $theme-image-path,
+
+  //// Colors - Customizable Theme Colors ////
+  // Some of these color settings are no-ops since our LDAF theme palette has
+  //   some overlap with the default USWDS theme palette.
+  // Our LDAF color variables can be found in src/variables.scss
+  // USWDS default colors can be found in the documentation:
+  //   https://designsystem.digital.gov/design-tokens/color/theme-tokens/
+  // ... with some additional undocumented options in the repo:
+  //   https://github.com/uswds/uswds/blob/v3.4.1/packages/uswds-core/src/styles/settings/_settings-color.scss
+  $theme-color-base-lightest: $base-lightest,
+  $theme-color-base-lighter: $base-lighter,
+  $theme-color-base-light: $base-light,
+  $theme-color-base: $base,
+  $theme-color-base-dark: $base-dark,
+  $theme-color-base-darker: $base-darker,
+  $theme-color-base-darkest: $base-ink,
+  $theme-color-base-ink: $base-ink,
+  $theme-color-primary-lightest: $primary-lightest,
+  $theme-color-primary-lighter: $primary-lighter,
+  $theme-color-primary-light: $primary-light,
+  $theme-color-primary: $primary,
+  $theme-color-primary-vivid: $primary-vivid,
+  $theme-color-primary-dark: $primary-dark,
+  $theme-color-primary-darker: $primary-darkest,
+  $theme-color-secondary-lighter: $accent-lighter,
+  $theme-color-secondary-light: $accent-light,
+  $theme-color-secondary: $accent-warm,
+  $theme-color-secondary-dark: $accent-dark,
+  $theme-color-secondary-darker: $accent-darker,
+  // Skip accent colors since we're not using them. Available options are:
+  // $theme-color-accent-cool-lighter
+  // $theme-color-accent-cool-light
+  // $theme-color-accent-cool
+  // $theme-color-accent-cool-dark
+  // $theme-color-accent-cool-darker
+  // $theme-color-accent-warm-lighter
+  // $theme-color-accent-warm-light
+  // $theme-color-accent-warm
+  // $theme-color-accent-warm-dark
+  // $theme-color-accent-warm-darker
+  $theme-color-info-lighter: $info-lighter,
+  $theme-color-info-light: $info-light,
+  $theme-color-info: $info,
+  $theme-color-info-dark: $info-dark,
+  $theme-color-info-darker: $info-darker,
+  $theme-color-error-lighter: $error-lighter,
+  $theme-color-error-light: $error-light,
+  $theme-color-error: $error,
+  $theme-color-error-dark: $error-dark,
+  $theme-color-error-darker: $error-darker,
+  $theme-color-warning-lighter: $warning-lighter,
+  $theme-color-warning-light: $warning-light,
+  $theme-color-warning: $warning,
+  $theme-color-warning-dark: $warning-dark,
+  $theme-color-warning-darker: $warning-darker,
+  $theme-color-success-lighter: $success-lighter,
+  $theme-color-success-light: $success-light,
+  $theme-color-success: $success,
+  $theme-color-success-dark: $success-dark,
+  $theme-color-success-darker: $success-darker,
+  // TODO: Uncomment once we upgrade the USWDS to >= 3.6.0
+  // $theme-color-disabled-lighter: $disabled-lighter,
+  $theme-color-disabled-light: $disabled-light,
+  $theme-color-disabled: $disabled,
+  $theme-color-disabled-dark: $disabled-dark,
+  // TODO: Uncomment once we upgrade the USWDS to >= 3.6.0
+  // $theme-color-disabled-darker: $disabled-darker,
+  //
+  //// Colors - Uncustomizable Component Colors ////
+  // The following color declarations must use strings that refer to above
+  //   declared colors. There are some declarations that are commented-out
+  //   since they need to be set to a custom color that is not captured by the
+  //   above tokens and thus cannot use a token.
+  // Links
+  $theme-link-color: "primary-light",
+  // $theme-link-visited-color
+  $theme-link-hover-color: "primary",
+  $theme-link-active-color: "primary-dark",
+  $theme-link-reverse-color: "primary-lightest",
+  // $theme-link-reverse-visited-color
+  $theme-link-reverse-hover-color: "primary-lighter",
+  $theme-link-reverse-active-color: "primary-light",
+  // Focus Styling
+  $theme-focus-color: "primary-vivid",
+
+  //// Fonts ////
   $theme-font-type-sans: "public-sans",
   $theme-font-role-ui: "sans",
   $theme-font-role-heading: "sans",
   $theme-font-role-body: "sans",
   $theme-font-role-alt: "sans",
-  $theme-show-notifications: false
+
+  //// Logs Settings ////
+  // Turn off notifications to avoid noise in the logs.
+  $theme-show-notifications: false,
+  // Turn off compilation warnings due to excessive contrast a11y warnings.
+  $theme-show-compile-warnings: false
 );
 
 html,

--- a/src/app.scss
+++ b/src/app.scss
@@ -62,26 +62,26 @@
   $theme-color-success: $success,
   $theme-color-success-dark: $success-dark,
   $theme-color-success-darker: $success-darker,
-  // TODO: Uncomment once we upgrade the USWDS to >= 3.6.0
+  // TODO: Add a disabled-lighter color once we upgrade the USWDS to >= 3.6.0
   // $theme-color-disabled-lighter: $disabled-lighter,
   $theme-color-disabled-light: $disabled-light,
   $theme-color-disabled: $disabled,
   $theme-color-disabled-dark: $disabled-dark,
-  // TODO: Uncomment once we upgrade the USWDS to >= 3.6.0
+  // TODO: Add a disabled-darker color once we upgrade the USWDS to >= 3.6.0
   // $theme-color-disabled-darker: $disabled-darker,
   //
   //// Colors - Uncustomizable Component Colors ////
   // The following color declarations must use strings that refer to above
-  //   declared colors. There are some declarations that are commented-out
-  //   since they need to be set to a custom color that is not captured by the
-  //   above tokens and thus cannot use a token.
+  //   declared colors.
   // Links
   $theme-link-color: "primary-light",
+  // This declaration is commented-out since it needs to be set to a custom
+  //   color that is not captured by the above tokens (and thus we don't have
+  //   a token we can use for it).
   // $theme-link-visited-color
   $theme-link-hover-color: "primary",
   $theme-link-active-color: "primary-dark",
   $theme-link-reverse-color: "primary-lightest",
-  // $theme-link-reverse-visited-color
   $theme-link-reverse-hover-color: "primary-lighter",
   $theme-link-reverse-active-color: "primary-light",
   // Focus Styling

--- a/src/app.scss
+++ b/src/app.scss
@@ -25,7 +25,7 @@
   $theme-color-primary: $primary,
   $theme-color-primary-vivid: $primary-vivid,
   $theme-color-primary-dark: $primary-dark,
-  $theme-color-primary-darker: $primary-darkest,
+  $theme-color-primary-darker: $primary-darker,
   $theme-color-secondary-lighter: $accent-lighter,
   $theme-color-secondary-light: $accent-light,
   $theme-color-secondary: $accent-warm,

--- a/src/lib/components/Alert/Alert.scss
+++ b/src/lib/components/Alert/Alert.scss
@@ -3,8 +3,6 @@
   border: none;
 }
 .ldaf-alert--site-wide.usa-alert--error {
-  background-color: $error-dark;
-
   .usa-alert__body {
     color: $white;
     background-color: $error-dark;
@@ -15,13 +13,8 @@
         color: $white;
       }
     }
-
     &::before {
       filter: invert(1);
     }
   }
-}
-
-.ldaf-alert--site-wide.usa-alert--info .usa-alert__body .usa-link:visited {
-  color: $link-color;
 }

--- a/src/lib/components/Alert/Alert.scss
+++ b/src/lib/components/Alert/Alert.scss
@@ -22,9 +22,6 @@
   }
 }
 
-.ldaf-alert--site-wide.usa-alert--info .usa-alert__body .usa-link {
-  color: $primary-light;
-  &:visited {
-    color: $primary-light;
-  }
+.ldaf-alert--site-wide.usa-alert--info .usa-alert__body .usa-link:visited {
+  color: $link-color;
 }

--- a/src/lib/components/AnnouncementBanner/AnnouncementBanner.scss
+++ b/src/lib/components/AnnouncementBanner/AnnouncementBanner.scss
@@ -3,7 +3,7 @@
 );
 
 .usa-banner.ldaf-banner--announcement {
-  background: $primary-darkest;
+  background: $primary-darker;
 
   .usa-banner__header-text,
   .usa-banner__guidance {

--- a/src/lib/components/Button/Button.scss
+++ b/src/lib/components/Button/Button.scss
@@ -1,24 +1,9 @@
 @use "sass:map";
 
-// TODO: replace with global color variables from src/variables.scss
+// TODO: Bring the below colors inline with global colors in `src/variables.scss`
 $colors: (
-  "primary": #0051ad,
-  "primary-dark": #063c7a,
-  "primary-darker": #00284d,
-  "secondary": #ffc745,
-  "secondary-dark": #ffb200,
-  "secondary-darker": #d49400,
-  "disabled": #c9c9c9,
-  "disabled-dark": #adadad,
-  "base-lightest": #f2f1f0,
-  "base-light": #a9aeb1,
-  "base-dark": #565c65,
-  "base-darker": #3d4551,
-  "gray-05": #f0f0f0,
-  "primary-lightest": #d1e9ff,
   "text-only-hover": rgba(6, 60, 122, 16%),
   "text-only-active": rgba(6, 60, 122, 30%),
-  "outline-inverse": #dcdee0,
   "unstyled-fg": #005ea2,
   "unstyled-fg-hover": #1a4480,
   "unstyled-fg-active": #162e51,
@@ -34,15 +19,17 @@ $filters: (
     contrast(102%),
   "primary-dark": invert(14%) sepia(71%) saturate(2991%) hue-rotate(202deg) brightness(91%)
     contrast(95%),
+  "primary-darkest": invert(11%) sepia(90%) saturate(1645%) hue-rotate(191deg) brightness(89%)
+    contrast(101%),
   "disabled": invert(88%) sepia(0%) saturate(135%) hue-rotate(146deg) brightness(86%) contrast(110%),
   "disabled-dark": invert(73%) sepia(17%) saturate(0%) hue-rotate(174deg) brightness(91%)
     contrast(95%),
   "base-lightest": invert(93%) sepia(6%) saturate(32%) hue-rotate(349deg) brightness(104%)
     contrast(92%),
+  "base-light": invert(71%) sepia(7%) saturate(176%) hue-rotate(159deg) brightness(98%)
+    contrast(86%),
   "base-darker": invert(23%) sepia(14%) saturate(719%) hue-rotate(177deg) brightness(93%)
     contrast(84%),
-  "outline-inverse": invert(96%) sepia(9%) saturate(44%) hue-rotate(169deg) brightness(90%)
-    contrast(99%),
   "unstyled-fg": invert(17%) sepia(91%) saturate(2870%) hue-rotate(191deg) brightness(95%)
     contrast(101%),
   "unstyled-fg-hover": invert(20%) sepia(50%) saturate(2048%) hue-rotate(195deg) brightness(92%)
@@ -57,74 +44,56 @@ $filters: (
 
 .usa-button {
   width: auto;
-  color: #fff;
-  background: map.get($colors, "primary");
   .usa-icon {
     filter: map.get($filters, "white");
-  }
-  &:hover {
-    background: map.get($colors, "primary-dark");
-  }
-  &:active {
-    background: map.get($colors, "primary-darker");
   }
   &:disabled,
   &:disabled:hover,
   &:disabled:active {
-    background: map.get($colors, "disabled-dark");
+    // Default is $disabled, but we want a shade darker.
+    background: $disabled-dark;
   }
 }
 
 .usa-button.usa-button--secondary {
-  color: map.get($colors, "primary");
-  background: map.get($colors, "secondary");
+  color: $primary;
   .usa-icon {
     filter: map.get($filters, "primary");
   }
-  &:hover {
-    background: map.get($colors, "secondary-dark");
-  }
-  &:active {
-    background: map.get($colors, "secondary-darker");
-  }
-  &:disabled,
-  &:disabled:hover,
-  &:disabled:active {
-    background: map.get($colors, "disabled-dark");
+  &:disabled {
+    color: $white;
+    .usa-icon {
+      filter: map.get($filters, "white");
+    }
   }
 }
 
 .usa-button.usa-button--base {
-  background: map.get($colors, "base-dark");
-  &:hover {
-    background: map.get($colors, "base-dark");
-  }
+  background: $base-dark;
   &:active {
-    background: map.get($colors, "base-darker");
+    background: $base-darker;
   }
-  &:disabled,
-  &:disabled:hover,
-  &:disabled:active {
-    background: map.get($colors, "disabled-dark");
+  &:disabled {
+    background: $disabled-dark;
   }
 }
 
 .usa-button.usa-button--inverse {
-  color: map.get($colors, "primary");
-  background: #fff;
+  color: $primary;
+  background: $white;
   .usa-icon {
     filter: map.get($filters, "primary");
   }
   &:hover {
-    color: map.get($colors, "primary");
-    background: map.get($colors, "gray-05");
+    color: $primary;
+    background: $grayscale-05;
     .usa-icon {
       filter: map.get($filters, "primary");
     }
   }
   &:active {
-    color: map.get($colors, "primary");
-    background: map.get($colors, "primary-lightest");
+    color: $primary;
+    background: $primary-lightest;
     .usa-icon {
       filter: map.get($filters, "primary");
     }
@@ -132,8 +101,8 @@ $filters: (
   &:disabled,
   &:disabled:hover,
   &:disabled:active {
-    color: #fff;
-    background: map.get($colors, "disabled-dark");
+    color: $white;
+    background: $disabled-dark;
     .usa-icon {
       filter: map.get($filters, "white");
     }
@@ -141,20 +110,18 @@ $filters: (
 }
 
 .usa-button.usa-button--text-only {
-  color: map.get($colors, "primary");
+  color: $primary;
   background: none;
   .usa-icon {
     filter: map.get($filters, "primary");
   }
   &:hover {
-    color: map.get($colors, "primary");
     background: map.get($colors, "text-only-hover");
     .usa-icon {
       filter: map.get($filters, "primary");
     }
   }
   &:active {
-    color: map.get($colors, "primary");
     background: map.get($colors, "text-only-active");
     .usa-icon {
       filter: map.get($filters, "primary");
@@ -164,7 +131,7 @@ $filters: (
   &:disabled:hover,
   &:disabled:active {
     background: none;
-    color: map.get($colors, "disabled");
+    color: $disabled;
     .usa-icon {
       filter: map.get($filters, "disabled");
     }
@@ -172,21 +139,15 @@ $filters: (
 }
 
 .usa-button.usa-button--outline {
-  background: none;
-  color: map.get($colors, "primary");
   .usa-icon {
     filter: map.get($filters, "primary");
   }
   &:hover {
-    background: none;
-    color: map.get($colors, "primary-dark");
     .usa-icon {
       filter: map.get($filters, "primary-dark");
     }
   }
   &:active {
-    background: none;
-    color: map.get($colors, "base-darker");
     .usa-icon {
       filter: map.get($filters, "base-darker");
     }
@@ -194,7 +155,7 @@ $filters: (
   &:disabled,
   &:disabled:hover,
   &:disabled:active {
-    color: map.get($colors, "disabled");
+    color: $disabled;
     background: none;
     .usa-icon {
       filter: map.get($filters, "disabled");
@@ -203,21 +164,21 @@ $filters: (
 }
 
 .usa-button.usa-button--outline-inverse {
-  color: map.get($colors, "outline-inverse");
-  box-shadow: inset 0 0 0 2px map.get($colors, "base-light");
+  color: $base-light;
+  box-shadow: inset 0 0 0 2px $base-light;
   .usa-icon {
-    filter: map.get($filters, "outline-inverse");
+    filter: map.get($filters, "base-light");
   }
   &:hover {
-    color: map.get($colors, "base-lightest");
-    box-shadow: inset 0 0 0 2px map.get($colors, "base-lightest");
+    color: $base-lightest;
+    box-shadow: inset 0 0 0 2px $base-lightest;
     .usa-icon {
       filter: map.get($filters, "base-lightest");
     }
   }
   &:active {
-    color: #fff;
-    box-shadow: inset 0 0 0 2px #fff;
+    color: $white;
+    box-shadow: inset 0 0 0 2px $white;
     .usa-icon {
       filter: map.get($filters, "white");
     }
@@ -226,8 +187,8 @@ $filters: (
   &:disabled:hover,
   &:disabled:active {
     background: none;
-    color: map.get($colors, "disabled-dark");
-    box-shadow: inset 0 0 0 2px map.get($colors, "disabled-dark");
+    color: $disabled-dark;
+    box-shadow: inset 0 0 0 2px $disabled-dark;
     .usa-icon {
       filter: map.get($filters, "disabled-dark");
     }
@@ -235,38 +196,28 @@ $filters: (
 }
 
 .usa-button.usa-button--big {
-  background: map.get($colors, "primary");
-  color: #fff;
   .usa-icon {
     filter: map.get($filters, "white");
   }
-  &:hover {
-    background: map.get($colors, "primary-dark");
-  }
-  &:active {
-    background: map.get($colors, "primary-darker");
-  }
   &:disabled {
-    background: map.get($colors, "disabled");
+    background: $disabled;
   }
 }
 
 .usa-button.usa-button--big-inverse {
   background: #fff;
-  color: map.get($colors, "primary");
+  color: $primary;
   .usa-icon {
     filter: map.get($filters, "primary");
   }
   &:hover {
-    background: map.get($colors, "gray-05");
-    color: map.get($colors, "primary");
+    background: $grayscale-05;
     .usa-icon {
       filter: map.get($filters, "primary");
     }
   }
   &:active {
-    background: map.get($colors, "primary-lightest");
-    color: map.get($colors, "primary");
+    background: $primary-lightest;
     .usa-icon {
       filter: map.get($filters, "primary");
     }
@@ -274,8 +225,8 @@ $filters: (
   &:disabled,
   &:disabled:hover,
   &:disabled:active {
-    background: map.get($colors, "disabled-dark");
-    color: #fff;
+    background: $disabled-dark;
+    color: $white;
     .usa-icon {
       filter: map.get($filters, "white");
     }
@@ -311,7 +262,7 @@ $filters: (
   &:disabled:active {
     box-shadow: none;
     background: none;
-    color: map.get($colors, "disabled");
+    color: $disabled;
     .usa-icon {
       filter: map.get($filters, "disabled");
     }
@@ -343,7 +294,7 @@ $filters: (
     &:disabled:hover,
     &:disabled:active {
       background: none;
-      color: map.get($colors, "disabled-dark");
+      color: $disabled-dark;
       .usa-icon {
         filter: map.get($filters, "disabled-dark");
       }

--- a/src/lib/components/Button/Button.scss
+++ b/src/lib/components/Button/Button.scss
@@ -19,7 +19,7 @@ $filters: (
     contrast(102%),
   "primary-dark": invert(14%) sepia(71%) saturate(2991%) hue-rotate(202deg) brightness(91%)
     contrast(95%),
-  "primary-darkest": invert(11%) sepia(90%) saturate(1645%) hue-rotate(191deg) brightness(89%)
+  "primary-darker": invert(11%) sepia(90%) saturate(1645%) hue-rotate(191deg) brightness(89%)
     contrast(101%),
   "disabled": invert(88%) sepia(0%) saturate(135%) hue-rotate(146deg) brightness(86%) contrast(110%),
   "disabled-dark": invert(73%) sepia(17%) saturate(0%) hue-rotate(174deg) brightness(91%)
@@ -149,7 +149,7 @@ $filters: (
   }
   &:active {
     .usa-icon {
-      filter: map.get($filters, "base-darker");
+      filter: map.get($filters, "primary-darker");
     }
   }
   &:disabled,

--- a/src/lib/components/Button/Button.scss
+++ b/src/lib/components/Button/Button.scss
@@ -205,7 +205,7 @@ $filters: (
 }
 
 .usa-button.usa-button--big-inverse {
-  background: #fff;
+  background: $white;
   color: $primary;
   .usa-icon {
     filter: map.get($filters, "primary");

--- a/src/lib/components/ContentfulRichText/nodes/Hyperlink.svelte
+++ b/src/lib/components/ContentfulRichText/nodes/Hyperlink.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import Link from "$lib/components/Link";
   import type { Node as NodeType, Hyperlink } from "@contentful/rich-text-types";
   import Node from "./Node.svelte";
   import { isHyperlink } from "../predicates";
@@ -12,6 +13,6 @@
   hyperlink = node;
 </script>
 
-<a href={hyperlink.data.uri}
-  >{#each hyperlink.content as subNode}<Node node={subNode} />{/each}</a
+<Link href={hyperlink.data.uri}
+  >{#each hyperlink.content as subNode}<Node node={subNode} />{/each}</Link
 >

--- a/src/lib/components/Footer/Footer.scss
+++ b/src/lib/components/Footer/Footer.scss
@@ -11,6 +11,18 @@
     white-space: nowrap;
   }
 
+  .usa-footer__return-to-top a.usa-link:visited {
+    color: $link-color;
+  }
+
+  // adjust default focus outline for the darker footer background
+  .ldaf-footer__primary-section,
+  .ldaf-footer__secondary-section {
+    [href]:focus {
+      outline-color: $focus-reverse-outline-color;
+    }
+  }
+
   .ldaf-footer__primary-section {
     background-color: $primary-dark;
     .ldaf-footer__nav {
@@ -28,7 +40,6 @@
       @include u-font("sans", "sm");
     }
     .ldaf-footer__secondary-link a {
-      color: $white;
       line-height: 1.3;
     }
   }

--- a/src/lib/components/Footer/Footer.scss
+++ b/src/lib/components/Footer/Footer.scss
@@ -39,8 +39,18 @@
       color: $accent-warm;
       @include u-font("sans", "sm");
     }
-    .ldaf-footer__secondary-link a {
+    .ldaf-footer__secondary-link .usa-link {
       line-height: 1.3;
+      // ignore visited state
+      &:visited {
+        color: $link-reverse-color;
+      }
+      &:hover {
+        color: $link-reverse-hover-color;
+      }
+      &:active {
+        color: $link-reverse-active-color;
+      }
     }
   }
 

--- a/src/lib/components/Footer/Footer.scss
+++ b/src/lib/components/Footer/Footer.scss
@@ -55,7 +55,7 @@
   }
 
   .ldaf-footer__secondary-section {
-    background-color: $primary-darkest;
+    background-color: $primary-darker;
     color: $accent-warm;
 
     .usa-link {

--- a/src/lib/components/Footer/Footer.svelte
+++ b/src/lib/components/Footer/Footer.svelte
@@ -46,7 +46,7 @@
              focus if the URL doesn't already include #top.
              Shift focus back to top if user hits this more than once. -->
   <div class="grid-container usa-footer__return-to-top">
-    <a href="#top">Return to top</a>
+    <Link href="#top">Return to top</Link>
   </div>
   <div class="usa-footer__primary-section ldaf-footer__primary-section">
     <div class="grid-container">
@@ -76,7 +76,7 @@
                   {#if children}
                     {#each children as item (item.id)}
                       <li class="usa-footer__secondary-link ldaf-footer__secondary-link">
-                        <Link href={item.link}>{item.name}</Link>
+                        <Link alternate={true} href={item.link}>{item.name}</Link>
                       </li>
                     {/each}
                   {/if}

--- a/src/lib/components/Header/Header.scss
+++ b/src/lib/components/Header/Header.scss
@@ -6,7 +6,7 @@ $header-height-without-navbar: 148px;
 
 .ldaf-header {
   position: relative;
-  background: linear-gradient(to right, transparent, $primary-darkest 30%);
+  background: linear-gradient(to right, transparent, $primary-darker 30%);
 }
 
 .ldaf-header .ldaf-header-bg-img {
@@ -112,7 +112,7 @@ $header-height-without-navbar: 148px;
 
 @include at-media-max("desktop") {
   .usa-header--extended .ldaf-nav.usa-navbar {
-    background: $primary-darkest;
+    background: $primary-darker;
     border-bottom: none;
   }
 

--- a/src/lib/components/Header/Header.scss
+++ b/src/lib/components/Header/Header.scss
@@ -22,8 +22,16 @@ $header-height-without-navbar: 148px;
     border-radius: 5px 0 0 5px;
   }
 
+  // secondary nav links use primary styling on mobile and inverse styling on
+  //   desktop, and a class like `desktop:usa-link--alt` doesn't work
   a {
     color: $link-color;
+    &:hover {
+      color: $link-hover-color;
+    }
+    &:active {
+      color: $link-active-color;
+    }
   }
 }
 
@@ -83,6 +91,8 @@ $header-height-without-navbar: 148px;
       bottom: 7.5rem;
     }
 
+    // see note above about secondary nav links; for desktop we need to use the
+    //   inverse styling
     a {
       color: $link-reverse-color;
       &:hover {

--- a/src/lib/components/Header/Header.scss
+++ b/src/lib/components/Header/Header.scss
@@ -23,7 +23,26 @@ $header-height-without-navbar: 148px;
   }
 
   a {
-    color: $primary-light;
+    color: $link-color;
+  }
+}
+
+// use a lighter focus style on darker header backgrounds
+.ldaf-header {
+  .usa-logo a,
+  .usa-menu-btn {
+    &:focus {
+      outline-color: $focus-reverse-outline-color;
+    }
+  }
+  @include at-media("desktop") {
+    .usa-nav__secondary-item a,
+    .usa-search .usa-input,
+    .usa-search .usa-search__submit {
+      &:focus {
+        outline-color: $focus-reverse-outline-color;
+      }
+    }
   }
 }
 
@@ -65,7 +84,13 @@ $header-height-without-navbar: 148px;
     }
 
     a {
-      color: $primary-lightest;
+      color: $link-reverse-color;
+      &:hover {
+        color: $link-reverse-hover-color;
+      }
+      &:active {
+        color: $link-reverse-active-color;
+      }
     }
   }
 

--- a/src/lib/components/Link/Link.scss
+++ b/src/lib/components/Link/Link.scss
@@ -1,10 +1,15 @@
 // Since we can't set a custom color for $theme-link-visited-color in the
-//   USWDS settings in src/app.scss, we need a bit more specific to override
-//   the default value.
+//   USWDS settings in src/app.scss, we need to be a bit more specific to
+//   override the default value.
 // Additionally, there are a ton of places where we never want to display a
 //   link as visited, such as links rendered as buttons, links in the primary
-//   and secondary nav in the header, and links in the side nav.
-a.usa-link:visited:not(.usa-button, .usa-header .usa-link, .usa-sidenav .usa-link) {
+//   and secondary nav in the header, links in the side nav, etc.
+a.usa-link:visited:not(
+    .usa-button,
+    .usa-header .usa-link,
+    .usa-sidenav .usa-link,
+    .youtube-subscribe-link
+  ) {
   color: $link-visited-color;
 }
 // For some reason the USWDS rules for alternate color links depends on the

--- a/src/lib/components/Link/Link.scss
+++ b/src/lib/components/Link/Link.scss
@@ -1,3 +1,12 @@
+// Since we can't set a custom color for $theme-link-visited-color in the
+//   USWDS settings in src/app.scss, we need a bit more specific to override
+//   the default value.
+// Additionally, there are a ton of places where we never want to display a
+//   link as visited, such as links rendered as buttons, links in the primary
+//   and secondary nav in the header, and links in the side nav.
+a.usa-link:visited:not(.usa-button, .usa-header .usa-link, .usa-sidenav .usa-link) {
+  color: $link-visited-color;
+}
 // For some reason the USWDS rules for alternate color links depends on the
 //   link being a child of an element with the 'usa-dark-background' class.
 //   This seems overly restrictive, so we'll set up the alternate style to be
@@ -9,5 +18,11 @@
   }
   &:active {
     color: $link-reverse-active-color;
+  }
+  &:visited {
+    color: $link-reverse-visited-color;
+  }
+  &:focus {
+    outline-color: $focus-reverse-outline-color;
   }
 }

--- a/src/lib/components/Link/Link.scss
+++ b/src/lib/components/Link/Link.scss
@@ -1,16 +1,13 @@
-@use "uswds-core" as uswds with (
-  $theme-show-notifications: false
-);
-// For some reason the USWDS rules for alternate color links depends on the link being a child of an element with the 'usa-dark-background' class.
-// This seems overly restrictive, so we'll set up the alternate style to be independent of its parent element.
-// Following styles were taken from: https://github.com/uswds/uswds/blob/30c61f34288bc706961b12b536fdc57537026385/packages/usa-dark-background/src/styles/_usa-dark-background.scss
-// TODO: Figure out how to get modified variables; if we change $theme-link-reverse-color it doesn't apply here.
+// For some reason the USWDS rules for alternate color links depends on the
+//   link being a child of an element with the 'usa-dark-background' class.
+//   This seems overly restrictive, so we'll set up the alternate style to be
+//   independent of its parent element.
 .usa-link.usa-link--alt {
-  color: uswds.color(uswds.$theme-link-reverse-color);
-  &:visited {
-    color: uswds.color(uswds.$theme-link-reverse-color);
-  }
+  color: $link-reverse-color;
   &:hover {
-    color: uswds.color(uswds.$theme-link-reverse-hover-color);
+    color: $link-reverse-hover-color;
+  }
+  &:active {
+    color: $link-reverse-active-color;
   }
 }

--- a/src/lib/components/Pagination/Pagination.scss
+++ b/src/lib/components/Pagination/Pagination.scss
@@ -36,5 +36,5 @@
 .ldaf-pagination__numeric-button--selected {
   background: #171717;
   border: 1px solid #171717;
-  color: #fff;
+  color: $white;
 }

--- a/src/lib/components/VideoCard/VideoCard.scss
+++ b/src/lib/components/VideoCard/VideoCard.scss
@@ -11,6 +11,10 @@
   &--hero {
     color: $white;
     background: $primary-darkest;
+    // set a lighter focus outline against the darker background
+    [href]:focus {
+      outline-color: $focus-reverse-outline-color;
+    }
   }
   &--primary {
     background: $accent-light;

--- a/src/lib/components/VideoCard/VideoCard.scss
+++ b/src/lib/components/VideoCard/VideoCard.scss
@@ -1,7 +1,3 @@
-@use "uswds-core" as * with (
-  $theme-show-notifications: false
-);
-
 .ldaf-video-card {
   display: flex;
   flex-wrap: wrap;
@@ -10,7 +6,7 @@
   // change colors based on variation
   &--hero {
     color: $white;
-    background: $primary-darkest;
+    background: $primary-darker;
     // set a lighter focus outline against the darker background
     [href]:focus {
       outline-color: $focus-reverse-outline-color;

--- a/src/lib/components/YoutubeSubscribeLink/YoutubeSubscribeLink.scss
+++ b/src/lib/components/YoutubeSubscribeLink/YoutubeSubscribeLink.scss
@@ -5,7 +5,7 @@
   background: #e62117;
   border: 1px solid #d7211a;
   border-radius: 3px;
-  color: white;
+  color: $white;
   text-decoration: none;
   height: 24px;
   padding: 0 8px 0 5.5px;

--- a/src/routes/(infoPages)/[topTierPage]/+page.svelte
+++ b/src/routes/(infoPages)/[topTierPage]/+page.svelte
@@ -3,7 +3,7 @@
 
   import { url as arrowIcon } from "$icons/arrow_forward";
 
-  import Button, { type Variant } from "$lib/components/Button";
+  import Button from "$lib/components/Button";
   import Card from "$lib/components/Card";
   import ContentfulRichText from "$lib/components/ContentfulRichText";
   import Icon from "$lib/components/Icon";
@@ -21,17 +21,6 @@
   $: videoTitle = video?.videoTitle ?? youtubeVideoData?.title;
   $: videoDescription = video?.videoSubhead ?? youtubeVideoData?.description;
   $: ({ thumbnails: videoThumbnails } = youtubeVideoData ?? ({} as Record<string, undefined>));
-
-  const getButtonVariant = (index: number): Variant => {
-    switch (index) {
-      case 0:
-        return "primary";
-      case 1:
-        return "secondary";
-      default:
-        return "outline";
-    }
-  };
 </script>
 
 {#if subheading}
@@ -74,7 +63,12 @@
               {item.subheading}
             {/if}
           </svelte:fragment>
-          <Button slot="footer" isLink={true} variant={getButtonVariant(index)} href={item.url}>
+          <Button
+            slot="footer"
+            isLink={true}
+            variant={index < 1 ? "primary" : "outline"}
+            href={item.url}
+          >
             <Icon src={arrowIcon} size={3} />
           </Button>
         </Card>
@@ -86,7 +80,12 @@
               {item.subheading}
             {/if}
           </svelte:fragment>
-          <Button slot="footer" isLink={true} variant={getButtonVariant(index)} href={item.url}>
+          <Button
+            slot="footer"
+            isLink={true}
+            variant={index < 1 ? "primary" : "outline"}
+            href={item.url}
+          >
             <Icon src={arrowIcon} size={3} />
           </Button>
         </Card>

--- a/src/routes/(infoPages)/[topTierPage]/[...serviceGroupPage]/+page.svelte
+++ b/src/routes/(infoPages)/[topTierPage]/[...serviceGroupPage]/+page.svelte
@@ -125,7 +125,7 @@
 
 {#if childServiceGroups.length > 0}
   <ul class="service-group-list">
-    {#each childServiceGroups as item}
+    {#each childServiceGroups as item, i}
       <Card class="service-group-card">
         <h3 class="usa-card__heading" slot="header">{item.title}</h3>
         <svelte:fragment slot="body">
@@ -133,7 +133,7 @@
             {item.subheading}
           {/if}
         </svelte:fragment>
-        <Button slot="footer" isLink={true} href={item.url}>
+        <Button slot="footer" isLink={true} href={item.url} variant={i < 1 ? "primary" : "outline"}>
           <Icon src={arrowIcon} size={3} />
         </Button>
       </Card>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -13,6 +13,7 @@
   import Analytics from "$lib/components/Analytics";
   import Header from "$lib/components/Header";
   import Footer from "$lib/components/Footer";
+  import Link from "$lib/components/Link";
   import { intersectionObserverSupport, lazyImageLoadingSupport } from "$lib/constants/support";
   import { RootIntersectionObserver } from "$lib/components/IntersectionObserver";
   import { BlurhashRenderer } from "$lib/components/Image";
@@ -111,7 +112,7 @@
   <!-- TODO: Skip nav will always scroll user to main, but will only shift
              focus if the URL doesn't already include #main-content.
              Shift focus back to main if user hits this more than once. -->
-  <a class="usa-skipnav" href="#main-content">Skip to main content</a>
+  <Link class="usa-skipnav" href="#main-content">Skip to main content</Link>
   <div class="usa-overlay" />
   <Header
     primaryNavItems={headerPrimaryNavItems}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -41,7 +41,7 @@
         return { card: "full", button: "primary", imageLoading: "eager" };
       case 1:
       case 2:
-        return { card: "half", button: "secondary", imageLoading: "lazy" };
+        return { card: "half", button: "outline", imageLoading: "lazy" };
       default:
         return { card: "third", button: "outline", imageLoading: "lazy" };
     }

--- a/src/routes/page.scss
+++ b/src/routes/page.scss
@@ -9,9 +9,9 @@
   // Columns are 7 and 5 (approx 60% and 40%), so lighten opacity at 60%
   background: linear-gradient(
     90deg,
-    rgba($primary-darkest, 0.95) 0%,
-    rgba($primary-darkest, 0.9) 60%,
-    rgba($primary-darkest, 0.8) 100%
+    rgba($primary-darker, 0.95) 0%,
+    rgba($primary-darker, 0.9) 60%,
+    rgba($primary-darker, 0.8) 100%
   );
   .greeting-background {
     position: absolute;

--- a/src/routes/search/search-page.scss
+++ b/src/routes/search/search-page.scss
@@ -15,7 +15,7 @@
 .usa-current .usa-pagination__button,
 .usa-current .usa-pagination__button:focus {
   border-radius: 0.25rem;
-  color: white;
+  color: $white;
 }
 
 .search-results li {
@@ -32,7 +32,7 @@
 }
 .search-results .usa-search__submit-icon {
   display: inline-block;
-  fill: white;
+  fill: $white;
 }
 
 .search-results {

--- a/src/stories/Alert.stories.ts
+++ b/src/stories/Alert.stories.ts
@@ -40,7 +40,7 @@ export const Informational: Story = {
   args: {},
 };
 
-export const Emergency: Story = {
+export const Error: Story = {
   args: { variant: "error", heading: "Emergency", slottedContent: "Something dangerous..." },
 };
 

--- a/src/stories/Button.stories.ts
+++ b/src/stories/Button.stories.ts
@@ -40,6 +40,10 @@ export const Disabled: Story = {
   args: { disabled: true },
 };
 
+export const Secondary: Story = {
+  args: { variant: "secondary" },
+};
+
 export const Base: Story = {
   args: {
     variant: "base",

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -21,7 +21,7 @@ $primary-lighter: #6fb1fc;
 $primary-light: #1670d9;
 $primary: #0051ad;
 $primary-dark: #063c7a;
-$primary-darkest: #00284d;
+$primary-darker: #00284d;
 
 $accent-super-light: #fff7e5;
 $accent-lightest: #fff0cf;

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -10,7 +10,7 @@ $white: #fff;
 $base-lightest: #f2f1f0;
 $base-lighter: #dfe1e2;
 $base-light: #a9aeb1;
-$base-base: #71767a;
+$base: #71767a;
 $base-dark: #565c65;
 $base-darker: #3d4551;
 $base-ink: #1b1b1b;
@@ -41,6 +41,7 @@ $grayscale-90: #171717;
 
 /* Miscellaneous */
 $primary-vivid: #0050d8;
+$color-violet-50v: #d1b3ff;
 $color-violet-70v: #562b97;
 
 /* Warnings, Alerts, and Errors */
@@ -68,6 +69,32 @@ $success: #00a91c;
 $success-dark: #33803f;
 $success-darker: #3c643b;
 
-$disabled: #e6e6e6;
-$disabled-dark: #c9c9c9;
-$disabled-darker: #adadad;
+$disabled-light: #e6e6e6;
+$disabled: #c9c9c9;
+$disabled-dark: #adadad;
+
+// We already set most links with this color via USWDS settings in
+//   src/app.scss, but there are a few cases where we need to provide this
+//   color as an override (e.g. to override the visited link color to set it to
+//   the normal color).
+$link-color: $primary-light;
+
+// The default behavior is to only apply the reverse link style if the link has
+//   a parent with the "usa-dark-background" class, which is overly
+//   restrictive. Again, we already set this in the USWDS settings, but we need
+//   to redeclare it here so we can override as appropriate.
+//   See $lib/components/Link/Link.scss for more info.
+$link-reverse-color: $primary-lightest;
+$link-reverse-hover-color: $primary-lighter;
+$link-reverse-active-color: $primary-light;
+
+// We can't set custom colors for the visited link state in the settings, so we
+//   need to use overrides.
+$link-visited-color: $color-violet-70v;
+$link-reverse-visited-color: $color-violet-50v;
+
+// The USWDS allows us to set a focus outline color, but it expects it to work
+//   on both light and dark backgrounds.
+// Our default focus color only works on light backgrounds, so we need to
+//   provide a lighter focus color for dark backgrounds.
+$focus-reverse-outline-color: $primary-lightest;

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -73,11 +73,13 @@ $disabled-light: #e6e6e6;
 $disabled: #c9c9c9;
 $disabled-dark: #adadad;
 
-// We already set most links with this color via USWDS settings in
-//   src/app.scss, but there are a few cases where we need to provide this
-//   color as an override (e.g. to override the visited link color to set it to
-//   the normal color).
+// We already set most links with these colors via USWDS settings in
+//   src/app.scss, but there are a few cases where we need to provide these
+//   colors as an override (e.g. to override the visited link color to set it
+//   to the normal color).
 $link-color: $primary-light;
+$link-hover-color: $primary;
+$link-active-color: $primary-dark;
 
 // The default behavior is to only apply the reverse link style if the link has
 //   a parent with the "usa-dark-background" class, which is overly


### PR DESCRIPTION
Jira ticket: [LDAF-427](https://ldaf.atlassian.net/browse/LDAF-427)

This is a replacement of #468; you don't necessarily need to look at the code on that PR, but the PR description provides some context.

Previously I had run into issues with using the USWDS theming settings because there are some settings that must take tokens (I was under the impression that all setings had to take tokens). I've documented this relatively well in `src/app.scss,` but basically there are two different types of settings: those where you can provide custom colors (we're using hex color variables), and those where you must use tokens. Thankfully in most cases we can use tokens that we're able to customize, but there are some outliers (in this PR, the main one is the visited link color).

## Proposed changes

- Sets all applicable USWDS settings variables to the appropriate LDAF colors. The only setting we currently can't handle properly (at least for links) is `theme-link-visited-color`. Made plenty of notes in-code about why this is.
- Use the `Link` component for all links handled by `ContentfulRichText` component.
- Updates styling on the `Link` component to handle the visited state color (which is ignored in some circumstances) and the inverse variation (when used on a dark background).
- Remove the "secondary" button variation from use. CTA buttons on the homepage, top tier pages, and core content pages should all now show the first CTA with the "primary" variation and all following CTAs with the "outline" variation.
- Makes tons of updates to `Button` component styling. Includes:
  - no-op changes to use available variables
  - updates to get colors to match with mocks
  - removal of a lot of color rules that are no longer needed thanks to using USWDS settings
- Adds a `Button` story for the `secondary` variation.
- Handles some use-cases for a lighter focus outline color for darker backgrounds (like in the footer and desktop header).
- Renames some color variables:
  - `$base-base` is now just `$base`
  - `$disabled` colors were previously `$disabled`, `$disabled-dark`, and `$disabled-darker`, now they're `$disabled-light`, `$disabled`, and `$disabled-dark`
  - `$primary-darkest` is now `$primary-darker`
- For consistency, use the `$white` variable instead of `#fff` or `white`.

## Acceptance criteria validation

- [x] Ensure all links are using the `<Link/>` component as appropriate.
- [x] All links should be using the colors outlined on the [typography board in Figma](https://www.figma.com/file/oGKbyCnCRRdNzLYbiags93/LDAF-Component-Library-USWDS-3.0.2?type=design&node-id=2178-9593&mode=design&t=i8ySkXmzN7RwXtom-4).

## Requested feedback

See self-review.


[LDAF-427]: https://ldaf.atlassian.net/browse/LDAF-427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ