### PR TITLE
Block bad actors by immediately responding with an HTTP error code.

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,10 +1,12 @@
 import { sequence } from "@sveltejs/kit/hooks";
 
-import handleSetupKVClient from "./hooks/server/handleSetupKVClient";
+import handleBadActors from "./hooks/server/handleBadActors";
 import handlePreload from "./hooks/server/handlePreload";
+import handleSetupKVClient from "./hooks/server/handleSetupKVClient";
 import handleCurrentUserAndContentfulClient from "./hooks/server/handleCurrentUserAndContentfulClient";
 
 export const handle = sequence(
+  handleBadActors,
   handlePreload,
   handleSetupKVClient,
   handleCurrentUserAndContentfulClient,

--- a/src/hooks/server/handleBadActors.ts
+++ b/src/hooks/server/handleBadActors.ts
@@ -1,0 +1,38 @@
+// This is a stop-gap measure to block known bad actors.
+// Rough implementation inspired by / stolen from:
+//   https://github.com/CaptainCodeman/svelte-kit-bot-block
+// Note that this will not stop bad actors from accessing static resources such
+//   as `/robots.txt` and `/favicon.ico`.
+
+// Some notable bot user agents from looking at our logs:
+// 1. FeedFetcher-Google - This is a tool used to crawl RSS feeds and can
+//    apparently be used as a DDOS attack vector. All of the requests from this
+//    agent lead to 404s and account for an outsized amount of site traffic (on
+//    July 8, 2024, it accounted for 32% of our traffic). Since we don't even
+//    serve any RSS feeds, there's no point in serving the site to this user
+//    agent.
+//    https://developers.google.com/search/docs/crawling-indexing/feedfetcher
+// 2. BLP_bbot - This is a Bloomberg bot that _aggressively_ requests the old
+//    news page (/category/news) and the new one (/about/news), presumably for
+//    financial analysis. It accounted for 9% of all site traffic on July 8,
+//    2024. Since this seems to be a more legitimate use-case, we're not
+//    blocking it quite yet.
+
+import type { Handle } from "@sveltejs/kit";
+
+// Add more user agent tokens to this regex as necessary (using pipes, `|`).
+const BAD_ACTORS = /(feedfetcher-google)/i;
+
+const handleBadActors = (async ({ event, resolve }) => {
+  const userAgent = event.request.headers.get("user-agent") || "";
+  if (BAD_ACTORS.test(userAgent))
+    // Give 'em the ol' rickroll. Willing this into existence:
+    //   https://bradgessler.com/articles/419-never-gonna-give-you-up/
+    return new Response("https://www.youtube.com/watch?v=dQw4w9WgXcQ", {
+      status: 419,
+      statusText: "Never Gonna Give You Up",
+    });
+  return resolve(event);
+}) satisfies Handle;
+
+export default handleBadActors;


### PR DESCRIPTION
Before we perform any load logic, we check the user agent of the request and give them an error if we know they're up to no good. More details are available in the in-code comments.

### Testing

Open up your HTTP-request-tool of choice and send a request to any URL on the site (either to your local or to the Vercel preview deployment) with the `User-Agent` header set to:
```
FeedFetcher-Google; (+http://www.google.com/feedfetcher.html)
```
All requests (besides to static assets such as `/robots.txt` and `/favicon.ico`) should result in a `419 Never Gonna Give You Up` error. This is not a real error code, but these requests don't deserve a real error code (in all seriousness, I can change this to a `403 Forbidden` if we want to be proper).

