### PR TITLE
Show an empty state for events, not the 404 page, when events.length is 0

### DIFF
--- a/src/routes/(infoPages)/about/events/+page.svelte
+++ b/src/routes/(infoPages)/about/events/+page.svelte
@@ -6,7 +6,11 @@
   $: ({ events, currentPageNumber, totalPages } = data);
 </script>
 
-<h1>All events</h1>
+<h1>Upcoming events</h1>
+
+{#if events.length === 0}
+  <p>There are no upcoming events to show at this time.</p>
+{/if}
 
 <!-- See src/routes/(infoPages)/layout.scss for styling. -->
 <div class="ldaf-events-list-container">

--- a/src/routes/(infoPages)/about/events/shared.server.ts
+++ b/src/routes/(infoPages)/about/events/shared.server.ts
@@ -105,10 +105,7 @@ export const loadEventsPage = async ({
         skip: limit * Math.max(pageNumber - 1, 0),
       },
     });
-    if (
-      !eventsData?.eventEntryCollection?.items ||
-      eventsData?.eventEntryCollection?.items?.length === 0
-    ) {
+    if (!eventsData?.eventEntryCollection?.items) {
       break fetchData;
     }
     return {


### PR DESCRIPTION
Before: 404 page
After:
<img width="1167" alt="Screenshot 2023-10-27 at 11 08 52 AM" src="https://github.com/la-ldaf/ldaf-site/assets/13280995/a126c8b3-b860-4f7c-b399-10e6b2106b98">
