### PR TITLE
Remove unused properties on ImageWrapper query

### DIFF
--- a/src/lib/fragments/entryProps.ts
+++ b/src/lib/fragments/entryProps.ts
@@ -27,10 +27,6 @@ export default gql`
         width
         height
       }
-      imageCategory {
-        categoryName
-        categoryDescription
-      }
     }
 
     ... on Contact {


### PR DESCRIPTION
This fixes the `Cannot query field "imageCategory" on type "ImageWrapper".` error that was occurring after the content model was changed