### PR TITLE
Add API route to process fire data CSV

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@poppanator/sveltekit-svg": "^4.1.0",
         "@uswds/uswds": "^3.4.1",
         "algoliasearch": "^4.20.0",
+        "csv-parse": "^5.5.6",
         "date-fns": "^2.30.0",
         "date-fns-tz": "^2.0.0",
         "devalue": "^4.3.2",
@@ -13617,6 +13618,11 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
       "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==",
       "dev": true
+    },
+    "node_modules/csv-parse": {
+      "version": "5.5.6",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.5.6.tgz",
+      "integrity": "sha512-uNpm30m/AGSkLxxy7d9yRXpJQFrZzVWLFBkS+6ngPcZkw/5k3L/jjFuj7tVnEpRn+QgmiXr21nDlhCiUK4ij2A=="
     },
     "node_modules/data-urls": {
       "version": "4.0.0",
@@ -34394,6 +34400,11 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
       "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==",
       "dev": true
+    },
+    "csv-parse": {
+      "version": "5.5.6",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.5.6.tgz",
+      "integrity": "sha512-uNpm30m/AGSkLxxy7d9yRXpJQFrZzVWLFBkS+6ngPcZkw/5k3L/jjFuj7tVnEpRn+QgmiXr21nDlhCiUK4ij2A=="
     },
     "data-urls": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "@poppanator/sveltekit-svg": "^4.1.0",
     "@uswds/uswds": "^3.4.1",
     "algoliasearch": "^4.20.0",
+    "csv-parse": "^5.5.6",
     "date-fns": "^2.30.0",
     "date-fns-tz": "^2.0.0",
     "devalue": "^4.3.2",

--- a/src/routes/api/v1/fire-weather/+server.ts
+++ b/src/routes/api/v1/fire-weather/+server.ts
@@ -1,0 +1,28 @@
+import { parse } from "csv-parse/sync";
+
+export async function POST({ request }) {
+  try {
+    const arrayBuffer = await request.arrayBuffer();
+    const decoder = new TextDecoder();
+    const csvString = decoder.decode(arrayBuffer);
+
+    const fireData = await parse(csvString, {
+      columns: true,
+      skip_empty_lines: true,
+    });
+
+    return new Response(JSON.stringify(fireData), {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  } catch (error) {
+    return new Response(JSON.stringify(error), {
+      status: 500,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  }
+}


### PR DESCRIPTION
## Proposed changes

<!-- Add detailed description of changes here. -->

- Adds an API route at `/api/v1/fire-weather`
- Presently just parses out an CSV file and returns it as JSON; will get updated to get added to the Vercel KV store

## Other details

I tested this locally with the [following script](https://gist.github.com/hinzed1127/4f51bef0853f6767fb7d7cf8912dffb1). It's intentionally very basic right for now

### Possible drawbacks

- Right now is requiring we integrate with LDAF's IIS FTP server. TBD on how integrating a node script within that goes
- TBD on how easy the KV integration is

<!-- What are the possible side-effects or negative impacts of the code change? Are there any security concerns? -->
