### PR TITLE
Enable viewing preview content for tagged events on top tier pages

### DIFF
--- a/src/routes/(infoPages)/[topTierPage]/+page.server.ts
+++ b/src/routes/(infoPages)/[topTierPage]/+page.server.ts
@@ -135,6 +135,7 @@ const taggedNewsAndEventsQuery = gql`
       }
       order: [eventDateAndTime_ASC]
       limit: 5
+      preview: $preview
     ) {
       items {
         sys {


### PR DESCRIPTION
I discovered this in the process of working on [LDAF-433](https://ldaf.atlassian.net/browse/LDAF-433). We already display the 5 most recent tagged events on top tier pages; this just displays them in preview.

[LDAF-433]: https://ldaf.atlassian.net/browse/LDAF-433?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ