### PR TITLE
[No Issue] Update schema after latest changes to Contentful (both built-ins and our content model changes).

### DIFF
--- a/src/lib/services/server/contentful/schema.graphql
+++ b/src/lib/services/server/contentful/schema.graphql
@@ -429,8 +429,12 @@ enum ContactLinkingCollectionsEventEntryCollectionOrder {
   eventDescription_DESC
   eventSummary_ASC
   eventSummary_DESC
+  indexInSearch_ASC
+  indexInSearch_DESC
   internalName_ASC
   internalName_DESC
+  metaTitle_ASC
+  metaTitle_DESC
   shortTitle_ASC
   shortTitle_DESC
   slug_ASC
@@ -448,6 +452,8 @@ enum ContactLinkingCollectionsEventEntryCollectionOrder {
 enum ContactLinkingCollectionsNewsCollectionOrder {
   byline_ASC
   byline_DESC
+  indexInSearch_ASC
+  indexInSearch_DESC
   metaTitle_ASC
   metaTitle_DESC
   publicationDate_ASC
@@ -691,10 +697,26 @@ enum ContentTypeLocationOrder {
 }
 
 type ContentfulMetadata {
+  concepts: [TaxonomyConcept]!
   tags: [ContentfulTag]!
 }
 
+input ContentfulMetadataConceptsDescendantsFilter {
+  id_contains_all: [String]
+  id_contains_none: [String]
+  id_contains_some: [String]
+}
+
+input ContentfulMetadataConceptsFilter {
+  descendants: ContentfulMetadataConceptsDescendantsFilter
+  id_contains_all: [String]
+  id_contains_none: [String]
+  id_contains_some: [String]
+}
+
 input ContentfulMetadataFilter {
+  concepts: ContentfulMetadataConceptsFilter
+  concepts_exists: Boolean
   tags: ContentfulMetadataTagsFilter
   tags_exists: Boolean
 }
@@ -781,8 +803,12 @@ enum DocumentWrapperLinkingCollectionsEventEntryCollectionOrder {
   eventDescription_DESC
   eventSummary_ASC
   eventSummary_DESC
+  indexInSearch_ASC
+  indexInSearch_DESC
   internalName_ASC
   internalName_DESC
+  metaTitle_ASC
+  metaTitle_DESC
   shortTitle_ASC
   shortTitle_DESC
   slug_ASC
@@ -1154,8 +1180,11 @@ type EventEntry implements Entry & _Node {
   eventDocumentsCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0, where: EventEntryEventDocumentsFilter): EventEntryEventDocumentsCollection
   eventRichTextDescription(locale: String): EventEntryEventRichTextDescription
   eventSummary(locale: String): String
+  indexInSearch(locale: String): Boolean
   internalName(locale: String): String
   linkedFrom(allowedLocales: [String]): EventEntryLinkingCollections
+  metaDescription(locale: String): String
+  metaTitle(locale: String): String
   shortTitle(locale: String): String
   slug(locale: String): String
   sys: Sys!
@@ -1256,6 +1285,9 @@ input EventEntryFilter {
   eventSummary_not: String
   eventSummary_not_contains: String
   eventSummary_not_in: [String]
+  indexInSearch: Boolean
+  indexInSearch_exists: Boolean
+  indexInSearch_not: Boolean
   internalName: String
   internalName_contains: String
   internalName_exists: Boolean
@@ -1263,6 +1295,20 @@ input EventEntryFilter {
   internalName_not: String
   internalName_not_contains: String
   internalName_not_in: [String]
+  metaDescription: String
+  metaDescription_contains: String
+  metaDescription_exists: Boolean
+  metaDescription_in: [String]
+  metaDescription_not: String
+  metaDescription_not_contains: String
+  metaDescription_not_in: [String]
+  metaTitle: String
+  metaTitle_contains: String
+  metaTitle_exists: Boolean
+  metaTitle_in: [String]
+  metaTitle_not: String
+  metaTitle_not_contains: String
+  metaTitle_not_in: [String]
   shortTitle: String
   shortTitle_contains: String
   shortTitle_exists: Boolean
@@ -1292,6 +1338,8 @@ type EventEntryLinkingCollections {
 enum EventEntryLinkingCollectionsNewsCollectionOrder {
   byline_ASC
   byline_DESC
+  indexInSearch_ASC
+  indexInSearch_DESC
   metaTitle_ASC
   metaTitle_DESC
   publicationDate_ASC
@@ -1395,12 +1443,102 @@ enum EventEntryOrder {
   eventDescription_DESC
   eventSummary_ASC
   eventSummary_DESC
+  indexInSearch_ASC
+  indexInSearch_DESC
   internalName_ASC
   internalName_DESC
+  metaTitle_ASC
+  metaTitle_DESC
   shortTitle_ASC
   shortTitle_DESC
   slug_ASC
   slug_DESC
+  sys_firstPublishedAt_ASC
+  sys_firstPublishedAt_DESC
+  sys_id_ASC
+  sys_id_DESC
+  sys_publishedAt_ASC
+  sys_publishedAt_DESC
+  sys_publishedVersion_ASC
+  sys_publishedVersion_DESC
+}
+
+"""
+One-off content type for managing the description text on the fire danger page [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/fireDangerMap)
+"""
+type FireDangerMap implements Entry & _Node {
+  _id: ID!
+  contentfulMetadata: ContentfulMetadata!
+  description(locale: String): FireDangerMapDescription
+  linkedFrom(allowedLocales: [String]): FireDangerMapLinkingCollections
+  pageMetadata(locale: String, preview: Boolean, where: PageMetadataFilter): PageMetadata
+  sys: Sys!
+}
+
+type FireDangerMapCollection {
+  items: [FireDangerMap]!
+  limit: Int!
+  skip: Int!
+  total: Int!
+}
+
+type FireDangerMapDescription {
+  json: JSON!
+  links: FireDangerMapDescriptionLinks!
+}
+
+type FireDangerMapDescriptionAssets {
+  block: [Asset]!
+  hyperlink: [Asset]!
+}
+
+type FireDangerMapDescriptionEntries {
+  block: [Entry]!
+  hyperlink: [Entry]!
+  inline: [Entry]!
+}
+
+type FireDangerMapDescriptionLinks {
+  assets: FireDangerMapDescriptionAssets!
+  entries: FireDangerMapDescriptionEntries!
+  resources: FireDangerMapDescriptionResources!
+}
+
+type FireDangerMapDescriptionResources {
+  block: [FireDangerMapDescriptionResourcesBlock!]!
+  hyperlink: [FireDangerMapDescriptionResourcesHyperlink!]!
+  inline: [FireDangerMapDescriptionResourcesInline!]!
+}
+
+type FireDangerMapDescriptionResourcesBlock implements ResourceLink {
+  sys: ResourceSys!
+}
+
+type FireDangerMapDescriptionResourcesHyperlink implements ResourceLink {
+  sys: ResourceSys!
+}
+
+type FireDangerMapDescriptionResourcesInline implements ResourceLink {
+  sys: ResourceSys!
+}
+
+input FireDangerMapFilter {
+  AND: [FireDangerMapFilter]
+  OR: [FireDangerMapFilter]
+  contentfulMetadata: ContentfulMetadataFilter
+  description_contains: String
+  description_exists: Boolean
+  description_not_contains: String
+  pageMetadata: cfPageMetadataNestedFilter
+  pageMetadata_exists: Boolean
+  sys: SysFilter
+}
+
+type FireDangerMapLinkingCollections {
+  entryCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): EntryCollection
+}
+
+enum FireDangerMapOrder {
   sys_firstPublishedAt_ASC
   sys_firstPublishedAt_DESC
   sys_id_ASC
@@ -1489,6 +1627,8 @@ enum HeroImageLinkingCollectionsNewsArticleCollectionOrder {
 enum HeroImageLinkingCollectionsNewsCollectionOrder {
   byline_ASC
   byline_DESC
+  indexInSearch_ASC
+  indexInSearch_DESC
   metaTitle_ASC
   metaTitle_DESC
   publicationDate_ASC
@@ -2174,6 +2314,7 @@ type News implements Entry & _Node {
   contactInformationCollection(limit: Int = 100, locale: String, order: [NewsContactInformationCollectionOrder], preview: Boolean, skip: Int = 0, where: ContactFilter): NewsContactInformationCollection
   contentfulMetadata: ContentfulMetadata!
   heroImage(locale: String, preview: Boolean, where: HeroImageFilter): HeroImage
+  indexInSearch(locale: String): Boolean
   linkedFrom(allowedLocales: [String]): NewsLinkingCollections
   metaDescription(locale: String): String
   metaTitle(locale: String): String
@@ -2356,6 +2497,9 @@ input NewsFilter {
   contentfulMetadata: ContentfulMetadataFilter
   heroImage: cfHeroImageNestedFilter
   heroImage_exists: Boolean
+  indexInSearch: Boolean
+  indexInSearch_exists: Boolean
+  indexInSearch_not: Boolean
   metaDescription: String
   metaDescription_contains: String
   metaDescription_exists: Boolean
@@ -2569,6 +2713,8 @@ type NewsLinkingCollections {
 enum NewsLinkingCollectionsNewsCollectionOrder {
   byline_ASC
   byline_DESC
+  indexInSearch_ASC
+  indexInSearch_DESC
   metaTitle_ASC
   metaTitle_DESC
   publicationDate_ASC
@@ -2649,6 +2795,8 @@ enum NewsLinkingCollectionsTopTierCollectionOrder {
 enum NewsOrder {
   byline_ASC
   byline_DESC
+  indexInSearch_ASC
+  indexInSearch_DESC
   metaTitle_ASC
   metaTitle_DESC
   publicationDate_ASC
@@ -2685,8 +2833,12 @@ enum NewsRelatedEventsCollectionOrder {
   eventDescription_DESC
   eventSummary_ASC
   eventSummary_DESC
+  indexInSearch_ASC
+  indexInSearch_DESC
   internalName_ASC
   internalName_DESC
+  metaTitle_ASC
+  metaTitle_DESC
   shortTitle_ASC
   shortTitle_DESC
   slug_ASC
@@ -2751,6 +2903,8 @@ type NewsRelatedNewsCollection {
 enum NewsRelatedNewsCollectionOrder {
   byline_ASC
   byline_DESC
+  indexInSearch_ASC
+  indexInSearch_DESC
   metaTitle_ASC
   metaTitle_DESC
   publicationDate_ASC
@@ -2968,7 +3122,6 @@ type PageMetadata implements Entry & _Node {
   metaDescription(locale: String): String
   metaTitle(locale: String): String
   parent(locale: String, preview: Boolean, where: PageMetadataFilter): PageMetadata
-  recentNewsCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): PageMetadataRecentNewsCollection
   slug(locale: String): String
   sys: Sys!
   title(locale: String): String
@@ -3012,7 +3165,6 @@ input PageMetadataFilter {
   metaTitle_not_in: [String]
   parent: cfPageMetadataNestedFilter
   parent_exists: Boolean
-  recentNewsCollection_exists: Boolean
   slug: String
   slug_contains: String
   slug_exists: Boolean
@@ -3035,6 +3187,7 @@ union PageMetadataInternalRedirect = EventEntry | News | PageMetadata
 type PageMetadataLinkingCollections {
   aggregationCollection(limit: Int = 100, locale: String, order: [PageMetadataLinkingCollectionsAggregationCollectionOrder], preview: Boolean, skip: Int = 0): AggregationCollection
   entryCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): EntryCollection
+  fireDangerMapCollection(limit: Int = 100, locale: String, order: [PageMetadataLinkingCollectionsFireDangerMapCollectionOrder], preview: Boolean, skip: Int = 0): FireDangerMapCollection
   homeCollection(limit: Int = 100, locale: String, order: [PageMetadataLinkingCollectionsHomeCollectionOrder], preview: Boolean, skip: Int = 0): HomeCollection
   menuItemCollection(limit: Int = 100, locale: String, order: [PageMetadataLinkingCollectionsMenuItemCollectionOrder], preview: Boolean, skip: Int = 0): MenuItemCollection
   officePageCollection(limit: Int = 100, locale: String, order: [PageMetadataLinkingCollectionsOfficePageCollectionOrder], preview: Boolean, skip: Int = 0): OfficePageCollection
@@ -3057,6 +3210,17 @@ enum PageMetadataLinkingCollectionsAggregationCollectionOrder {
   sys_publishedVersion_DESC
   title_ASC
   title_DESC
+}
+
+enum PageMetadataLinkingCollectionsFireDangerMapCollectionOrder {
+  sys_firstPublishedAt_ASC
+  sys_firstPublishedAt_DESC
+  sys_id_ASC
+  sys_id_DESC
+  sys_publishedAt_ASC
+  sys_publishedAt_DESC
+  sys_publishedVersion_ASC
+  sys_publishedVersion_DESC
 }
 
 enum PageMetadataLinkingCollectionsHomeCollectionOrder {
@@ -3197,13 +3361,6 @@ enum PageMetadataOrder {
   sys_publishedVersion_DESC
   title_ASC
   title_DESC
-}
-
-type PageMetadataRecentNewsCollection {
-  items: [Entry]!
-  limit: Int!
-  skip: Int!
-  total: Int!
 }
 
 """
@@ -3466,6 +3623,8 @@ type Query {
   errorCollection(limit: Int = 100, locale: String, order: [ErrorOrder], preview: Boolean, skip: Int = 0, where: ErrorFilter): ErrorCollection
   eventEntry(id: String!, locale: String, preview: Boolean): EventEntry
   eventEntryCollection(limit: Int = 100, locale: String, order: [EventEntryOrder], preview: Boolean, skip: Int = 0, where: EventEntryFilter): EventEntryCollection
+  fireDangerMap(id: String!, locale: String, preview: Boolean): FireDangerMap
+  fireDangerMapCollection(limit: Int = 100, locale: String, order: [FireDangerMapOrder], preview: Boolean, skip: Int = 0, where: FireDangerMapFilter): FireDangerMapCollection
   heroImage(id: String!, locale: String, preview: Boolean): HeroImage
   heroImageCollection(limit: Int = 100, locale: String, order: [HeroImageOrder], preview: Boolean, skip: Int = 0, where: HeroImageFilter): HeroImageCollection
   home(id: String!, locale: String, preview: Boolean): Home
@@ -3954,6 +4113,8 @@ type ServiceGroupRecentNewsCollection {
 enum ServiceGroupRecentNewsCollectionOrder {
   byline_ASC
   byline_DESC
+  indexInSearch_ASC
+  indexInSearch_DESC
   metaTitle_ASC
   metaTitle_DESC
   publicationDate_ASC
@@ -4009,8 +4170,12 @@ enum ServiceGroupUpcomingEventsCollectionOrder {
   eventDescription_DESC
   eventSummary_ASC
   eventSummary_DESC
+  indexInSearch_ASC
+  indexInSearch_DESC
   internalName_ASC
   internalName_DESC
+  metaTitle_ASC
+  metaTitle_DESC
   shortTitle_ASC
   shortTitle_DESC
   slug_ASC
@@ -4072,6 +4237,14 @@ input SysFilter {
   publishedVersion_lte: Float
   publishedVersion_not: Float
   publishedVersion_not_in: [Float]
+}
+
+"""
+Represents a tag entity for finding and organizing content easily.
+        Find out more here: https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/content-concepts
+"""
+type TaxonomyConcept {
+  id: String
 }
 
 """
@@ -4342,6 +4515,8 @@ type TopTierRecentNewsCollection {
 enum TopTierRecentNewsCollectionOrder {
   byline_ASC
   byline_DESC
+  indexInSearch_ASC
+  indexInSearch_DESC
   metaTitle_ASC
   metaTitle_DESC
   publicationDate_ASC
@@ -4378,8 +4553,12 @@ enum TopTierUpcomingEventsCollectionOrder {
   eventDescription_DESC
   eventSummary_ASC
   eventSummary_DESC
+  indexInSearch_ASC
+  indexInSearch_DESC
   internalName_ASC
   internalName_DESC
+  metaTitle_ASC
+  metaTitle_DESC
   shortTitle_ASC
   shortTitle_DESC
   slug_ASC
@@ -4716,6 +4895,9 @@ input cfEventEntryNestedFilter {
   eventSummary_not: String
   eventSummary_not_contains: String
   eventSummary_not_in: [String]
+  indexInSearch: Boolean
+  indexInSearch_exists: Boolean
+  indexInSearch_not: Boolean
   internalName: String
   internalName_contains: String
   internalName_exists: Boolean
@@ -4723,6 +4905,20 @@ input cfEventEntryNestedFilter {
   internalName_not: String
   internalName_not_contains: String
   internalName_not_in: [String]
+  metaDescription: String
+  metaDescription_contains: String
+  metaDescription_exists: Boolean
+  metaDescription_in: [String]
+  metaDescription_not: String
+  metaDescription_not_contains: String
+  metaDescription_not_in: [String]
+  metaTitle: String
+  metaTitle_contains: String
+  metaTitle_exists: Boolean
+  metaTitle_in: [String]
+  metaTitle_not: String
+  metaTitle_not_contains: String
+  metaTitle_not_in: [String]
   shortTitle: String
   shortTitle_contains: String
   shortTitle_exists: Boolean
@@ -4831,6 +5027,9 @@ input cfNewsNestedFilter {
   contactInformationCollection_exists: Boolean
   contentfulMetadata: ContentfulMetadataFilter
   heroImage_exists: Boolean
+  indexInSearch: Boolean
+  indexInSearch_exists: Boolean
+  indexInSearch_not: Boolean
   metaDescription: String
   metaDescription_contains: String
   metaDescription_exists: Boolean
@@ -4920,7 +5119,6 @@ input cfPageMetadataNestedFilter {
   metaTitle_not_contains: String
   metaTitle_not_in: [String]
   parent_exists: Boolean
-  recentNewsCollection_exists: Boolean
   slug: String
   slug_contains: String
   slug_exists: Boolean

--- a/src/lib/services/server/contentful/schema.ts
+++ b/src/lib/services/server/contentful/schema.ts
@@ -787,8 +787,12 @@ export enum ContactLinkingCollectionsEventEntryCollectionOrder {
   EventDescriptionDesc = 'eventDescription_DESC',
   EventSummaryAsc = 'eventSummary_ASC',
   EventSummaryDesc = 'eventSummary_DESC',
+  IndexInSearchAsc = 'indexInSearch_ASC',
+  IndexInSearchDesc = 'indexInSearch_DESC',
   InternalNameAsc = 'internalName_ASC',
   InternalNameDesc = 'internalName_DESC',
+  MetaTitleAsc = 'metaTitle_ASC',
+  MetaTitleDesc = 'metaTitle_DESC',
   ShortTitleAsc = 'shortTitle_ASC',
   ShortTitleDesc = 'shortTitle_DESC',
   SlugAsc = 'slug_ASC',
@@ -806,6 +810,8 @@ export enum ContactLinkingCollectionsEventEntryCollectionOrder {
 export enum ContactLinkingCollectionsNewsCollectionOrder {
   BylineAsc = 'byline_ASC',
   BylineDesc = 'byline_DESC',
+  IndexInSearchAsc = 'indexInSearch_ASC',
+  IndexInSearchDesc = 'indexInSearch_DESC',
   MetaTitleAsc = 'metaTitle_ASC',
   MetaTitleDesc = 'metaTitle_DESC',
   PublicationDateAsc = 'publicationDate_ASC',
@@ -1119,10 +1125,26 @@ export enum ContentTypeLocationOrder {
 
 export type ContentfulMetadata = {
   __typename?: 'ContentfulMetadata';
+  concepts: Array<Maybe<TaxonomyConcept>>;
   tags: Array<Maybe<ContentfulTag>>;
 };
 
+export type ContentfulMetadataConceptsDescendantsFilter = {
+  id_contains_all?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  id_contains_none?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  id_contains_some?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type ContentfulMetadataConceptsFilter = {
+  descendants?: InputMaybe<ContentfulMetadataConceptsDescendantsFilter>;
+  id_contains_all?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  id_contains_none?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  id_contains_some?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
 export type ContentfulMetadataFilter = {
+  concepts?: InputMaybe<ContentfulMetadataConceptsFilter>;
+  concepts_exists?: InputMaybe<Scalars['Boolean']['input']>;
   tags?: InputMaybe<ContentfulMetadataTagsFilter>;
   tags_exists?: InputMaybe<Scalars['Boolean']['input']>;
 };
@@ -1240,8 +1262,12 @@ export enum DocumentWrapperLinkingCollectionsEventEntryCollectionOrder {
   EventDescriptionDesc = 'eventDescription_DESC',
   EventSummaryAsc = 'eventSummary_ASC',
   EventSummaryDesc = 'eventSummary_DESC',
+  IndexInSearchAsc = 'indexInSearch_ASC',
+  IndexInSearchDesc = 'indexInSearch_DESC',
   InternalNameAsc = 'internalName_ASC',
   InternalNameDesc = 'internalName_DESC',
+  MetaTitleAsc = 'metaTitle_ASC',
+  MetaTitleDesc = 'metaTitle_DESC',
   ShortTitleAsc = 'shortTitle_ASC',
   ShortTitleDesc = 'shortTitle_DESC',
   SlugAsc = 'slug_ASC',
@@ -1756,8 +1782,11 @@ export type EventEntry = Entry & _Node & {
   eventDocumentsCollection?: Maybe<EventEntryEventDocumentsCollection>;
   eventRichTextDescription?: Maybe<EventEntryEventRichTextDescription>;
   eventSummary?: Maybe<Scalars['String']['output']>;
+  indexInSearch?: Maybe<Scalars['Boolean']['output']>;
   internalName?: Maybe<Scalars['String']['output']>;
   linkedFrom?: Maybe<EventEntryLinkingCollections>;
+  metaDescription?: Maybe<Scalars['String']['output']>;
+  metaTitle?: Maybe<Scalars['String']['output']>;
   shortTitle?: Maybe<Scalars['String']['output']>;
   slug?: Maybe<Scalars['String']['output']>;
   sys: Sys;
@@ -1799,6 +1828,12 @@ export type EventEntryEventSummaryArgs = {
 
 
 /** LDAF events such as board meetings, saddle microchipping events, etc. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/eventEntry) */
+export type EventEntryIndexInSearchArgs = {
+  locale?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** LDAF events such as board meetings, saddle microchipping events, etc. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/eventEntry) */
 export type EventEntryInternalNameArgs = {
   locale?: InputMaybe<Scalars['String']['input']>;
 };
@@ -1807,6 +1842,18 @@ export type EventEntryInternalNameArgs = {
 /** LDAF events such as board meetings, saddle microchipping events, etc. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/eventEntry) */
 export type EventEntryLinkedFromArgs = {
   allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+/** LDAF events such as board meetings, saddle microchipping events, etc. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/eventEntry) */
+export type EventEntryMetaDescriptionArgs = {
+  locale?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** LDAF events such as board meetings, saddle microchipping events, etc. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/eventEntry) */
+export type EventEntryMetaTitleArgs = {
+  locale?: InputMaybe<Scalars['String']['input']>;
 };
 
 
@@ -1926,6 +1973,9 @@ export type EventEntryFilter = {
   eventSummary_not?: InputMaybe<Scalars['String']['input']>;
   eventSummary_not_contains?: InputMaybe<Scalars['String']['input']>;
   eventSummary_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  indexInSearch?: InputMaybe<Scalars['Boolean']['input']>;
+  indexInSearch_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  indexInSearch_not?: InputMaybe<Scalars['Boolean']['input']>;
   internalName?: InputMaybe<Scalars['String']['input']>;
   internalName_contains?: InputMaybe<Scalars['String']['input']>;
   internalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
@@ -1933,6 +1983,20 @@ export type EventEntryFilter = {
   internalName_not?: InputMaybe<Scalars['String']['input']>;
   internalName_not_contains?: InputMaybe<Scalars['String']['input']>;
   internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  metaDescription?: InputMaybe<Scalars['String']['input']>;
+  metaDescription_contains?: InputMaybe<Scalars['String']['input']>;
+  metaDescription_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  metaDescription_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  metaDescription_not?: InputMaybe<Scalars['String']['input']>;
+  metaDescription_not_contains?: InputMaybe<Scalars['String']['input']>;
+  metaDescription_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  metaTitle?: InputMaybe<Scalars['String']['input']>;
+  metaTitle_contains?: InputMaybe<Scalars['String']['input']>;
+  metaTitle_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  metaTitle_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  metaTitle_not?: InputMaybe<Scalars['String']['input']>;
+  metaTitle_not_contains?: InputMaybe<Scalars['String']['input']>;
+  metaTitle_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   shortTitle?: InputMaybe<Scalars['String']['input']>;
   shortTitle_contains?: InputMaybe<Scalars['String']['input']>;
   shortTitle_exists?: InputMaybe<Scalars['Boolean']['input']>;
@@ -2016,6 +2080,8 @@ export type EventEntryLinkingCollectionsTopTierCollectionArgs = {
 export enum EventEntryLinkingCollectionsNewsCollectionOrder {
   BylineAsc = 'byline_ASC',
   BylineDesc = 'byline_DESC',
+  IndexInSearchAsc = 'indexInSearch_ASC',
+  IndexInSearchDesc = 'indexInSearch_DESC',
   MetaTitleAsc = 'metaTitle_ASC',
   MetaTitleDesc = 'metaTitle_DESC',
   PublicationDateAsc = 'publicationDate_ASC',
@@ -2119,12 +2185,139 @@ export enum EventEntryOrder {
   EventDescriptionDesc = 'eventDescription_DESC',
   EventSummaryAsc = 'eventSummary_ASC',
   EventSummaryDesc = 'eventSummary_DESC',
+  IndexInSearchAsc = 'indexInSearch_ASC',
+  IndexInSearchDesc = 'indexInSearch_DESC',
   InternalNameAsc = 'internalName_ASC',
   InternalNameDesc = 'internalName_DESC',
+  MetaTitleAsc = 'metaTitle_ASC',
+  MetaTitleDesc = 'metaTitle_DESC',
   ShortTitleAsc = 'shortTitle_ASC',
   ShortTitleDesc = 'shortTitle_DESC',
   SlugAsc = 'slug_ASC',
   SlugDesc = 'slug_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC'
+}
+
+/** One-off content type for managing the description text on the fire danger page [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/fireDangerMap) */
+export type FireDangerMap = Entry & _Node & {
+  __typename?: 'FireDangerMap';
+  _id: Scalars['ID']['output'];
+  contentfulMetadata: ContentfulMetadata;
+  description?: Maybe<FireDangerMapDescription>;
+  linkedFrom?: Maybe<FireDangerMapLinkingCollections>;
+  pageMetadata?: Maybe<PageMetadata>;
+  sys: Sys;
+};
+
+
+/** One-off content type for managing the description text on the fire danger page [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/fireDangerMap) */
+export type FireDangerMapDescriptionArgs = {
+  locale?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** One-off content type for managing the description text on the fire danger page [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/fireDangerMap) */
+export type FireDangerMapLinkedFromArgs = {
+  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+/** One-off content type for managing the description text on the fire danger page [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/fireDangerMap) */
+export type FireDangerMapPageMetadataArgs = {
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  where?: InputMaybe<PageMetadataFilter>;
+};
+
+export type FireDangerMapCollection = {
+  __typename?: 'FireDangerMapCollection';
+  items: Array<Maybe<FireDangerMap>>;
+  limit: Scalars['Int']['output'];
+  skip: Scalars['Int']['output'];
+  total: Scalars['Int']['output'];
+};
+
+export type FireDangerMapDescription = {
+  __typename?: 'FireDangerMapDescription';
+  json: Scalars['JSON']['output'];
+  links: FireDangerMapDescriptionLinks;
+};
+
+export type FireDangerMapDescriptionAssets = {
+  __typename?: 'FireDangerMapDescriptionAssets';
+  block: Array<Maybe<Asset>>;
+  hyperlink: Array<Maybe<Asset>>;
+};
+
+export type FireDangerMapDescriptionEntries = {
+  __typename?: 'FireDangerMapDescriptionEntries';
+  block: Array<Maybe<Entry>>;
+  hyperlink: Array<Maybe<Entry>>;
+  inline: Array<Maybe<Entry>>;
+};
+
+export type FireDangerMapDescriptionLinks = {
+  __typename?: 'FireDangerMapDescriptionLinks';
+  assets: FireDangerMapDescriptionAssets;
+  entries: FireDangerMapDescriptionEntries;
+  resources: FireDangerMapDescriptionResources;
+};
+
+export type FireDangerMapDescriptionResources = {
+  __typename?: 'FireDangerMapDescriptionResources';
+  block: Array<FireDangerMapDescriptionResourcesBlock>;
+  hyperlink: Array<FireDangerMapDescriptionResourcesHyperlink>;
+  inline: Array<FireDangerMapDescriptionResourcesInline>;
+};
+
+export type FireDangerMapDescriptionResourcesBlock = ResourceLink & {
+  __typename?: 'FireDangerMapDescriptionResourcesBlock';
+  sys: ResourceSys;
+};
+
+export type FireDangerMapDescriptionResourcesHyperlink = ResourceLink & {
+  __typename?: 'FireDangerMapDescriptionResourcesHyperlink';
+  sys: ResourceSys;
+};
+
+export type FireDangerMapDescriptionResourcesInline = ResourceLink & {
+  __typename?: 'FireDangerMapDescriptionResourcesInline';
+  sys: ResourceSys;
+};
+
+export type FireDangerMapFilter = {
+  AND?: InputMaybe<Array<InputMaybe<FireDangerMapFilter>>>;
+  OR?: InputMaybe<Array<InputMaybe<FireDangerMapFilter>>>;
+  contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
+  description_contains?: InputMaybe<Scalars['String']['input']>;
+  description_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  description_not_contains?: InputMaybe<Scalars['String']['input']>;
+  pageMetadata?: InputMaybe<CfPageMetadataNestedFilter>;
+  pageMetadata_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  sys?: InputMaybe<SysFilter>;
+};
+
+export type FireDangerMapLinkingCollections = {
+  __typename?: 'FireDangerMapLinkingCollections';
+  entryCollection?: Maybe<EntryCollection>;
+};
+
+
+export type FireDangerMapLinkingCollectionsEntryCollectionArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+};
+
+export enum FireDangerMapOrder {
   SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
   SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
   SysIdAsc = 'sys_id_ASC',
@@ -2289,6 +2482,8 @@ export enum HeroImageLinkingCollectionsNewsArticleCollectionOrder {
 export enum HeroImageLinkingCollectionsNewsCollectionOrder {
   BylineAsc = 'byline_ASC',
   BylineDesc = 'byline_DESC',
+  IndexInSearchAsc = 'indexInSearch_ASC',
+  IndexInSearchDesc = 'indexInSearch_DESC',
   MetaTitleAsc = 'metaTitle_ASC',
   MetaTitleDesc = 'metaTitle_DESC',
   PublicationDateAsc = 'publicationDate_ASC',
@@ -3184,6 +3379,7 @@ export type News = Entry & _Node & {
   contactInformationCollection?: Maybe<NewsContactInformationCollection>;
   contentfulMetadata: ContentfulMetadata;
   heroImage?: Maybe<HeroImage>;
+  indexInSearch?: Maybe<Scalars['Boolean']['output']>;
   linkedFrom?: Maybe<NewsLinkingCollections>;
   metaDescription?: Maybe<Scalars['String']['output']>;
   metaTitle?: Maybe<Scalars['String']['output']>;
@@ -3227,6 +3423,12 @@ export type NewsHeroImageArgs = {
   locale?: InputMaybe<Scalars['String']['input']>;
   preview?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<HeroImageFilter>;
+};
+
+
+/** A press release or news article. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/news) */
+export type NewsIndexInSearchArgs = {
+  locale?: InputMaybe<Scalars['String']['input']>;
 };
 
 
@@ -3539,6 +3741,9 @@ export type NewsFilter = {
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
   heroImage?: InputMaybe<CfHeroImageNestedFilter>;
   heroImage_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  indexInSearch?: InputMaybe<Scalars['Boolean']['input']>;
+  indexInSearch_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  indexInSearch_not?: InputMaybe<Scalars['Boolean']['input']>;
   metaDescription?: InputMaybe<Scalars['String']['input']>;
   metaDescription_contains?: InputMaybe<Scalars['String']['input']>;
   metaDescription_exists?: InputMaybe<Scalars['Boolean']['input']>;
@@ -3856,6 +4061,8 @@ export type NewsLinkingCollectionsTopTierCollectionArgs = {
 export enum NewsLinkingCollectionsNewsCollectionOrder {
   BylineAsc = 'byline_ASC',
   BylineDesc = 'byline_DESC',
+  IndexInSearchAsc = 'indexInSearch_ASC',
+  IndexInSearchDesc = 'indexInSearch_DESC',
   MetaTitleAsc = 'metaTitle_ASC',
   MetaTitleDesc = 'metaTitle_DESC',
   PublicationDateAsc = 'publicationDate_ASC',
@@ -3936,6 +4143,8 @@ export enum NewsLinkingCollectionsTopTierCollectionOrder {
 export enum NewsOrder {
   BylineAsc = 'byline_ASC',
   BylineDesc = 'byline_DESC',
+  IndexInSearchAsc = 'indexInSearch_ASC',
+  IndexInSearchDesc = 'indexInSearch_DESC',
   MetaTitleAsc = 'metaTitle_ASC',
   MetaTitleDesc = 'metaTitle_DESC',
   PublicationDateAsc = 'publicationDate_ASC',
@@ -3973,8 +4182,12 @@ export enum NewsRelatedEventsCollectionOrder {
   EventDescriptionDesc = 'eventDescription_DESC',
   EventSummaryAsc = 'eventSummary_ASC',
   EventSummaryDesc = 'eventSummary_DESC',
+  IndexInSearchAsc = 'indexInSearch_ASC',
+  IndexInSearchDesc = 'indexInSearch_DESC',
   InternalNameAsc = 'internalName_ASC',
   InternalNameDesc = 'internalName_DESC',
+  MetaTitleAsc = 'metaTitle_ASC',
+  MetaTitleDesc = 'metaTitle_DESC',
   ShortTitleAsc = 'shortTitle_ASC',
   ShortTitleDesc = 'shortTitle_DESC',
   SlugAsc = 'slug_ASC',
@@ -4048,6 +4261,8 @@ export type NewsRelatedNewsCollection = {
 export enum NewsRelatedNewsCollectionOrder {
   BylineAsc = 'byline_ASC',
   BylineDesc = 'byline_DESC',
+  IndexInSearchAsc = 'indexInSearch_ASC',
+  IndexInSearchDesc = 'indexInSearch_DESC',
   MetaTitleAsc = 'metaTitle_ASC',
   MetaTitleDesc = 'metaTitle_DESC',
   PublicationDateAsc = 'publicationDate_ASC',
@@ -4347,7 +4562,6 @@ export type PageMetadata = Entry & _Node & {
   metaDescription?: Maybe<Scalars['String']['output']>;
   metaTitle?: Maybe<Scalars['String']['output']>;
   parent?: Maybe<PageMetadata>;
-  recentNewsCollection?: Maybe<PageMetadataRecentNewsCollection>;
   slug?: Maybe<Scalars['String']['output']>;
   sys: Sys;
   title?: Maybe<Scalars['String']['output']>;
@@ -4396,15 +4610,6 @@ export type PageMetadataParentArgs = {
   locale?: InputMaybe<Scalars['String']['input']>;
   preview?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<PageMetadataFilter>;
-};
-
-
-/** Options to control what the page does, where it lives, and how people can find it. Includes URL, menu linking, description that shows up in search engines, and redirects. A page will not appear on the site unless it has a corresponding Page details entry. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/pageMetadata) */
-export type PageMetadataRecentNewsCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
 };
 
 
@@ -4458,7 +4663,6 @@ export type PageMetadataFilter = {
   metaTitle_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   parent?: InputMaybe<CfPageMetadataNestedFilter>;
   parent_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  recentNewsCollection_exists?: InputMaybe<Scalars['Boolean']['input']>;
   slug?: InputMaybe<Scalars['String']['input']>;
   slug_contains?: InputMaybe<Scalars['String']['input']>;
   slug_exists?: InputMaybe<Scalars['Boolean']['input']>;
@@ -4482,6 +4686,7 @@ export type PageMetadataLinkingCollections = {
   __typename?: 'PageMetadataLinkingCollections';
   aggregationCollection?: Maybe<AggregationCollection>;
   entryCollection?: Maybe<EntryCollection>;
+  fireDangerMapCollection?: Maybe<FireDangerMapCollection>;
   homeCollection?: Maybe<HomeCollection>;
   menuItemCollection?: Maybe<MenuItemCollection>;
   officePageCollection?: Maybe<OfficePageCollection>;
@@ -4504,6 +4709,15 @@ export type PageMetadataLinkingCollectionsAggregationCollectionArgs = {
 export type PageMetadataLinkingCollectionsEntryCollectionArgs = {
   limit?: InputMaybe<Scalars['Int']['input']>;
   locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type PageMetadataLinkingCollectionsFireDangerMapCollectionArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  order?: InputMaybe<Array<InputMaybe<PageMetadataLinkingCollectionsFireDangerMapCollectionOrder>>>;
   preview?: InputMaybe<Scalars['Boolean']['input']>;
   skip?: InputMaybe<Scalars['Int']['input']>;
 };
@@ -4584,6 +4798,17 @@ export enum PageMetadataLinkingCollectionsAggregationCollectionOrder {
   SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
   TitleAsc = 'title_ASC',
   TitleDesc = 'title_DESC'
+}
+
+export enum PageMetadataLinkingCollectionsFireDangerMapCollectionOrder {
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC'
 }
 
 export enum PageMetadataLinkingCollectionsHomeCollectionOrder {
@@ -4725,14 +4950,6 @@ export enum PageMetadataOrder {
   TitleAsc = 'title_ASC',
   TitleDesc = 'title_DESC'
 }
-
-export type PageMetadataRecentNewsCollection = {
-  __typename?: 'PageMetadataRecentNewsCollection';
-  items: Array<Maybe<Entry>>;
-  limit: Scalars['Int']['output'];
-  skip: Scalars['Int']['output'];
-  total: Scalars['Int']['output'];
-};
 
 /** Includes standard fields for a press release [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/pressRelease) */
 export type PressRelease = Entry & _Node & {
@@ -5116,6 +5333,8 @@ export type Query = {
   errorCollection?: Maybe<ErrorCollection>;
   eventEntry?: Maybe<EventEntry>;
   eventEntryCollection?: Maybe<EventEntryCollection>;
+  fireDangerMap?: Maybe<FireDangerMap>;
+  fireDangerMapCollection?: Maybe<FireDangerMapCollection>;
   heroImage?: Maybe<HeroImage>;
   heroImageCollection?: Maybe<HeroImageCollection>;
   home?: Maybe<Home>;
@@ -5337,6 +5556,23 @@ export type QueryEventEntryCollectionArgs = {
   preview?: InputMaybe<Scalars['Boolean']['input']>;
   skip?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<EventEntryFilter>;
+};
+
+
+export type QueryFireDangerMapArgs = {
+  id: Scalars['String']['input'];
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+
+export type QueryFireDangerMapCollectionArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  order?: InputMaybe<Array<InputMaybe<FireDangerMapOrder>>>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  where?: InputMaybe<FireDangerMapFilter>;
 };
 
 
@@ -6321,6 +6557,8 @@ export type ServiceGroupRecentNewsCollection = {
 export enum ServiceGroupRecentNewsCollectionOrder {
   BylineAsc = 'byline_ASC',
   BylineDesc = 'byline_DESC',
+  IndexInSearchAsc = 'indexInSearch_ASC',
+  IndexInSearchDesc = 'indexInSearch_DESC',
   MetaTitleAsc = 'metaTitle_ASC',
   MetaTitleDesc = 'metaTitle_DESC',
   PublicationDateAsc = 'publicationDate_ASC',
@@ -6378,8 +6616,12 @@ export enum ServiceGroupUpcomingEventsCollectionOrder {
   EventDescriptionDesc = 'eventDescription_DESC',
   EventSummaryAsc = 'eventSummary_ASC',
   EventSummaryDesc = 'eventSummary_DESC',
+  IndexInSearchAsc = 'indexInSearch_ASC',
+  IndexInSearchDesc = 'indexInSearch_DESC',
   InternalNameAsc = 'internalName_ASC',
   InternalNameDesc = 'internalName_DESC',
+  MetaTitleAsc = 'metaTitle_ASC',
+  MetaTitleDesc = 'metaTitle_DESC',
   ShortTitleAsc = 'shortTitle_ASC',
   ShortTitleDesc = 'shortTitle_DESC',
   SlugAsc = 'slug_ASC',
@@ -6441,6 +6683,15 @@ export type SysFilter = {
   publishedVersion_lte?: InputMaybe<Scalars['Float']['input']>;
   publishedVersion_not?: InputMaybe<Scalars['Float']['input']>;
   publishedVersion_not_in?: InputMaybe<Array<InputMaybe<Scalars['Float']['input']>>>;
+};
+
+/**
+ * Represents a tag entity for finding and organizing content easily.
+ *         Find out more here: https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/content-concepts
+ */
+export type TaxonomyConcept = {
+  __typename?: 'TaxonomyConcept';
+  id?: Maybe<Scalars['String']['output']>;
 };
 
 /** Example content type with some rich text. [See type definition](https://app.contentful.com/spaces/pc5e1rlgfrov/content_types/testRichText) */
@@ -6862,6 +7113,8 @@ export type TopTierRecentNewsCollection = {
 export enum TopTierRecentNewsCollectionOrder {
   BylineAsc = 'byline_ASC',
   BylineDesc = 'byline_DESC',
+  IndexInSearchAsc = 'indexInSearch_ASC',
+  IndexInSearchDesc = 'indexInSearch_DESC',
   MetaTitleAsc = 'metaTitle_ASC',
   MetaTitleDesc = 'metaTitle_DESC',
   PublicationDateAsc = 'publicationDate_ASC',
@@ -6899,8 +7152,12 @@ export enum TopTierUpcomingEventsCollectionOrder {
   EventDescriptionDesc = 'eventDescription_DESC',
   EventSummaryAsc = 'eventSummary_ASC',
   EventSummaryDesc = 'eventSummary_DESC',
+  IndexInSearchAsc = 'indexInSearch_ASC',
+  IndexInSearchDesc = 'indexInSearch_DESC',
   InternalNameAsc = 'internalName_ASC',
   InternalNameDesc = 'internalName_DESC',
+  MetaTitleAsc = 'metaTitle_ASC',
+  MetaTitleDesc = 'metaTitle_DESC',
   ShortTitleAsc = 'shortTitle_ASC',
   ShortTitleDesc = 'shortTitle_DESC',
   SlugAsc = 'slug_ASC',
@@ -7323,6 +7580,9 @@ export type CfEventEntryNestedFilter = {
   eventSummary_not?: InputMaybe<Scalars['String']['input']>;
   eventSummary_not_contains?: InputMaybe<Scalars['String']['input']>;
   eventSummary_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  indexInSearch?: InputMaybe<Scalars['Boolean']['input']>;
+  indexInSearch_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  indexInSearch_not?: InputMaybe<Scalars['Boolean']['input']>;
   internalName?: InputMaybe<Scalars['String']['input']>;
   internalName_contains?: InputMaybe<Scalars['String']['input']>;
   internalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
@@ -7330,6 +7590,20 @@ export type CfEventEntryNestedFilter = {
   internalName_not?: InputMaybe<Scalars['String']['input']>;
   internalName_not_contains?: InputMaybe<Scalars['String']['input']>;
   internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  metaDescription?: InputMaybe<Scalars['String']['input']>;
+  metaDescription_contains?: InputMaybe<Scalars['String']['input']>;
+  metaDescription_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  metaDescription_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  metaDescription_not?: InputMaybe<Scalars['String']['input']>;
+  metaDescription_not_contains?: InputMaybe<Scalars['String']['input']>;
+  metaDescription_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  metaTitle?: InputMaybe<Scalars['String']['input']>;
+  metaTitle_contains?: InputMaybe<Scalars['String']['input']>;
+  metaTitle_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  metaTitle_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  metaTitle_not?: InputMaybe<Scalars['String']['input']>;
+  metaTitle_not_contains?: InputMaybe<Scalars['String']['input']>;
+  metaTitle_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   shortTitle?: InputMaybe<Scalars['String']['input']>;
   shortTitle_contains?: InputMaybe<Scalars['String']['input']>;
   shortTitle_exists?: InputMaybe<Scalars['Boolean']['input']>;
@@ -7438,6 +7712,9 @@ export type CfNewsNestedFilter = {
   contactInformationCollection_exists?: InputMaybe<Scalars['Boolean']['input']>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
   heroImage_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  indexInSearch?: InputMaybe<Scalars['Boolean']['input']>;
+  indexInSearch_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  indexInSearch_not?: InputMaybe<Scalars['Boolean']['input']>;
   metaDescription?: InputMaybe<Scalars['String']['input']>;
   metaDescription_contains?: InputMaybe<Scalars['String']['input']>;
   metaDescription_exists?: InputMaybe<Scalars['Boolean']['input']>;
@@ -7527,7 +7804,6 @@ export type CfPageMetadataNestedFilter = {
   metaTitle_not_contains?: InputMaybe<Scalars['String']['input']>;
   metaTitle_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   parent_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  recentNewsCollection_exists?: InputMaybe<Scalars['Boolean']['input']>;
   slug?: InputMaybe<Scalars['String']['input']>;
   slug_contains?: InputMaybe<Scalars['String']['input']>;
   slug_exists?: InputMaybe<Scalars['Boolean']['input']>;

--- a/src/routes/(infoPages)/about/organization/[officePage]/__tests__/OfficePageTestContent.ts
+++ b/src/routes/(infoPages)/about/organization/[officePage]/__tests__/OfficePageTestContent.ts
@@ -4,7 +4,7 @@ import documentWithParagraphData from "$lib/components/ContentfulRichText/__test
 export default {
   _id: "0",
   sys: { id: "0", environmentId: "", spaceId: "" },
-  contentfulMetadata: { tags: [] },
+  contentfulMetadata: { tags: [], concepts: [] },
   pageTitle: "Sample Office Page",
   subheading:
     "This page is loaded with test data since a connection with Contentful could not be established.",
@@ -31,7 +31,7 @@ export default {
       environmentId: "",
       spaceId: "",
     },
-    contentfulMetadata: { tags: [] },
+    contentfulMetadata: { tags: [], concepts: [] },
     name: "Sample Office",
     streetAddress1: "123 Main Street",
     streetAddress2: "Suite 456",
@@ -47,7 +47,7 @@ export default {
       {
         _id: "2",
         sys: { id: "2", environmentId: "", spaceId: "" },
-        contentfulMetadata: { tags: [] },
+        contentfulMetadata: { tags: [], concepts: [] },
         entityName: "Contact Person 1",
         phone: "(123) 456-7890",
         phoneExt: "123",
@@ -56,7 +56,7 @@ export default {
       {
         _id: "3",
         sys: { id: "3", environmentId: "", spaceId: "" },
-        contentfulMetadata: { tags: [] },
+        contentfulMetadata: { tags: [], concepts: [] },
         entityName: "Contact Person 2",
         phone: "(789) 012-3456",
         email: "contact2@example.com",


### PR DESCRIPTION
Ran `npm run gen-schema` to get the latest updates (including a new built-in field, `concepts`), and then needed to update some test data for the Office Pages (since these are using an outdated mechanism for handling Contentful data) to get type checks passing.