### PR TITLE
Refactor news and events

### DIFF
--- a/src/routes/api/v1/search-index/+server.ts
+++ b/src/routes/api/v1/search-index/+server.ts
@@ -17,39 +17,23 @@ const CONTENTFUL_ACTIONS = {
   DELETE: "ContentManagement.Entry.delete",
 };
 
-const getMetaTitleAndDescription = (
-  item?: SearchIndexingMetadataMapItem,
-): { metaTitle?: string | null; metaDescription?: string | null } => {
-  let metaTitle, metaDescription;
-  if (item?.__typename == "PageMetadata") {
-    metaTitle = item?.metaTitle ?? item?.title;
-    metaDescription = item?.metaDescription;
-  } else if (item?.__typename === "News") {
-    metaTitle = item?.metaTitle ?? item?.title;
-    metaDescription = item?.metaDescription ?? item?.subhead;
-  } else if (item?.__typename === "EventEntry") {
-    metaTitle = item?.metaTitle ?? item?.shortTitle;
-    metaDescription = item?.metaDescription ?? item?.eventSummary;
-  }
-  return { metaTitle, ...(metaDescription ? { metaDescription } : {}) };
-};
-
 export const POST = async ({ request, locals: { contentfulClient } }) => {
   authenticateRequest(request);
 
   const contentfulAction = request.headers.get("x-contentful-topic") || "";
   const body = await request.json();
   const contentType = body?.sys?.contentType?.sys?.id;
-  const contentTypes = ["pageMetadata", "news", "eventEntry"];
+  // TODO: in the future, we might want to consolidate these search index endpoints
+  // to handle a wider range of contentTypes in a single POST endpoint. As it stands,
+  // the transform logic is varied enough that it's easier to have some duplicative scaffolding
+  // for calling algolia in a similar way but with different transformation logic in the
+  // "Contentful webhook -> SvelteKit API route -> Algolia index" pipeline
+  const contentTypes = ["pageMetadata"];
   const { pageMetadataMap } = await loadPageMetadataMap({ contentfulClient });
-  const eventsAndNewsMap = await loadEventsAndNewsMap({ contentfulClient });
-
-  const metadataMap = new Map([...eventsAndNewsMap, ...pageMetadataMap]);
 
   try {
     if (contentfulAction === CONTENTFUL_ACTIONS.PUBLISH && contentTypes.includes(contentType)) {
-      const contentfulValue = metadataMap.get(body.sys.id);
-      const metaTitleAndDescription = getMetaTitleAndDescription(contentfulValue);
+      const contentfulValue = pageMetadataMap.get(body.sys.id) || { url: "", children: [] };
       // The webhook body is missing `children` and `url`, since we
       // construct those in `loadPageMetadataMap`. Add those properties here.
       const transformedFields: AlgoliaMetadataRecord = {
@@ -58,9 +42,7 @@ export const POST = async ({ request, locals: { contentfulClient } }) => {
           id: body.sys.id,
         },
         url: contentfulValue?.url,
-        ...metaTitleAndDescription,
-        // conditionally add page attributes
-        ...{ ...(contentfulValue?.children ? { children: contentfulValue?.children } : {}) },
+        children: contentfulValue?.children,
       };
       for (const field in body.fields) {
         // The webhook body unfortunately prefaces each field with a sub-property equal to
@@ -106,6 +88,23 @@ export const POST = async ({ request, locals: { contentfulClient } }) => {
   } catch (message) {
     throw error(400, message as string);
   }
+};
+
+const getMetaTitleAndDescription = (
+  item?: SearchIndexingMetadataMapItem,
+): { metaTitle?: string | null; metaDescription?: string | null } => {
+  let metaTitle, metaDescription;
+  if (item?.__typename == "PageMetadata") {
+    metaTitle = item?.metaTitle ?? item?.title;
+    metaDescription = item?.metaDescription;
+  } else if (item?.__typename === "News") {
+    metaTitle = item?.metaTitle ?? item?.title;
+    metaDescription = item?.metaDescription ?? item?.subhead;
+  } else if (item?.__typename === "EventEntry") {
+    metaTitle = item?.metaTitle ?? item?.shortTitle;
+    metaDescription = item?.metaDescription ?? item?.eventSummary;
+  }
+  return { metaTitle, ...(metaDescription ? { metaDescription } : {}) };
 };
 
 // Return all suitable Page Metadata, News, and Events map items

--- a/src/routes/api/v1/search-index/news-and-events/+server.ts
+++ b/src/routes/api/v1/search-index/news-and-events/+server.ts
@@ -17,7 +17,7 @@ const CONTENTFUL_ACTIONS = {
 
 const addNewsMetadata = (algoliaIndexObject: AlgoliaMetadataRecord) => {
   // Add some sensible defaults in if metaTitle and metaDescription are undefined.
-  // `title` is required in Contentful, so that's an easy
+  // `title` is required for news content in Contentful, so that's an easy fallback here
   if (algoliaIndexObject.metaTitle === undefined) {
     algoliaIndexObject.metaTitle = algoliaIndexObject.title;
   }
@@ -86,8 +86,6 @@ export const POST = async ({ request }) => {
       if (contentType === "eventEntry") {
         addEventMetadata(algoliaIndexObject);
       }
-
-      return json(algoliaIndexObject);
 
       /**
        * `partialUpdateObject` only creates or updates attributes included in the call. Any preexisting

--- a/src/routes/api/v1/search-index/news-and-events/+server.ts
+++ b/src/routes/api/v1/search-index/news-and-events/+server.ts
@@ -1,0 +1,117 @@
+import { json, error } from "@sveltejs/kit";
+import algoliasearch from "algoliasearch";
+import { PUBLIC_ALGOLIA_APP_ID, PUBLIC_ALGOLIA_INDEX } from "$env/static/public";
+import { ALGOLIA_API_KEY } from "$env/static/private";
+import { authenticateRequest } from "$lib/services/server";
+import type { AlgoliaMetadataRecord } from "../types";
+import { format, parseISO } from "date-fns";
+
+const algoliaClient = algoliasearch(PUBLIC_ALGOLIA_APP_ID, ALGOLIA_API_KEY);
+const index = algoliaClient.initIndex(PUBLIC_ALGOLIA_INDEX);
+
+const CONTENTFUL_ACTIONS = {
+  PUBLISH: "ContentManagement.Entry.publish",
+  UNPUBLISH: "ContentManagement.Entry.unpublish",
+  DELETE: "ContentManagement.Entry.delete",
+};
+
+const addNewsMetadata = (algoliaIndexObject: AlgoliaMetadataRecord) => {
+  // Add some sensible defaults in if metaTitle and metaDescription are undefined.
+  // `title` is required in Contentful, so that's an easy
+  if (algoliaIndexObject.metaTitle === undefined) {
+    algoliaIndexObject.metaTitle = algoliaIndexObject.title;
+  }
+
+  if (algoliaIndexObject.metaDescription === undefined) {
+    const { subhead, type, publicationDate } = algoliaIndexObject;
+
+    if (subhead) {
+      algoliaIndexObject.metaDescription = subhead;
+    } else if (publicationDate) {
+      const date = parseISO(publicationDate);
+      algoliaIndexObject.metaDescription = `${type} published on ${format(date, "MMMM d, yyyy")}`;
+    }
+  }
+};
+
+const addEventMetadata = (algoliaIndexObject: AlgoliaMetadataRecord) => {
+  if (algoliaIndexObject.metaTitle === undefined) {
+    algoliaIndexObject.metaTitle = algoliaIndexObject.shortTitle;
+  }
+
+  if (algoliaIndexObject.metaDescription === undefined) {
+    const { eventSummary, eventDateAndTime } = algoliaIndexObject;
+    if (eventSummary) {
+      algoliaIndexObject.metaDescription = eventSummary;
+    } else if (eventDateAndTime) {
+      const date = parseISO(eventDateAndTime);
+      algoliaIndexObject.metaDescription = `Event on ${format(date, "MMMM d, yyyy")}`;
+    }
+  }
+};
+
+export const POST = async ({ request }) => {
+  authenticateRequest(request);
+
+  const contentfulAction = request.headers.get("x-contentful-topic") || "";
+  const body = await request.json();
+  const contentType = body?.sys?.contentType?.sys?.id;
+  const contentTypes = ["news", "eventEntry"];
+
+  try {
+    if (contentfulAction === CONTENTFUL_ACTIONS.PUBLISH && contentTypes.includes(contentType)) {
+      const algoliaIndexObject: AlgoliaMetadataRecord = {
+        objectID: body.sys.id,
+        sys: {
+          id: body.sys.id,
+        },
+        entryType: contentType === "news" ? "News" : "Event",
+      };
+
+      for (const field in body.fields) {
+        // The webhook body unfortunately prefaces each field with a sub-property equal to
+        // the locale value, so we need to flatten that first.
+        const englishValue = body.fields[field]["en-US"];
+
+        // The `body` property is bunch of rich text noise, so omit it
+        if (field === "body") continue;
+
+        algoliaIndexObject[field] = englishValue;
+      }
+
+      if (contentType === "news") {
+        addNewsMetadata(algoliaIndexObject);
+      }
+
+      if (contentType === "eventEntry") {
+        addEventMetadata(algoliaIndexObject);
+      }
+
+      return json(algoliaIndexObject);
+
+      /**
+       * `partialUpdateObject` only creates or updates attributes included in the call. Any preexisting
+       * properties on the record that are not in the call are unaffected.
+       * Docs: https://www.algolia.com/doc/api-reference/api-methods/partial-update-objects/#about-this-method
+       * - If the objectID exists, Algolia replaces the attributes
+       * - If the objectID is specified but doesn’t exist, Algolia creates a new record
+       * - If the objectID isn’t specified, the method returns an error
+       */
+      const response = await index.partialUpdateObject(algoliaIndexObject, {
+        createIfNotExists: true,
+      });
+      return json(response);
+    }
+
+    const deleteActions = [CONTENTFUL_ACTIONS.UNPUBLISH, CONTENTFUL_ACTIONS.DELETE];
+    if (deleteActions.includes(contentfulAction) && contentTypes.includes(contentType)) {
+      const response = await index.deleteObject(body.sys.id);
+      return json(response);
+    }
+
+    // Fall-through response if the request body doesn't result in any Algolia updates.
+    return json("No action taken on the supplied request body.");
+  } catch (message) {
+    throw error(400, message as string);
+  }
+};

--- a/src/routes/api/v1/search-index/service-entries/+server.ts
+++ b/src/routes/api/v1/search-index/service-entries/+server.ts
@@ -30,6 +30,8 @@ export const POST = async ({ request, fetch }) => {
       contentfulAction === CONTENTFUL_ACTIONS.PUBLISH &&
       contentType === serviceEntryContentType
     ) {
+      // TODO: refactor this fetch call to a loadServiceEntries function similar to how
+      // loadPageMetadataMap works in src/routes/api/v1/search-index/+server.ts
       const { serviceEntries } = await fetch("/api/v1/service-entries").then((res) => res.json());
       // Find the matching service entry via the metadata map to allow us to set the accordion URL
       const serviceEntry = serviceEntries.find(

--- a/src/routes/api/v1/search-index/types.ts
+++ b/src/routes/api/v1/search-index/types.ts
@@ -11,6 +11,8 @@ export type AlgoliaMetadataRecord = {
       type?: string;
     };
   } | null;
+  publicationDate?: string;
+  eventDateAndTime?: string;
   // Unfortunately, we can't know what all of what will exist in the the `fields`
   // property from Contentful (especially once we're adding Service Entries),
   // so we have to allow for some dynamic flexibility here


### PR DESCRIPTION
There's enough here that I wanted to separate it out into a side-PR before merging everything.

On a high level, this: 

- breaks out news and events updates into their own API endpoint and contentful webhook
- reverts some of the mapping in the original algolia endpoint to make sure `pageMetadata` records don't get accidentally undefined